### PR TITLE
crates: Add 'id' attribute to all advisories

### DIFF
--- a/crates/base64/RUSTSEC-2017-0004.toml
+++ b/crates/base64/RUSTSEC-2017-0004.toml
@@ -1,4 +1,5 @@
 [advisory]
+id = "RUSTSEC-2017-0004"
 package = "base64"
 patched_versions = [">= 0.5.2"]
 dwf = ["CVE-2017-1000430"]

--- a/crates/cookie/RUSTSEC-2017-0005.toml
+++ b/crates/cookie/RUSTSEC-2017-0005.toml
@@ -1,4 +1,5 @@
 [advisory]
+id = "RUSTSEC-2017-0005"
 package = "cookie"
 patched_versions = ["< 0.6.0", "^0.6.2", ">= 0.7.6"]
 dwf = []

--- a/crates/hyper/RUSTSEC-2017-0002.toml
+++ b/crates/hyper/RUSTSEC-2017-0002.toml
@@ -1,4 +1,5 @@
 [advisory]
+id = "RUSTSEC-2017-0002"
 package = "hyper"
 patched_versions = [">= 0.10.2", "< 0.10.0, >= 0.9.18"]
 dwf = []

--- a/crates/security-framework/RUSTSEC-2017-0003.toml
+++ b/crates/security-framework/RUSTSEC-2017-0003.toml
@@ -1,4 +1,5 @@
 [advisory]
+id = "RUSTSEC-2017-0003"
 package = "security-framework"
 patched_versions = [">= 0.1.12"]
 dwf = []

--- a/crates/smallvec/RUSTSEC-2018-0003.toml
+++ b/crates/smallvec/RUSTSEC-2018-0003.toml
@@ -1,4 +1,5 @@
 [advisory]
+id = "RUSTSEC-2018-0003"
 package = "smallvec"
 unaffected_versions = ["< 0.3.2"]
 patched_versions = [">= 0.6.3", "^0.3.4", "^0.4.5", "^0.5.1"]

--- a/crates/sodiumoxide/RUSTSEC-2017-0001.toml
+++ b/crates/sodiumoxide/RUSTSEC-2017-0001.toml
@@ -1,4 +1,5 @@
 [advisory]
+id = "RUSTSEC-2017-0001"
 package = "sodiumoxide"
 patched_versions = [">= 0.0.14"]
 dwf = ["CVE-2017-1000168"]

--- a/crates/untrusted/RUSTSEC-2018-0001.toml
+++ b/crates/untrusted/RUSTSEC-2018-0001.toml
@@ -1,4 +1,5 @@
 [advisory]
+id = "RUSTSEC-2018-0001"
 package = "untrusted"
 unaffected_versions = []
 patched_versions = [">= 0.6.2"]


### PR DESCRIPTION
This is needed to parse them with serde directly from these files (as opposed to using Advisories.toml)