### PR TITLE
Advisory: sodiumoxide degenerate public keys

### DIFF
--- a/crates/sodiumoxide/RUSTSEC-0000-0000.toml
+++ b/crates/sodiumoxide/RUSTSEC-0000-0000.toml
@@ -1,0 +1,14 @@
+[advisory]
+package = "sodiumoxide"
+patched_versions = [">= 0.0.14"]
+dwf = []
+url = "https://github.com/dnaq/sodiumoxide/issues/154"
+title = "scalarmult() vulnerable to degenerate public keys"
+description = """
+The `scalarmult()` function included in previous versions of this crate
+accepted all-zero public keys, for which the resulting Diffie-Hellman shared
+secret will always be zero regardless of the private key used.
+
+This issue was fixed by checking for this class of keys and rejecting them
+if they are used.
+"""


### PR DESCRIPTION
Fixed in sodiumoxide 0.0.14 (cc @dnaq)

See: https://github.com/dnaq/sodiumoxide/issues/154

---

This commit also serves as a sort of archetype for filing future security advisories.

It proposes a `RUSTSEC-YYYY-NNNN` format for identifying advisories. Ideally we'd use [Distributed Weakness Filing](https://github.com/distributedweaknessfiling/) for this purpose, but I've been having trouble getting ahold of the DWF maintainer to move forward on that (cc @kurtseifried)

However, we can adopt the `RUSTSEC-...` scheme for now, then refile vulnerabilities under DWF if and when we get a block assigned (RubySec, as an example, has had to refile vulnerabilities this way several times)