### PR TITLE
Add unmaintained crate informational advisory: libusb

### DIFF
--- a/crates/libusb/RUSTSEC-0000-0000.toml
+++ b/crates/libusb/RUSTSEC-0000-0000.toml
@@ -1,0 +1,16 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libusb"
+title = "libusb is unmaintained; use rusb instead"
+informational = "unmaintained"
+date = "2016-09-10"
+unaffected_versions = ["> 0.3.0"] # last release
+url = "https://github.com/dcuddeback/libusb-rs/issues/33"
+description = """
+The `libusb` crate has not seen a release since September 2016, and its author
+is unresponsive.
+
+The `rusb` crate is a maintained fork:
+
+https://github.com/a1ien/rusb
+"""

--- a/crates/libusb/RUSTSEC-2016-0004.toml
+++ b/crates/libusb/RUSTSEC-2016-0004.toml
@@ -1,5 +1,5 @@
 [advisory]
-id = "RUSTSEC-0000-0000"
+id = "RUSTSEC-2016-0004"
 package = "libusb"
 title = "libusb is unmaintained; use rusb instead"
 informational = "unmaintained"


### PR DESCRIPTION
No releases since 2016 and no responses from the author about its maintenance status; with several open PRs and issues:

https://github.com/dcuddeback/libusb-rs/issues/33

Recommending `rusb`, a maintained fork, as a successor:

https://github.com/a1ien/rusb