### PR TITLE
Add advisory for broken `blake2` impls

### DIFF
--- a/crates/blake2/RUSTSEC-0000-0000.toml
+++ b/crates/blake2/RUSTSEC-0000-0000.toml
@@ -1,0 +1,20 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "blake2"
+date = "2019-08-25"
+title = "HMAC-BLAKE2 algorithms compute incorrect results"
+description = """
+When used in conjunction with the Hash-based Message Authentication Code (HMAC),
+the BLAKE2b and BLAKE2s implementations in `blake2` crate versions prior to
+v0.8.1 used an incorrect block size (32-bytes instead of 64-bytes for BLAKE2s,
+and 64-bytes instead of 128-bytes for BLAKE2b), causing them to miscompute the
+`MacResult`.
+
+The v0.8.1 release of the `blake2` crate uses the correct block sizes.
+
+Note that this advisory only impacts usage of BLAKE2 with HMAC, and does not
+impact `Digest` functionality.
+"""
+patched_versions = [">= 0.8.1"]
+url = "https://github.com/RustCrypto/MACs/issues/19"
+category = ["crypto-failure"]


### PR DESCRIPTION
BLAKE2b and BLAKE2s were implemented using the wrong block size. All versions of the `blake2` crate prior to v0.8.1 compute incorrect digests.

See: https://github.com/RustCrypto/MACs/issues/19