### PR TITLE
Rename `package` TOML attribute to `crate_name`

### DIFF
--- a/Advisories.toml
+++ b/Advisories.toml
@@ -1,6 +1,6 @@
 [[advisory]]
 id = "RUSTSEC-2017-0001"
-package = "sodiumoxide"
+crate_name = "sodiumoxide"
 patched_versions = [">= 0.0.14"]
 dwf = []
 date = "2017-01-26"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Each advisory contains information in [TOML] format:
 
 ```toml
 [advisory]
-package = "mypackage"
+crate_name = "vulnerablecrate"
 
 # Versions which were never vulnerable
 unaffected_versions = ["< 1.1.0"]

--- a/crates/sodiumoxide/RUSTSEC-2017-0001.toml
+++ b/crates/sodiumoxide/RUSTSEC-2017-0001.toml
@@ -1,5 +1,5 @@
 [advisory]
-package = "sodiumoxide"
+crate_name = "sodiumoxide"
 patched_versions = [">= 0.0.14"]
 dwf = []
 date = "2017-01-26"


### PR DESCRIPTION
The correct name for a Rust package is a "crate", so something with "crate" is
less ambiguous than "package".

However, "crate" itself is a Rust keyword. To avoid clashes in Rust code which
uses this same attribute name, "crate_name" can be used instead unambigously.