### PR TITLE
Add unmaintained crate informational advisory: cassandra

### DIFF
--- a/crates/cassandra/RUSTSEC-0000-0000.toml
+++ b/crates/cassandra/RUSTSEC-0000-0000.toml
@@ -1,0 +1,16 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "cassandra"
+title = "`cassandra` crate is unmaintained; use `cassandra-cpp` instead"
+informational = "unmaintained"
+date = "2016-12-15"
+url = "https://github.com/tupshin/cassandra-rs/issues/52"
+unaffected_versions = ["> 0.8.1"] # last release
+description = """
+The `cassandra` crate has not seen a release since December 2016, and its author
+is unresponsive.
+
+The `cassandra-cpp` crate is a maintained fork:
+
+https://github.com/Metaswitch/cassandra-rs
+"""

--- a/crates/cassandra/RUSTSEC-2016-0006.toml
+++ b/crates/cassandra/RUSTSEC-2016-0006.toml
@@ -1,11 +1,12 @@
 [advisory]
-id = "RUSTSEC-0000-0000"
+id = "RUSTSEC-2016-0006"
 package = "cassandra"
 title = "`cassandra` crate is unmaintained; use `cassandra-cpp` instead"
 informational = "unmaintained"
 date = "2016-12-15"
 url = "https://github.com/tupshin/cassandra-rs/issues/52"
 unaffected_versions = ["> 0.8.1"] # last release
+patched_versions = []
 description = """
 The `cassandra` crate has not seen a release since December 2016, and its author
 is unresponsive.


### PR DESCRIPTION
No releases since 2016 and no responses from the author about its maintenance status:

https://github.com/tupshin/cassandra-rs/issues/52

Recommending `cassandra-cpp`, a maintained fork, as a successor:

https://github.com/Metaswitch/cassandra-rs