### PR TITLE
Aribtrary filesystem writes in tar 0.4.15 and older

### DIFF
--- a/crates/tar/RUSTSEC-2018-0002.toml
+++ b/crates/tar/RUSTSEC-2018-0002.toml
@@ -1,0 +1,25 @@
+[[advisory]]
+id = "RUSTSEC-2018-0002"
+package = "tar"
+unaffected_versions = []
+patched_versions = [">= 0.4.16"]
+dwf = []
+url = "https://github.com/alexcrichton/tar-rs/pull/156"
+title = "Links in archives can overwrite any existing file"
+date = "2018-06-29"
+description = """
+When unpacking a tarball with the `unpack_in`-family of functions it's intended
+that only files within the specified directory are able to be written. Tarballs
+with hard links or symlinks, however, can be used to overwrite any file on the
+filesystem.
+
+Tarballs can contain multiple entries for the same file. A tarball which first
+contains an entry for a hard link or symlink pointing to any file on the
+filesystem will have the link created, and then afterwards if the same file is
+listed in the tarball the hard link will be rewritten and any file can be
+rewritten on the filesystem.
+
+This has been fixed in https://github.com/alexcrichton/tar-rs/pull/156 and is
+published as `tar` 0.4.16. Thanks to Max Justicz for discovering this and
+emailing about the issue!
+"""


### PR DESCRIPTION
More details inside!