### PR TITLE
rust-crypto: Add orion as alternative

### DIFF
--- a/crates/rust-crypto/RUSTSEC-2016-0005.toml
+++ b/crates/rust-crypto/RUSTSEC-2016-0005.toml
@@ -46,12 +46,12 @@ which algorithms you need:
   - Signature algorithms: Ed25519
   - Short-input PRF: SipHash24
 - [`orion`]:
-  - AEAD algorithms: ChaCha20Poly1305 (IETF version), XChaCha20Poly1305 (IETF version)
+  - AEAD algorithms: ChaCha20Poly1305 (IETF version), XChaCha20Poly1305
   - Digest algorithms: SHA-512, BLAKE2b
   - Key derivation: HKDF
   - MACs: HMAC, Poly1305
   - Password hashing: PBKDF2
-  - Stream ciphers: ChaCha20 (IETF version), XChaCha20 (IETF version)
+  - Stream ciphers: ChaCha20 (IETF version), XChaCha20
 
 [dalek-cryptography GitHub Org]: https://github.com/dalek-cryptography
 [RustCrypto GitHub Org]: https://github.com/RustCrypto

--- a/crates/rust-crypto/RUSTSEC-2016-0005.toml
+++ b/crates/rust-crypto/RUSTSEC-2016-0005.toml
@@ -45,6 +45,13 @@ which algorithms you need:
   - Public key encryption: NaCl "Box" (X25519 + XSalsa20Poly1305)
   - Signature algorithms: Ed25519
   - Short-input PRF: SipHash24
+- [`orion`]:
+  - AEAD algorithms: ChaCha20Poly1305 (IETF version), XChaCha20Poly1305 (IETF version)
+  - Digest algorithms: SHA-512, BLAKE2b
+  - Key derivation: HKDF
+  - MACs: HMAC, Poly1305
+  - Password hashing: PBKDF2
+  - Stream ciphers: ChaCha20 (IETF version), XChaCha20 (IETF version)
 
 [dalek-cryptography GitHub Org]: https://github.com/dalek-cryptography
 [RustCrypto GitHub Org]: https://github.com/RustCrypto
@@ -76,4 +83,5 @@ which algorithms you need:
 [`sodiumoxide`]: https://crates.io/crates/sodiumoxide
 [`x25519-dalek`]: https://crates.io/crates/x25519-dalek
 [`xsalsa20poly1305`]: https://crates.io/crates/xsalsa20poly1305
+[`orion`]: https://crates.io/crates/orion
 """


### PR DESCRIPTION
I'd like to propose that [orion](https://crates.io/crates/orion)(which I'm the author/maintainer of) be added to the list of alternative, maintained crates in the rust-crypto informational advisory.