### PR TITLE
protobuf 2.6.0 and 1.7.5 released with fix to RUSTSEC-2019-0003

### DIFF
--- a/crates/protobuf/RUSTSEC-2019-0003.toml
+++ b/crates/protobuf/RUSTSEC-2019-0003.toml
@@ -12,4 +12,4 @@ vulnerable method on untrusted data.
 url = "https://github.com/stepancheg/rust-protobuf/issues/411"
 keywords = ["oom", "panic", "dos"]
 affected_functions = ["stream::read_raw_bytes_into"]
-patched_versions = []
+patched_versions = [">= 1.7.5, >= 2.6.0"]


### PR DESCRIPTION
Upstream issue: https://github.com/stepancheg/rust-protobuf/issues/411
