### PR TITLE
CVE-2019-16760: update advisory title

### DIFF
--- a/rust/cargo/CVE-2019-16760.toml
+++ b/rust/cargo/CVE-2019-16760.toml
@@ -2,7 +2,10 @@
 id = "CVE-2019-16760"
 package = "cargo"
 date = "2019-09-30"
-title = "Security advisory for Cargo"
+aliases = ["GHSA-phjm-8x66-qw4r"]
+unaffected_versions = [">= 1.26.0"]
+url = "https://groups.google.com/forum/#!topic/rustlang-security-announcements/rVQ5e3TDnpQ"
+title = "Cargo prior to Rust 1.26.0 may download the wrong dependency"
 description = """
 The Rust team was recently notified of a security concern when using older
 versions of Cargo to build crates which use the package rename feature added in
@@ -106,5 +109,3 @@ with our [security policy][5].
 [4]: https://gist.github.com/pietroalbini/0d293b24a44babbeb6187e06eebd4992
 [5]: https://www.rust-lang.org/policies/security
 """
-unaffected_versions = [">= 1.26.0"]
-url = "https://groups.google.com/forum/#!topic/rustlang-security-announcements/rVQ5e3TDnpQ"


### PR DESCRIPTION
Matches the advisory title used for:

https://github.com/rust-lang/rust/security/advisories/GHSA-phjm-8x66-qw4r

Also adds `GHSA-phjm-8x66-qw4r` as an alias