### PR TITLE
[portaudio] add build script RCE

### DIFF
--- a/crates/portaudio/RUSTSEC-0000-0000.toml
+++ b/crates/portaudio/RUSTSEC-0000-0000.toml
@@ -1,0 +1,15 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "portaudio"
+date = "2016-08-01"
+title = "HTTP download and execution allows MitM RCE"
+description = """
+The build script in the portaudio crate will attempt to download via HTTP
+the portaudio source and build it.
+
+A Mallory in the middle can intercept the download with their own archive
+and get RCE.
+"""
+patched_versions = []
+url = "https://github.com/RustAudio/rust-portaudio/issues/144"
+keywords = ["ssl", "mitm"]


### PR DESCRIPTION
Via: https://github.com/RustAudio/rust-portaudio/issues/144

This is, as of yet, unfixed.