### PR TITLE
Add unmaintained crate informational advisory: chan

### DIFF
--- a/crates/chan/RUSTSEC-0000-0000.toml
+++ b/crates/chan/RUSTSEC-0000-0000.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "chan"
+title = "chan is end-of-life; use crossbeam-channel instead"
+informational = "unmaintained"
+date = "2018-07-31"
+url = "https://github.com/BurntSushi/chan/commit/0a5c0d4ad4adc90a54ee04a427389acf2e157275"
+unaffected_versions = ["> 0.1.23"] # last release
+description = """
+**`chan` has reached its end-of-life and is now deprecated.**
+
+The intended successor of this crate is
+[`crossbeam-channel`](https://github.com/crossbeam-rs/crossbeam/tree/master/crossbeam-channel).
+Its API is strikingly similar, but comes with a much better `select!` macro,
+better performance, a better test suite and an all-around better
+implementation.
+"""

--- a/crates/chan/RUSTSEC-2018-0014.toml
+++ b/crates/chan/RUSTSEC-2018-0014.toml
@@ -1,5 +1,5 @@
 [advisory]
-id = "RUSTSEC-0000-0000"
+id = "RUSTSEC-2018-0014"
 package = "chan"
 title = "chan is end-of-life; use crossbeam-channel instead"
 informational = "unmaintained"


### PR DESCRIPTION
Officially deprecated by its author @BurntSushi:

https://github.com/BurntSushi/chan/commit/0a5c0d4ad4adc90a54ee04a427389acf2e157275