### PR TITLE
RUSTSEC-2018-9999: cargo-audit meta advisory for <0.3

### DIFF
--- a/Advisories.toml
+++ b/Advisories.toml
@@ -196,3 +196,24 @@ they will not be dropped more than once.
 Thank you to @Vurich for reporting this bug.
 """
 
+[[advisory]]
+id = "RUSTSEC-2018-9999"
+package = "cargo-audit"
+patched_versions = [">= 0.3.0"]
+url = "https://github.com/RustSec/advisory-db/issues/29"
+title = "Versions of cargo-audit prior to 0.3.0 will cease to work after September 1st, 2018"
+date = "2018-08-25"
+description = """
+RustSec has migrated to a new advisory database format which no longer relies
+on a monolithic TOML file (Advisories.toml). We are removing Advisories.toml
+on September 1st, 2018.
+
+After that date, older versions of cargo-audit will report the following error:
+
+```
+    Fetching advisories `https://raw.githubusercontent.com/RustSec/advisory-db/master/Advisories.toml`
+thread 'main' panicked at 'Couldn't fetch advisory database: ServerResponse', libcore/result.rs:945:5
+```
+
+Please update cargo-audit prior to September 1st, 2018 to ensure it continues working.
+"""


### PR DESCRIPTION
Adds a "meta advisory" only to Advisories.toml noting that `Advisories.toml` will be deleted on September 1st, 2018.

Versions of cargo-audit >= 0.3 will never see this, because they do not parse Advisories.toml but instead read the individual advisory files for each crate.

See:

https://github.com/RustSec/advisory-db/issues/29