### PR TITLE
Rename "dwf" TOML tag to "aliases" (closes #36)

### DIFF
--- a/Advisories.toml
+++ b/Advisories.toml
@@ -2,7 +2,6 @@
 id = "RUSTSEC-2017-0001"
 package = "sodiumoxide"
 patched_versions = [">= 0.0.14"]
-dwf = []
 date = "2017-01-26"
 url = "https://github.com/dnaq/sodiumoxide/issues/154"
 title = "scalarmult() vulnerable to degenerate public keys"
@@ -19,7 +18,6 @@ if they are used.
 id = "RUSTSEC-2017-0002"
 package = "hyper"
 patched_versions = [">= 0.10.2", "< 0.10.0, >= 0.9.18"]
-dwf = []
 date = "2017-01-23"
 url = "https://github.com/hyperium/hyper/wiki/Security-001"
 title = "headers containing newline characters can split messages"
@@ -37,7 +35,6 @@ a header value.
 id = "RUSTSEC-2017-0003"
 package = "security-framework"
 patched_versions = [">= 0.1.12"]
-dwf = []
 date = "2017-03-15"
 url = "https://github.com/sfackler/rust-security-framework/pull/27"
 title = "Hostname verification skipped when custom root certs used"
@@ -54,7 +51,6 @@ perform that check.
 id = "RUSTSEC-2017-0004"
 package = "base64"
 patched_versions = [">= 0.5.2"]
-dwf = []
 url = "https://github.com/alicemaz/rust-base64/commit/24ead980daf11ba563e4fb2516187a56a71ad319"
 title = "Integer overflow leads to heap-based buffer overflow in encode_config_buf"
 date = "2017-05-03"
@@ -75,7 +71,6 @@ the size of the buffer.
 id = "RUSTSEC-2017-0005"
 package = "cookie"
 patched_versions = ["< 0.6.0", "^0.6.2", ">= 0.7.6"]
-dwf = []
 url = "https://github.com/alexcrichton/cookie-rs/pull/86"
 title = "Large cookie Max-Age values can cause a denial of service"
 date = "2017-05-06"
@@ -94,7 +89,6 @@ id = "RUSTSEC-2018-0001"
 package = "untrusted"
 unaffected_versions = []
 patched_versions = [">= 0.6.2"]
-dwf = []
 url = "https://github.com/briansmith/untrusted/pull/20"
 title = "An integer underflow could lead to panic"
 date = "2018-06-21"
@@ -117,7 +111,6 @@ id = "RUSTSEC-2018-0002"
 package = "tar"
 unaffected_versions = []
 patched_versions = [">= 0.4.16"]
-dwf = []
 url = "https://github.com/alexcrichton/tar-rs/pull/156"
 title = "Links in archives can overwrite any existing file"
 date = "2018-06-29"
@@ -143,7 +136,6 @@ id = "RUSTSEC-2018-0003"
 package = "smallvec"
 unaffected_versions = ["< 0.3.2"]
 patched_versions = [">= 0.6.3", "^0.3.4", "^0.4.5", "^0.5.1"]
-dwf = []
 url = "https://github.com/servo/rust-smallvec/issues/96"
 title = "Possible double free during unwinding in SmallVec::insert_many"
 date = "2018-07-19"

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ unaffected_versions = ["< 1.1.0"]
 # Versions which include fixes for this vulnerability
 patched_versions = [">= 1.2.0"]
 
-# It is strongly recommended to request a CVE, or alternatively a DWF, and
-# reference the assigned number here.
-# - CVE: https://iwantacve.org/
-# - DWF: https://distributedweaknessfiling.org/
-dwf = []
-# dwf = ["CVE-YYYY-XXXX"]
-# dwf = ["CVE-YYYY-XXXX", "CVE-ZZZZ-WWWW"]
+# Vulnerability aliases (e.g. CVE IDs). Optional but recommended.
+# Request a CVE for your RustSec vulns: https://iwantacve.org/
+aliases = ["CVE-2018-XXXX"]
+
+# References to related vulnerabilities (Optional)
+# e.g. CVE for a C library wrapped by a -sys crate)
+references = ["CVE-2018-YYYY", "CVE-2018-ZZZZ"]
 
 # URL to a long-form description of this issue, e.g. a blogpost announcing
 # the release or a changelog entry (optional)

--- a/crates/base64/RUSTSEC-2017-0004.toml
+++ b/crates/base64/RUSTSEC-2017-0004.toml
@@ -2,7 +2,7 @@
 id = "RUSTSEC-2017-0004"
 package = "base64"
 patched_versions = [">= 0.5.2"]
-dwf = ["CVE-2017-1000430"]
+aliases = ["CVE-2017-1000430"]
 url = "https://github.com/alicemaz/rust-base64/commit/24ead980daf11ba563e4fb2516187a56a71ad319"
 title = "Integer overflow leads to heap-based buffer overflow in encode_config_buf"
 date = "2017-05-03"

--- a/crates/cookie/RUSTSEC-2017-0005.toml
+++ b/crates/cookie/RUSTSEC-2017-0005.toml
@@ -2,7 +2,6 @@
 id = "RUSTSEC-2017-0005"
 package = "cookie"
 patched_versions = ["< 0.6.0", "^0.6.2", ">= 0.7.6"]
-dwf = []
 url = "https://github.com/alexcrichton/cookie-rs/pull/86"
 title = "Large cookie Max-Age values can cause a denial of service"
 date = "2017-05-06"

--- a/crates/hyper/RUSTSEC-2017-0002.toml
+++ b/crates/hyper/RUSTSEC-2017-0002.toml
@@ -2,7 +2,6 @@
 id = "RUSTSEC-2017-0002"
 package = "hyper"
 patched_versions = [">= 0.10.2", "< 0.10.0, >= 0.9.18"]
-dwf = []
 date = "2017-01-23"
 url = "https://github.com/hyperium/hyper/wiki/Security-001"
 title = "headers containing newline characters can split messages"

--- a/crates/security-framework/RUSTSEC-2017-0003.toml
+++ b/crates/security-framework/RUSTSEC-2017-0003.toml
@@ -2,7 +2,6 @@
 id = "RUSTSEC-2017-0003"
 package = "security-framework"
 patched_versions = [">= 0.1.12"]
-dwf = []
 date = "2017-03-15"
 url = "https://github.com/sfackler/rust-security-framework/pull/27"
 title = "Hostname verification skipped when custom root certs used"

--- a/crates/smallvec/RUSTSEC-2018-0003.toml
+++ b/crates/smallvec/RUSTSEC-2018-0003.toml
@@ -3,7 +3,6 @@ id = "RUSTSEC-2018-0003"
 package = "smallvec"
 unaffected_versions = ["< 0.3.2"]
 patched_versions = [">= 0.6.3", "^0.3.4", "^0.4.5", "^0.5.1"]
-dwf = []
 url = "https://github.com/servo/rust-smallvec/issues/96"
 title = "Possible double free during unwinding in SmallVec::insert_many"
 date = "2018-07-19"

--- a/crates/sodiumoxide/RUSTSEC-2017-0001.toml
+++ b/crates/sodiumoxide/RUSTSEC-2017-0001.toml
@@ -2,7 +2,7 @@
 id = "RUSTSEC-2017-0001"
 package = "sodiumoxide"
 patched_versions = [">= 0.0.14"]
-dwf = ["CVE-2017-1000168"]
+aliases = ["CVE-2017-1000168"]
 date = "2017-01-26"
 url = "https://github.com/dnaq/sodiumoxide/issues/154"
 title = "scalarmult() vulnerable to degenerate public keys"

--- a/crates/tar/RUSTSEC-2018-0002.toml
+++ b/crates/tar/RUSTSEC-2018-0002.toml
@@ -3,7 +3,6 @@ id = "RUSTSEC-2018-0002"
 package = "tar"
 unaffected_versions = []
 patched_versions = [">= 0.4.16"]
-dwf = []
 url = "https://github.com/alexcrichton/tar-rs/pull/156"
 title = "Links in archives can overwrite any existing file"
 date = "2018-06-29"

--- a/crates/untrusted/RUSTSEC-2018-0001.toml
+++ b/crates/untrusted/RUSTSEC-2018-0001.toml
@@ -3,7 +3,6 @@ id = "RUSTSEC-2018-0001"
 package = "untrusted"
 unaffected_versions = []
 patched_versions = [">= 0.6.2"]
-dwf = []
 url = "https://github.com/briansmith/untrusted/pull/20"
 title = "An integer underflow could lead to panic"
 date = "2018-06-21"


### PR DESCRIPTION
Nobody knows what "dwf" is, and the data isn't presently consumed or surfaced by the `rustsec` crate, so we (hopefully) can rename it without breaking anything.