### PR TITLE
Add advisory for generator

### DIFF
--- a/crates/generator/RUSTSEC-0000-0000.toml
+++ b/crates/generator/RUSTSEC-0000-0000.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+
+package = "generator"
+
+date = "2019-09-06"
+
+title = "fix unsound APIs that could lead to UB"
+
+description = """
+Affected versions of this crate API could use uninitialized memory with some APIs in special
+cases, like use the API in none generator context. This could lead to UB.
+The flaw was corrected by <https://github.com/Xudong-Huang/generator-rs/issues/9>
+                          <https://github.com/Xudong-Huang/generator-rs/issues/11>
+                          <https://github.com/Xudong-Huang/generator-rs/issues/13>
+                          <https://github.com/Xudong-Huang/generator-rs/issues/14>                                                  
+This patch fixes all those issues above.
+"""
+
+patched_versions = [">= 0.6.18"]
+
+url = "https://github.com/Xudong-Huang/generator-rs/issues/9"
+
+keywords = ["memory-corruption"]


### PR DESCRIPTION
As asked for at Xudong-Huang/generator-rs/issues/9 (comment).

Some notes:

The new release fix several memory corruption APIs in some special cases by adding more checks. Some of the APIs were deprecated.