### PR TITLE
Revert "Merge pull request #8 from RustSec/rename-package-to-crate-name"

### DIFF
--- a/Advisories.toml
+++ b/Advisories.toml
@@ -1,6 +1,6 @@
 [[advisory]]
 id = "RUSTSEC-2017-0001"
-crate_name = "sodiumoxide"
+package = "sodiumoxide"
 patched_versions = [">= 0.0.14"]
 dwf = []
 date = "2017-01-26"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Each advisory contains information in [TOML] format:
 
 ```toml
 [advisory]
-crate_name = "vulnerablecrate"
+package = "mypackage"
 
 # Versions which were never vulnerable
 unaffected_versions = ["< 1.1.0"]

--- a/crates/sodiumoxide/RUSTSEC-2017-0001.toml
+++ b/crates/sodiumoxide/RUSTSEC-2017-0001.toml
@@ -1,5 +1,5 @@
 [advisory]
-crate_name = "sodiumoxide"
+package = "sodiumoxide"
 patched_versions = [">= 0.0.14"]
 dwf = []
 date = "2017-01-26"


### PR DESCRIPTION
Cargo uses "package" in Cargo.lock, so there is wisdom to using "package"
instead of "crate_name"

This reverts commit 986c090c066185ea24cc1e58aef2bb949c152810, reversing
changes made to 9556f0fdeedba0c3b8ff4ca51490ea3bf7c31e43.