### PR TITLE
Add unmaintained crate informational advisory: term

### DIFF
--- a/crates/term/RUSTSEC-0000-0000.toml
+++ b/crates/term/RUSTSEC-0000-0000.toml
@@ -1,0 +1,18 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "term"
+title = "term is looking for a new maintainer"
+informational = "unmaintained"
+date = "2018-11-19"
+url = "https://github.com/Stebalien/term/issues/93"
+description = """
+The author of the `term` crate does not have time to maintain it and is looking
+for a new maintainer.
+
+Some maintained alternatives you can potentially switch to instead, depending
+on your needs:
+
+- [`crossterm`](https://github.com/crossterm-rs/crossterm)
+- [`termcolor`](https://crates.io/crates/termcolor)
+- [`yansi`](https://crates.io/crates/yansi)
+"""

--- a/crates/term/RUSTSEC-2018-0015.toml
+++ b/crates/term/RUSTSEC-2018-0015.toml
@@ -1,10 +1,12 @@
 [advisory]
-id = "RUSTSEC-0000-0000"
+id = "RUSTSEC-2018-0015"
 package = "term"
 title = "term is looking for a new maintainer"
 informational = "unmaintained"
 date = "2018-11-19"
 url = "https://github.com/Stebalien/term/issues/93"
+unaffected_versions = ["> 0.6.1"] # last release
+patched_versions = []
 description = """
 The author of the `term` crate does not have time to maintain it and is looking
 for a new maintainer.


### PR DESCRIPTION
The author of `term`, @Stebalien, has opened the following GitHub issue looking for a new maintainer:

https://github.com/Stebalien/term/issues/93

Ideally we can help find one by increasing visibility on this issue. Otherwise this advisory includes a list of possible alternatives.