### PR TITLE
RUSTSEC-2019-0024: Test advisory for `rustsec-example-crate` (closes #158)

### DIFF
--- a/crates/rustsec-example-crate/RUSTSEC-2019-0024.toml
+++ b/crates/rustsec-example-crate/RUSTSEC-2019-0024.toml
@@ -1,0 +1,25 @@
+[advisory]
+id = "RUSTSEC-2019-0024"
+package = "rustsec-example-crate"
+patched_versions = [">= 1.0.0"]
+date = "2019-10-08"
+url = "https://github.com/RustSec/advisory-db/issues/158"
+title = "Test advisory with associated example crate"
+description = """
+This is a test advisory useful for verifying RustSec tooling and vulnerability
+detection pipelines are working correctly. Aside from the fact that it is filed
+against an example crate, it is otherwise considered by the Advisory Database
+itself to be a normal security advisory.
+
+It's filed against `rustsec-example-crate`, an otherwise completely empty crate
+with no functionality or code, which has two releases:
+
+- [v0.0.1]: *vulnerable* according to this advisory
+- [v1.0.0]: *patched* by this advisory
+
+(Technically there is a third release, v0.0.0, which is yanked, but otherwise
+identical to the v0.0.1 release)
+
+[v0.0.1]: https://crates.io/crates/rustsec-example-crate/0.0.1
+[v1.0.0]: https://crates.io/crates/rustsec-example-crate/1.0.0
+"""


### PR DESCRIPTION
This is a test advisory useful for verifying RustSec tooling and vulnerability detection pipelines are working correctly. Aside from the fact that it is filed against an example crate, it is otherwise
considered by the Advisory Database itself to be a normal security advisory.

It's filed against `rustsec-example-crate`, an otherwise completely empty crate with no functionality or code, which has two releases:

- [v0.0.1]: *vulnerable* according to this advisory
- [v1.0.0]: *patched* by this advisory

(Technically there is a third release, v0.0.0, which is yanked, but otherwise identical to the v0.0.1 release)

[v0.0.1]: https://crates.io/crates/rustsec-example-crate/0.0.1
[v1.0.0]: https://crates.io/crates/rustsec-example-crate/1.0.0