### PR TITLE
RUSTSEC-2019-0006: Use -0005's format vuln wording

### DIFF
--- a/crates/ncurses/RUSTSEC-2019-0006.toml
+++ b/crates/ncurses/RUSTSEC-2019-0006.toml
@@ -10,8 +10,9 @@ description = """
 
 - Pass buffers without length to C functions that may write an arbitrary amount of
   data, leading to a buffer overflow. (`instr`, `mvwinstr`, etc)
-- Passes rust &str to strings expecting C format arguments, allowing a format
-  vulnerability (functions in the `printw` family).
+- Passes rust &str to strings expecting C format arguments, allowing hostile
+  input to execute a format string attack, which trivially allows writing
+  arbitrary data to stack memory (functions in the `printw` family).
 """
 
 patched_versions = []


### PR DESCRIPTION
As filed, advisory RUSTSEC-2019-0006 simply notes that certain
functions in the covered crate create a "format vulnerability". This
patch, following up on [an exchange of comments on GitHub][1], edits
advisory RUSTSEC-2019-0006 to summarize the risk introduced by a
format vulnerability, copying the wording of the associated advisory
RUSTSEC-2019-0005.

[1]: <https://github.com/RustSec/advisory-db/pull/107#pullrequestreview-250212575>