### PR TITLE
Undefined behavior in renderdoc crate

### DIFF
--- a/crates/renderdoc/RUSTSEC-0000-0000.toml
+++ b/crates/renderdoc/RUSTSEC-0000-0000.toml
@@ -1,0 +1,23 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "renderdoc"
+date = "2019-09-02"
+title = "Internally mutating methods take immutable ref self"
+description = """
+Affected versions of this crate exposed several methods which took `self` by
+immutable reference, despite the requesting the RenderDoc API to set a mutable
+value internally.
+
+This is technically unsound and calling these methods from multiple threads
+without synchronization could lead to unexpected and unpredictable behavior.
+ 
+The flaw was corrected in release 0.5.0.
+"""
+patched_versions = [">= 0.5.0"]
+url = "https://github.com/ebkalderon/renderdoc-rs/pull/32"
+keywords = ["undefined_behavior"]
+affected_os = ["linux", "windows"]
+affected_functions = [
+    "renderdoc::api::RenderDocV110::trigger_multi_frame_capture",
+    "renderdoc::api::RenderDocV120::set_capture_file_comments",
+]

--- a/crates/renderdoc/RUSTSEC-0000-0000.toml
+++ b/crates/renderdoc/RUSTSEC-0000-0000.toml
@@ -16,7 +16,6 @@ The flaw was corrected in release 0.5.0.
 patched_versions = [">= 0.5.0"]
 url = "https://github.com/ebkalderon/renderdoc-rs/pull/32"
 keywords = ["undefined_behavior"]
-affected_os = ["linux", "windows"]
 affected_functions = [
     "renderdoc::api::RenderDocV110::trigger_multi_frame_capture",
     "renderdoc::api::RenderDocV120::set_capture_file_comments",


### PR DESCRIPTION
While updating the [renderdoc-rs](https://github.com/ebkalderon/renderdoc-rs) bindings a few months ago, I had identified several methods that were taking immutable reference to `self` but were actually making internally mutating [RenderDoc](https://renderdoc.org) API calls, which could potentially lead to undefined behavior.

This issue was corrected in the 0.5.0 release, and it was [recently suggested](https://github.com/ebkalderon/renderdoc-rs/issues/28#issuecomment-526860298) that I file a public advisory here, which was a very good idea.

I would appreciate any feedback in reporting this advisory properly, and I hope to report any such cases in a more timely manner in the future.