### PR TITLE
Dedicate advisory database to the public domain

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,11 @@
+All code and data in the RustSec advisory database repository is dedicated to
+the public domain:
+
+https://creativecommons.org/publicdomain/zero/1.0/
+
+By committing to this repository, you hereby waive all rights to the work
+worldwide under copyright law, including all related and neighboring rights, to
+the extent allowed by law.
+
+You can copy, modify, distribute, and retransmit any information in this
+repository, even for commercial purposes, without asking permission.

--- a/README.md
+++ b/README.md
@@ -39,3 +39,7 @@ The flaw was corrected by Z.
 
 [TOML]: https://github.com/toml-lang/toml
 [cargo-audit]: https://github.com/rustsec/cargo-audit
+
+## License
+
+[![Public Domain](http://i.creativecommons.org/p/zero/1.0/88x31.png)](https://github.com/RustSec/advisory-db/blob/master/LICENSE.txt)


### PR DESCRIPTION
If a good reason for doing so comes up, we could potentially retain some copyright in the future, but to begin with all content will be placed in the public domain.