### PR TITLE
Assign RUSTSEC-2019-0003 to protobuf; -0004 to libp2p-core

### DIFF
--- a/crates/libp2p-core/RUSTSEC-2019-0004.toml
+++ b/crates/libp2p-core/RUSTSEC-2019-0004.toml
@@ -1,5 +1,5 @@
 [advisory]
-id = "RUSTSEC-0000-0000"
+id = "RUSTSEC-2019-0004"
 package = "libp2p-core"
 date = "2019-05-15"
 title = "Failure to properly verify ed25519 signatures makes any signature valid"

--- a/crates/protobuf/RUSTSEC-2019-0003.toml
+++ b/crates/protobuf/RUSTSEC-2019-0003.toml
@@ -1,5 +1,5 @@
 [advisory]
-id = "RUSTSEC-0000-0000"
+id = "RUSTSEC-2019-0003"
 package = "protobuf"
 date = "2018-06-08"
 title = "Out of Memory in stream::read_raw_bytes_into()"


### PR DESCRIPTION
Original PRs:

- `protobuf`: https://github.com/RustSec/advisory-db/pull/97
- `libp2p-core`: https://github.com/RustSec/advisory-db/pull/98