### PR TITLE
Use-after-free in portaudio-rs and double free in linea

### DIFF
--- a/crates/linea/RUSTSEC-0000-0000.toml
+++ b/crates/linea/RUSTSEC-0000-0000.toml
@@ -1,0 +1,25 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+
+package = "linea"
+
+date = "2019-9-14"
+
+title = "`Matrix::zip_elements` causes double free"
+
+description = """
+Affected versions of this crate did not properly implements the `Matrix::zip_elements` method, which causes an double free when the given trait implementation might panic.
+
+This allows an attacker to corrupt or take control of the memory.
+ 
+The flaw was corrected by Phosphorus15.
+"""
+
+# yet not merged
+patched_versions = ["> 0.9.4"]
+
+url = "https://github.com/strake/linea.rs/issues/2"
+
+categories = ["memory-corruption"]
+
+keywords = ["double free"]

--- a/crates/linea/RUSTSEC-0000-0000.toml
+++ b/crates/linea/RUSTSEC-0000-0000.toml
@@ -3,7 +3,7 @@ id = "RUSTSEC-0000-0000"
 
 package = "linea"
 
-date = "2019-9-14"
+date = "2019-09-14"
 
 title = "`Matrix::zip_elements` causes double free"
 

--- a/crates/portaudio-rs/RUSTSEC-0000-0000.toml
+++ b/crates/portaudio-rs/RUSTSEC-0000-0000.toml
@@ -1,0 +1,29 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+
+package = "portaudio-rs"
+
+date = "2017-9-14"
+
+# Single-line description of a vulnerability (mandatory)
+title = "Stream callback function is not unwind safe"
+
+# Enter a short-form description of the vulnerability here (mandatory)
+description = """
+Affected versions of this crate is not panic safe within callback functions `stream_callback` and `stream_finished_callback`.
+
+The call to user-provided closure might panic before a `mem::forget` call, which then causes a use after free that grants attacker to control the callback function pointer.
+
+This allows an attacker to construct an arbitrary code execution .
+ 
+The flaw was reported by Phosphorus15.
+"""
+
+# yet not patched
+patched_versions = ["> 0.3.1"]
+
+url = "https://github.com/mvdnes/portaudio-rs/issues/20"
+
+categories = ["code-execution", "memory-corruption"]
+
+keywords = ["audio", "ffi"]

--- a/crates/portaudio-rs/RUSTSEC-0000-0000.toml
+++ b/crates/portaudio-rs/RUSTSEC-0000-0000.toml
@@ -3,7 +3,7 @@ id = "RUSTSEC-0000-0000"
 
 package = "portaudio-rs"
 
-date = "2017-9-14"
+date = "2017-09-14"
 
 # Single-line description of a vulnerability (mandatory)
 title = "Stream callback function is not unwind safe"


### PR DESCRIPTION
Two unwind-safety problem was detected in crates mentioned above.