### PR TITLE
Denial of service with debug build of http-codec

### DIFF
--- a/crates/http-codec/RUSTSEC-0000-0000.toml
+++ b/crates/http-codec/RUSTSEC-0000-0000.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "http-codec"
+date = "2018-09-07"
+title = "Integer overflow in Content-Length panics in debug mode"
+description = """
+All versions of http-codec parse the Content-Length header using unchecked
+arithmetic and will panic on integer overflow when compiled in debug mode or
+with `-C overflow-checks=on`.
+
+Since networking code is generally expected to be panic free this can lead to
+denial of service (but is not otherwise exploitable because the Content-Length
+header is not trusted).
+
+The http-codec crate is now unmaintained.
+"""
+patched_versions = []
+keywords = ["crash"]


### PR DESCRIPTION
This is mostly a case of
> When in doubt, please open a PR.

It's a minor issue, because only debug builds and builds with `-C overflow-checks=on` are affected. One reason to file an advisory would be that this is unlikely to get fixed: I contacted the author and he says he is no longer maintaining the crate.