### PR TITLE
Add titles to advisories

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ dwf = []
 # the release or a changelog entry (optional)
 url = false
 
+# Single-line description of a vulnerability
+title = "Flaw in X allows Y"
+
 # Enter a short-form description of the vulnerability here (required)
 description = """
 Affected versions of this crate did not properly X.


### PR DESCRIPTION
Once again taking a cue from RubySec (but also systems like CVE),
advisories should have a one-liner title