### PR TITLE
Use [advisory] as the table header for advisories

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ automated tools to consume.
 Each advisory contains information in [TOML] format:
 
 ```toml
-[vulnerability]
+[advisory]
 package = "mypackage"
 
 # Versions which were never vulnerable


### PR DESCRIPTION
Was previously `[vulnerability]`, but as the contents are a security advisory
it's probably a more apt label.