### PR TITLE
README.md: Bump maintained date

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RustSec Advisory Database
 
 [![Build Status][build-image]][build-link]
-![Maintained as of December 2018][maintained-image]
+![Maintained][maintained-image]
 [![Gitter Chat][gitter-image]][gitter-link]
 
 [build-image]: https://travis-ci.org/RustSec/advisory-db.svg?branch=master


### PR DESCRIPTION
This is largely to work around the following:

```
$ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
error: couldn't fetch advisory database: git operation failed: no signature on commit 0a981e2b6f3c8aeaaaa194989d8d3e4a53e3c199: Add affected functions to legacy security warnings (#83) (Moritz Beller <Inventitech@users.noreply.github.com>)
```

I tried to Squash-and-Merge on #83. GitHub does not sign the resulting commit. Oops.

So this commit is just to make `HEAD` a GitHub-signed merge commit.