### PR TITLE
Fix "date" field on RUSTSEC-2018-0007

### DIFF
--- a/crates/trust-dns-proto/RUSTSEC-2018-0007.toml
+++ b/crates/trust-dns-proto/RUSTSEC-2018-0007.toml
@@ -1,7 +1,7 @@
 [advisory]
 id = "RUSTSEC-2018-0007"
 package = "trust-dns-proto"
-date = "2017-10-09"
+date = "2018-10-09"
 title = "Stack overflow when parsing malicious DNS packet"
 description = """
 There's a stack overflow leading to a crash when Trust-DNS's parses a


### PR DESCRIPTION
It appears it was mistakenly filed as being in 2017

cc @oherrala