### PR TITLE
Use backticks for escaped characters

### DIFF
--- a/crates/hyper/RUSTSEC-2017-0002.toml
+++ b/crates/hyper/RUSTSEC-2017-0002.toml
@@ -6,7 +6,7 @@ date = "2017-01-23"
 url = "https://github.com/hyperium/hyper/wiki/Security-001"
 title = "headers containing newline characters can split messages"
 description = """
-Serializing of headers to the socket did not filter the values for newline bytes (\\r or \\n),
+Serializing of headers to the socket did not filter the values for newline bytes (`\\r` or `\\n`),
 which allowed for header values to split a request or response. People would not likely include
 newlines in the headers in their own applications, so the way for most people to exploit this
 is if an application constructs headers based on unsanitized user input.


### PR DESCRIPTION
Followup to #177.