### PR TITLE
README.md: Documented `affected_arch` and `affected_os`

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,15 @@ patched_versions = [">= 1.2.0"]
 # Versions which were never vulnerable (optional)
 unaffected_versions = ["< 1.1.0"]
 
-# Platforms this vulnerability specifically affects (optional)
-# See: https://docs.rs/rustsec/latest/rustsec/advisory/struct.PlatformReq.html
-#affected_platforms = ["*windows*"]
+# CPU architectures impacted by this vulnerability (optional)
+# For a list of CPU architecture strings, see the "platforms" crate:
+# <https://docs.rs/platforms/latest/platforms/target/enum.Arch.html>
+#affected_arch = ["x86", "x86_64"]
+
+# Operating systems impacted by this vulnerability (optional)
+# For a list of OS strings, see the "platforms" crate:
+# <https://docs.rs/platforms/latest/platforms/target/enum.OS.html>
+#affected_os = ["windows"]
 
 # Vulnerability aliases, e.g. CVE IDs (optional but recommended)
 # Request a CVE for your RustSec vulns: https://iwantacve.org/

--- a/README.md
+++ b/README.md
@@ -60,18 +60,26 @@ This allows an attacker to Y.
 The flaw was corrected by Z.
 """
 
-# URL to a long-form description of this issue, e.g. a GitHub issue/PR,
-# a change log entry, or a blogpost announcing the release (optional)
-url = "https://github.com/mystuff/mycrate/issues/123"
-
-# Keywords which describe this vulnerability, similar to Cargo keywords
-keywords = ["ssl", "mitm"]
-
 # Versions which include fixes for this vulnerability (mandatory)
 patched_versions = [">= 1.2.0"]
 
 # Versions which were never vulnerable (optional)
-unaffected_versions = ["< 1.1.0"]
+#unaffected_versions = ["< 1.1.0"]
+
+# URL to a long-form description of this issue, e.g. a GitHub issue/PR,
+# a change log entry, or a blogpost announcing the release (optional)
+url = "https://github.com/mystuff/mycrate/issues/123"
+
+# Keywords which describe this vulnerability, similar to Cargo (optional)
+keywords = ["ssl", "mitm"]
+
+# Vulnerability aliases, e.g. CVE IDs (optional but recommended)
+# Request a CVE for your RustSec vulns: https://iwantacve.org/
+#aliases = ["CVE-2018-XXXX"]
+
+# References to related vulnerabilities (optional)
+# e.g. CVE for a C library wrapped by a -sys crate)
+#references = ["CVE-2018-YYYY", "CVE-2018-ZZZZ"]
 
 # CPU architectures impacted by this vulnerability (optional)
 # For a list of CPU architecture strings, see the "platforms" crate:
@@ -82,14 +90,6 @@ unaffected_versions = ["< 1.1.0"]
 # For a list of OS strings, see the "platforms" crate:
 # <https://docs.rs/platforms/latest/platforms/target/enum.OS.html>
 #affected_os = ["windows"]
-
-# Vulnerability aliases, e.g. CVE IDs (optional but recommended)
-# Request a CVE for your RustSec vulns: https://iwantacve.org/
-aliases = ["CVE-2018-XXXX"]
-
-# References to related vulnerabilities (optional)
-# e.g. CVE for a C library wrapped by a -sys crate)
-references = ["CVE-2018-YYYY", "CVE-2018-ZZZZ"]
 ```
 
 ## License

--- a/crates/hyper/RUSTSEC-2016-0002.toml
+++ b/crates/hyper/RUSTSEC-2016-0002.toml
@@ -5,7 +5,7 @@ date = "2016-05-09"
 url = "https://github.com/hyperium/hyper/blob/master/CHANGELOG.md#v094-2016-05-09"
 title = "HTTPS MitM vulnerability due to lack of hostname verification"
 keywords = ["ssl", "mitm"]
-affected_platforms = ["*windows*"]
+affected_os = ["windows"]
 patched_versions = [">= 0.9.4"]
 references = ["RUSTSEC-2016-0001"]
 description = """


### PR DESCRIPTION
These are new attributes as of `rustsec` crate v0.9.0 which use enums from the `platforms` crate to represent CPU architectures and operating systems.

This replaces the previous `affected_platforms` attribute (only used in one advisory)

Also updates RUSTSEC-2016-0002.toml to use the new 'affected_os' attribute.