### PR TITLE
Enum repr memory corruption in arrayfire crate

### DIFF
--- a/crates/arrayfire/RUSTSEC-0000-0000.toml
+++ b/crates/arrayfire/RUSTSEC-0000-0000.toml
@@ -26,7 +26,7 @@ unaffected_versions = ["<= 3.5.0"]
 
 url = "https://github.com/arrayfire/arrayfire-rust/pull/177"
 
-keywords = ["enum", "repr"]
+keywords = ["enum", "repr", "memory-corruption"]
 
 affected_arch = ["x86_64"]
 

--- a/crates/arrayfire/RUSTSEC-0000-0000.toml
+++ b/crates/arrayfire/RUSTSEC-0000-0000.toml
@@ -1,0 +1,33 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+
+package = "arrayfire"
+
+date = "2018-12-18"
+
+title = "Enum repr causing potential memory corruption"
+
+description = """
+The attribute repr() added to enums to be compatible with C-FFI caused
+memory corruption on MSVC toolchain.
+
+arrayfire crates <= version 3.5.0 do not have this issue when used with
+Rust versions 1.27 or earlier. The issue only started to appear since
+Rust version 1.28.
+
+The issue seems to be interlinked with which version of Rust is being used.
+
+The issue was fixed in crate 3.6.0.
+"""
+
+patched_versions = [">= 3.6.0"]
+
+unaffected_versions = ["<= 3.5.0"]
+
+url = "https://github.com/arrayfire/arrayfire-rust/pull/177"
+
+keywords = ["enum", "repr"]
+
+affected_arch = ["x86_64"]
+
+affected_os = ["windows"]


### PR DESCRIPTION
I have filled in the template to the best of my knowledge.

The following are the URLS for the issue and corresponding PR that fixes the issue on the crate repository.

https://github.com/arrayfire/arrayfire-rust/issues/176
https://github.com/arrayfire/arrayfire-rust/pull/177

Please let me know if any modifications are required.

Thank you.