### PR TITLE
Assign RUSTSEC-2019-0004 to ncurses; -0005 to pancurses

### DIFF
--- a/crates/ncurses/RUSTSEC-2019-0004.toml
+++ b/crates/ncurses/RUSTSEC-2019-0004.toml
@@ -1,6 +1,5 @@
 [advisory]
-id = "RUSTSEC-0000-0000"
-
+id = "RUSTSEC-2019-0004"
 package = "ncurses"
 date = "2019-06-15"
 

--- a/crates/pancurses/RUSTSEC-2019-0005.toml
+++ b/crates/pancurses/RUSTSEC-2019-0005.toml
@@ -1,6 +1,5 @@
 [advisory]
-id = "RUSTSEC-0000-0000"
-
+id = "RUSTSEC-2019-0005"
 package = "pancurses"
 date = "2019-06-15"
 


### PR DESCRIPTION
Original PRs:

- **RUSTSEC-2019-0004** (ncurses): https://github.com/RustSec/advisory-db/pull/107
- **RUSTSEC-2019-0005** (pancurses): https://github.com/RustSec/advisory-db/pull/108