### PR TITLE
add out-of-bounds memory access in compact_arena < 0.4.0

### DIFF
--- a/crates/compact_arena/RUSTSEC-0000-0000.toml
+++ b/crates/compact_arena/RUSTSEC-0000-0000.toml
@@ -1,0 +1,19 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "compact_arena"
+date = "2019-05-21"
+title = "Flaw in generativity allows out-of-bounds access"
+description = """
+Affected versions of this crate did not properly implement the generativity,
+because the invariant lifetimes were not necessarily `drop`ped.
+
+This allows an attacker to mix up two arenas, using indices created from one 
+arena with another one. This might lead to an out-of-bounds read or write 
+access into the memory reserved for the arena.
+ 
+The flaw was corrected by implementing generativity correctly in version 0.4.0.
+"""
+patched_versions = [">= 0.4.0"]
+url = "https://github.com/llogiq/compact_arena/issues/22"
+keywords = ["memory-corruption", "uninitialized-memory"]
+affected_functions = ["compact_arena::SmallArena::new"]


### PR DESCRIPTION
Thanks @Shnatsel for pointing me to this repo in [this comment](https://github.com/llogiq/compact_arena/issues/22#issuecomment-526859341).