### PR TITLE
RUSTSEC-2017-0004 is also known as CVE-2017-1000430

### DIFF
--- a/crates/base64/RUSTSEC-2017-0004.toml
+++ b/crates/base64/RUSTSEC-2017-0004.toml
@@ -1,7 +1,7 @@
 [advisory]
 package = "base64"
 patched_versions = [">= 0.5.2"]
-dwf = []
+dwf = ["CVE-2017-1000430"]
 url = "https://github.com/alicemaz/rust-base64/commit/24ead980daf11ba563e4fb2516187a56a71ad319"
 title = "Integer overflow leads to heap-based buffer overflow in encode_config_buf"
 date = "2017-05-03"


### PR DESCRIPTION
https://github.com/CVEProject/cvelist/pull/219/