### PR TITLE
Advisory: Possible double free in SmallVec::insert_many

### DIFF
--- a/crates/smallvec/RUSTSEC-0000-0000.toml
+++ b/crates/smallvec/RUSTSEC-0000-0000.toml
@@ -1,0 +1,21 @@
+[advisory]
+package = "smallvec"
+unaffected_versions = ["< 0.3.2"]
+patched_versions = [">= 0.6.3"]
+dwf = []
+url = "https://github.com/servo/rust-smallvec/issues/96"
+title = "Possible double free during unwinding in SmallVec::insert_many"
+date = "2018-07-19"
+description = """
+If an iterator passed to `SmallVec::insert_many` panicked in `Iterator::next`,
+destructors were run during unwinding while the vector was in an inconsistent
+state, possibly causing a double free (a destructor running on two copies of
+the same value).
+
+This is fixed in smallvec 0.6.3 by ensuring that the vector's length is not
+updated to include moved items until they have been removed from their
+original positions.  Items may now be leaked if `Iterator::next` panics, but
+they will not be dropped more than once.
+
+Thank you to @Vurich for reporting this bug.
+"""


### PR DESCRIPTION
For details, see:

* servo/rust-smallvec#96 - original bug report
* servo/rust-smallvec#103 - fix