### PR TITLE
Update 'rustsec' crate to 0.5.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ categories = ["api-bindings", "development-tools"]
 keywords = ["rustsec", "security", "advisory", "vulnerability"]
 
 [dependencies]
-rustsec = "^0.3"
+rustsec = "^0.5.2"


### PR DESCRIPTION
This version includes a complete rewrite of the advisory parser