### PR TITLE
Add advisory for string-interner

### DIFF
--- a/crates/string-interner/RUSTSEC-0000-0000.toml
+++ b/crates/string-interner/RUSTSEC-0000-0000.toml
@@ -1,0 +1,20 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "string-interner"
+date = "2019-08-24"
+title = "Cloned interners may read already dropped strings"
+description = """
+Affected versions of this crate did not clone contained strings when an interner is cloned.
+Interners have raw pointers to the contained strings, and they keep pointing the strings which the old interner owns, after the interner is cloned.
+If a new cloned interner is alive and the old original interner is dead, the new interner has dangling pointers to the old interner's storage, which is already dropped.
+
+This allows an attacker to read the already freed memory.
+The dangling pointers are used by the interners to check a string is already interned.
+An attacker can do brute force attack to get the data pointed by the dangling pointer.
+
+The flaw was corrected by <https://github.com/Robbepop/string-interner/pull/10>.
+This patch implements `Clone` manually to the interner type, so that the internal raw pointers always point the strings owned by the same interner.
+"""
+patched_versions = [">= 0.7.1"]
+url = "https://github.com/Robbepop/string-interner/issues/9"
+keywords = ["use after free"]


### PR DESCRIPTION
As asked for at <https://github.com/Robbepop/string-interner/issues/9#issuecomment-526857810>.

Some notes:

* I think the attacker can read some already dropped memory, not by direct access, but by brute-forcing.
  I don't know how I can say it in the title.
* The fix is [already merged](https://github.com/Robbepop/string-interner/pull/10), but not yet released.
* I sent [another patch](https://github.com/Robbepop/string-interner/pull/12) to add an additional test that checks there are no dangling pointers in such situations, but it is not yet merged.
  So I didn't write about it in the description.
* I'm not native English speaker, so feel free to point out if there are unnatural wordings.