### PR TITLE
Reassign ncurses vuln from RUSTSEC-2019-0004 => 0006

### DIFF
--- a/crates/ncurses/RUSTSEC-2019-0006.toml
+++ b/crates/ncurses/RUSTSEC-2019-0006.toml
@@ -1,5 +1,5 @@
 [advisory]
-id = "RUSTSEC-2019-0004"
+id = "RUSTSEC-2019-0006"
 package = "ncurses"
 date = "2019-06-15"
 


### PR DESCRIPTION
RUSTSEC-2019-0004 is already assigned to a `libp2p-core` vulnerability.

Apparently we don't have tests to catch this? Unfortunate.

I opened an issue about that here:

https://github.com/RustSec/rustsec-crate/issues/63