### PR TITLE
support.toml: Initial file

### DIFF
--- a/support.toml
+++ b/support.toml
@@ -1,0 +1,3 @@
+# Minimum supported version of the `rustsec` crate
+[rustsec]
+version = ">= 0.12"


### PR DESCRIPTION
Adds an initial file indicating what version of the `rustsec` crate the advisory database is compatible with. This is designed for use with the corresponding feature in the `rustsec` crate:

https://github.com/RustSec/rustsec-crate/pull/76