### PR TITLE
Add affected functions to legacy security warnings

### DIFF
--- a/crates/base64/RUSTSEC-2017-0004.toml
+++ b/crates/base64/RUSTSEC-2017-0004.toml
@@ -19,3 +19,4 @@ and possibly the execution of arbitrary code.
 This flaw was corrected by using checked arithmetic to calculate
 the size of the buffer.
 """
+affected_functions = ["base64::encode_config","base64::encode_config_buf"]

--- a/crates/hyper/RUSTSEC-2017-0002.toml
+++ b/crates/hyper/RUSTSEC-2017-0002.toml
@@ -14,3 +14,4 @@ is if an application constructs headers based on unsanitized user input.
 This issue was fixed by replacing all newline characters with a space during serialization of
 a header value.
 """
+affected_functions = ["hyper::header::Headers::set"]

--- a/crates/smallvec/RUSTSEC-2018-0003.toml
+++ b/crates/smallvec/RUSTSEC-2018-0003.toml
@@ -20,3 +20,4 @@ they will not be dropped more than once.
 
 Thank you to @Vurich for reporting this bug.
 """
+affected_functions = ["smallvec::SmallVec::insert_many"]

--- a/crates/tar/RUSTSEC-2018-0002.toml
+++ b/crates/tar/RUSTSEC-2018-0002.toml
@@ -23,3 +23,4 @@ This has been fixed in https://github.com/alexcrichton/tar-rs/pull/156 and is
 published as `tar` 0.4.16. Thanks to Max Justicz for discovering this and
 emailing about the issue!
 """
+affected_functions = ["tar::Entry::unpack_in"]

--- a/crates/untrusted/RUSTSEC-2018-0001.toml
+++ b/crates/untrusted/RUSTSEC-2018-0001.toml
@@ -20,3 +20,4 @@ The error in untrusted is fixed in release 0.6.2 released 2018-06-21. It's also
 advisable that users of untrusted check for their sources for cases where errors
 returned by untrusted are not handled correctly.
 """
+affected_functions = ["untrusted::Reader::skip_and_get_input"]


### PR DESCRIPTION
Adds the newly introduced `affected_functions` attribute to some legacy security warnings.