### PR TITLE
Add advisory for serde_yaml

### DIFF
--- a/crates/serde_yaml/RUSTSEC-0000-0000.toml
+++ b/crates/serde_yaml/RUSTSEC-0000-0000.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "serde_yaml"
+date = "2018-09-17"
+title = "Uncontrolled recursion leads to abort in deserialization"
+description = """
+Affected versions of this crate did not properly check for recursion
+while deserializing aliases.
+
+This allows an attacker to make a YAML file with an alias referring
+to itself causing an abort.
+
+The flaw was corrected by checking the recursion depth.
+"""
+patched_versions = [">= 0.8.4"]
+unaffected_versions = ["< 0.6.0-rc1"]
+url = "https://github.com/dtolnay/serde-yaml/pull/105"
+keywords = ["crash"]


### PR DESCRIPTION
Not sure if an abort is a valid vulnerability, but for me crashing the entire application with no possibility of recovery (it's abort, not a panic) sounds like denial of service.

This is separate from #60, this is about YAML aliases, not very deep data structures. That said, #60 was discovered while trying to fix that one.