### PR TITLE
RUSTSEC-2017-0006: rmpv: add patched versions

### DIFF
--- a/crates/rmpv/RUSTSEC-2017-0006.toml
+++ b/crates/rmpv/RUSTSEC-2017-0006.toml
@@ -10,7 +10,7 @@ buffers without checking whether there is sufficient data available.
 This allows an attacker to do denial-of-service attacks by sending small
 msgpack messages that allocate gigabytes of memory.
 """
-patched_versions = []
+patched_versions = [">= 0.4.2"]
 url = "https://github.com/3Hren/msgpack-rust/issues/151"
 categories = ["denial-of-service"]
 keywords = ["memory", "dos", "msgpack", "serialization", "deserialization"]


### PR DESCRIPTION
Patched as of v0.4.2:

https://github.com/RustSec/advisory-db/pull/171#issuecomment-540169499