### PR TITLE
Add a flatbuffers unsound code advisory

### DIFF
--- a/crates/flatbuffers/RUSTSEC-2019-0024.toml
+++ b/crates/flatbuffers/RUSTSEC-2019-0024.toml
@@ -1,0 +1,17 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "flatbuffers"
+patched_versions = []
+unaffected_versions = ["< 0.4.0"]
+date = "2019-10-20"
+url = "https://github.com/google/flatbuffers/issues/5530"
+title = "Unsound `impl Follow for bool`"
+description = """
+The implementation of `impl Follow for bool` allows to reinterpret arbitrary bytes as a `bool`.
+
+In Rust `bool` has stringent requirements for its in-memory representation. Use of this function
+allows to violate these requirements and invoke undefined behaviour in safe code.
+"""
+
+[affected]
+functions = { "flatbuffers::Follow::follow" = [">= 0.4.0", "<= 0.6.0"] }

--- a/crates/flatbuffers/RUSTSEC-2019-0028.toml
+++ b/crates/flatbuffers/RUSTSEC-2019-0028.toml
@@ -1,5 +1,5 @@
 [advisory]
-id = "RUSTSEC-0000-0000"
+id = "RUSTSEC-2019-0028"
 package = "flatbuffers"
 patched_versions = []
 unaffected_versions = ["< 0.4.0"]


### PR DESCRIPTION
A couple of observations:

* There are still no released versions with a fix.
* The issue does not strictly fall into any particular criteria listed in https://github.com/RustSec/advisory-db/blob/master/CONTRIBUTING.md#criteria, but given the nature of this library the input is likely to be some untrusted external input over network or similar. This gives an attacker an easy vector to exploit UB which could subsequently result in execution of unintended branches in code, cause panics, or circumvent authorization checks, etc.