### PR TITLE
Filed an advisory for ::safemem::prepend() reference to uninit memory

### DIFF
--- a/crates/safemem/RUSTSEC-0000-0000.toml
+++ b/crates/safemem/RUSTSEC-0000-0000.toml
@@ -1,0 +1,21 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "safemem"
+date = "2019-10-23"
+title = "prepend() internals create a reference to uninitialized memory"
+description = """
+Affected versions of this crate had a non-unsafe prepend() function that
+temporarily created a `&mut` reference to uninitialized memory of type <T : Copy>
+to afterwards write to it, which currently is Undefined Behavior.
+
+This does not allow an attacker to do anything yet, since the uninitialized memory
+is not explicitely used by the code, and the current implementations of the
+compiler do not seem to exploit the UB.
+
+The flaw was corrected by @danielhenrymantilla and published as of version 0.3.3.
+"""
+patched_versions = [">= 0.3.3"]
+url = "https://github.com/abonander/safemem/issues/7"
+keywords = ["uninitialized-memory", "UB"]
+[affected]
+functions = { "::safemem::prepend" = ["< 0.3.3"] }

--- a/crates/safemem/RUSTSEC-0000-0000.toml
+++ b/crates/safemem/RUSTSEC-0000-0000.toml
@@ -18,4 +18,4 @@ patched_versions = [">= 0.3.3"]
 url = "https://github.com/abonander/safemem/issues/7"
 keywords = ["uninitialized-memory", "UB"]
 [affected]
-functions = { "::safemem::prepend" = ["< 0.3.3"] }
+functions = { "safemem::prepend" = ["< 0.3.3"] }


### PR DESCRIPTION
I don't know the severity of this soundness issue, as it's currently rather theoretical (currently, reference to uninit memory = UB), but I've preferred to submit an advisory anyways as suggested by @CAD97 in https://github.com/abonander/safemem/issues/7. I'll let you be the judges of that.