### PR TITLE
actually memoffset also had an uninit-drop vuln

### DIFF
--- a/crates/memoffset/RUSTSEC-2019-0011.toml
+++ b/crates/memoffset/RUSTSEC-2019-0011.toml
@@ -5,7 +5,7 @@ date = "2019-07-16"
 title = "Flaw in offset_of and span_of causes SIGILL, drops uninitialized memory of arbitrary type on panic in client code"
 description = """
 Affected versions of this crate caused traps and/or memory unsafety by zero-initializing references.
-They also could leat to uninitialized memory being dropped if the field for which the offset is requested was behind a deref coercion, and that deref coercion caused a panic.
+They also could lead to uninitialized memory being dropped if the field for which the offset is requested was behind a deref coercion, and that deref coercion caused a panic.
 
 The flaw was corrected by using `MaybeUninit`.
 """

--- a/crates/memoffset/RUSTSEC-2019-0011.toml
+++ b/crates/memoffset/RUSTSEC-2019-0011.toml
@@ -2,13 +2,13 @@
 id = "RUSTSEC-2019-0011"
 package = "memoffset"
 date = "2019-07-16"
-title = "Flaw in offset_of and span_of causes SIGILL, potential memory unsafety"
+title = "Flaw in offset_of and span_of causes SIGILL, drops uninitialized memory of arbitrary type on panic in client code"
 description = """
 Affected versions of this crate caused traps and/or memory unsafety by zero-initializing references.
+They also could leat to uninitialized memory being dropped if the field for which the offset is requested was behind a deref coercion, and that deref coercion caused a panic.
 
 The flaw was corrected by using `MaybeUninit`.
 """
 
 patched_versions = [">= 0.5.0"]
-unaffected_versions = ["< 0.3.0"]
 url = "https://github.com/Gilnaa/memoffset/issues/9#issuecomment-505461490"


### PR DESCRIPTION
This affects all versions ever published.