### PR TITLE
Update RUSTSEC-2019-0026.toml

### DIFF
--- a/crates/sodiumoxide/RUSTSEC-2019-0026.toml
+++ b/crates/sodiumoxide/RUSTSEC-2019-0026.toml
@@ -14,5 +14,5 @@ patched_versions = [">= 0.2.5"]
 keywords = ["cryptography"]
 
 [affected.functions]
-"sodiumoxide::crypto::generichash::Digest::eq" = ["< 0.2.5, >= 0.1.0"]
-"sodiumoxide::crypto::generichash::Digest::ne" = ["< 0.2.5, >= 0.1.0"]
+"sodiumoxide::crypto::generichash::Digest::eq" = ["< 0.2.5, >= 0.2.0"]
+"sodiumoxide::crypto::generichash::Digest::ne" = ["< 0.2.5, >= 0.2.0"]


### PR DESCRIPTION
According to the change log it was introduced in 0.2.0

Versions 0.2.0-0.2.4 were yanked.