### PR TITLE
Advisories.toml: Add RUSTSEC-2016-0001 and RUSTSEC-2016-0002

### DIFF
--- a/Advisories.toml
+++ b/Advisories.toml
@@ -1,4 +1,47 @@
 [[advisory]]
+id = "RUSTSEC-2016-0001"
+package = "openssl"
+patched_versions = [">= 0.9.0"]
+date = "2016-11-05"
+keywords = ["ssl", "mitm"]
+url = "https://github.com/sfackler/rust-openssl/releases/tag/v0.9.0"
+title = "SSL/TLS MitM vulnerability due to insecure defaults"
+description = """
+All versions of rust-openssl prior to 0.9.0 contained numerous insecure defaults
+including off-by-default certificate verification and no API to perform hostname
+verification.
+
+Unless configured correctly by a developer, these defaults could allow an attacker
+to perform man-in-the-middle attacks.
+
+The problem was addressed in newer versions by enabling certificate verification
+by default and exposing APIs to perform hostname verification. Use the
+`SslConnector` and `SslAcceptor` types to take advantage of these new features
+(as opposed to the lower-level `SslContext` type).
+"""
+
+[[advisory]]
+id = "RUSTSEC-2016-0002"
+package = "hyper"
+date = "2016-05-09"
+url = "https://github.com/hyperium/hyper/blob/master/CHANGELOG.md#v094-2016-05-09"
+title = "HTTPS MitM vulnerability due to lack of hostname verification"
+keywords = ["ssl", "mitm"]
+affected_platforms = ["*windows*"]
+patched_versions = [">= 0.9.4"]
+references = ["RUSTSEC-2016-0001"]
+description = """
+When used on Windows platforms, all versions of Hyper prior to 0.9.4 did not
+perform hostname verification when making HTTPS requests.
+
+This allows an attacker to perform MitM attacks by preventing any valid
+CA-issued certificate, even if there's a hostname mismatch.
+
+The problem was addressed by leveraging rust-openssl's built-in support for
+hostname verification.
+"""
+
+[[advisory]]
 id = "RUSTSEC-2017-0001"
 package = "sodiumoxide"
 patched_versions = [">= 0.0.14"]


### PR DESCRIPTION
Adds the newly merged (but oldest chronological!) advisories into the `Advisories.toml` file (which can go away pending #29)