### PR TITLE
Update rustsec crate to ^0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ categories = ["api-bindings", "development-tools"]
 keywords = ["rustsec", "security", "advisory", "vulnerability"]
 
 [dependencies]
-rustsec = "^0.2"
+rustsec = "^0.3"


### PR DESCRIPTION
The latest version handles the `crate_name` -> `package` revert