### PR TITLE
Advisory: An integer underflow in untrusted 0.6.1 and older which could lead to panic

### DIFF
--- a/crates/untrusted/RUSTSEC-0000-0000.toml
+++ b/crates/untrusted/RUSTSEC-0000-0000.toml
@@ -1,0 +1,41 @@
+[advisory]
+package = "untrusted"
+
+# Versions which were never vulnerable
+unaffected_versions = []
+
+# Versions which include fixes for this vulnerability
+patched_versions = [">= 0.6.2"]
+
+# It is strongly recommended to request a CVE, or alternatively a DWF, and
+# reference the assigned number here.
+# - CVE: https://iwantacve.org/
+# - DWF: https://distributedweaknessfiling.org/
+dwf = []
+# dwf = ["CVE-YYYY-XXXX"]
+# dwf = ["CVE-YYYY-XXXX", "CVE-ZZZZ-WWWW"]
+
+# URL to a long-form description of this issue, e.g. a blogpost announcing
+# the release or a changelog entry (optional)
+url = "https://github.com/briansmith/untrusted/pull/20"
+
+# Single-line description of a vulnerability
+title = "An integer underflow could lead to panic"
+
+# Disclosure date of the advisory (RFC 3339)
+date = "2018-06-21"
+
+# Enter a short-form description of the vulnerability here (required)
+description = """
+A mistake in error handling in untrusted before 0.6.2 could lead to an integer
+underflow and panic if a user of the crate didn't properly check for errors
+returned by untrusted.
+
+Combination of these two programming errors (one in untrusted and another by
+user of this crate) could lead to a panic and maybe a denial of service of
+affected software.
+
+The error in untrusted is fixed in release 0.6.2 released 2018-06-21. It's also
+advisable that users of untrusted check for their sources for cases where errors
+returned by untrusted are not handled correctly.
+"""


### PR DESCRIPTION
Ping @briansmith, the author and maintainer of untrusted who has seen this advisory before submission.

Short description:

> A mistake in error handling in untrusted before 0.6.2 could lead to an integer underflow and panic if a user of the crate didn't properly check for errors returned by untrusted.
>
> Combination of these two programming errors (one in untrusted and another by user of this crate) could lead to a panic and maybe a denial of service of affected software.
>
> The error in untrusted is fixed in release 0.6.2 released 2018-06-21. It's also advisable that users of untrusted check for their sources for cases where errors returned by untrusted are not handled correctly.