### PR TITLE
Add `patched_versions` to informational advisories

### DIFF
--- a/crates/chan/RUSTSEC-2018-0014.toml
+++ b/crates/chan/RUSTSEC-2018-0014.toml
@@ -6,6 +6,7 @@ informational = "unmaintained"
 date = "2018-07-31"
 url = "https://github.com/BurntSushi/chan/commit/0a5c0d4ad4adc90a54ee04a427389acf2e157275"
 unaffected_versions = ["> 0.1.23"] # last release
+patched_versions = []
 description = """
 **`chan` has reached its end-of-life and is now deprecated.**
 

--- a/crates/libusb/RUSTSEC-2016-0004.toml
+++ b/crates/libusb/RUSTSEC-2016-0004.toml
@@ -5,6 +5,7 @@ title = "libusb is unmaintained; use rusb instead"
 informational = "unmaintained"
 date = "2016-09-10"
 unaffected_versions = ["> 0.3.0"] # last release
+patched_versions = []
 url = "https://github.com/dcuddeback/libusb-rs/issues/33"
 description = """
 The `libusb` crate has not seen a release since September 2016, and its author


### PR DESCRIPTION
Its absence breaks older versions of cargo-audit:

    $ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
    error: error loading advisory database: couldn't parse data: missing field `patched_versions` for key `advisory`
    Exited with code 1