### PR TITLE
Add advisory for Claxon 0.3.2 and 0.4.1

### DIFF
--- a/crates/claxon/RUSTSEC-0000-0000.toml
+++ b/crates/claxon/RUSTSEC-0000-0000.toml
@@ -1,0 +1,22 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "claxon"
+date = "2018-08-25"
+title = "Malicious input could cause uninitialized memory to be exposed"
+description = """
+Affected versions of Claxon made an invalid assumption about the decode buffer
+size being a multiple of a value read from the bitstream. This could cause parts
+of the decode buffer to not be overwritten. If the decode buffer was newly
+allocated and uninitialized, this uninitialized memory could be exposed.
+
+This allows an attacker to observe parts of the uninitialized memory in the
+decoded audio stream.
+
+The flaw was corrected by checking that the value read from the bistream divides
+the decode buffer size, and returning a format error if it does not. If an error
+is returned, the decode buffer is not exposed. Regression tests and an
+additional fuzzer have been added to prevent similar flaws in the future.
+"""
+patched_versions = ["=0.3.2", ">= 0.4.1"]
+url = "https://github.com/ruuda/claxon/commit/8f28ec275e412dd3af4f3cda460605512faf332c"
+keywords = ["uninitialized-memory"]


### PR DESCRIPTION
I just published Claxon 0.3.2 and 0.4.1 which fix https://github.com/ruuda/claxon/issues/10.