### PR TITLE
RUSTSEC-2019-0003: Fix date

### DIFF
--- a/crates/protobuf/RUSTSEC-2019-0003.toml
+++ b/crates/protobuf/RUSTSEC-2019-0003.toml
@@ -1,7 +1,7 @@
 [advisory]
 id = "RUSTSEC-2019-0003"
 package = "protobuf"
-date = "2018-06-08"
+date = "2019-06-08"
 title = "Out of Memory in stream::read_raw_bytes_into()"
 description = """
 Affected versions of this crate called Vec::reserve() on user-supplied input.


### PR DESCRIPTION
Mistakenly logged as 2018