### PR TITLE
Upgrade to rustsec 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,4 @@ name = "rustsec-advisory-db"
 [dependencies]
 gumdrop = "0.4"
 gumdrop_derive = "0.4"
-rustsec = "0.7"
+rustsec = "0.8"


### PR DESCRIPTION
Adds support for `affected_platforms` and `keywords` attributes on security advisories.