### PR TITLE
Added RUSTSEC advisory for crust as an archived/unmaintained.

### DIFF
--- a/crates/crust/RUSTSEC-0000-0000.toml
+++ b/crates/crust/RUSTSEC-0000-0000.toml
@@ -1,0 +1,16 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "crust"
+title = "crust repo has been archived; use libp2p instead"
+informational = "unmaintained"
+date = "2019-11-21"
+url = "https://github.com/maidsafe/crust"
+unaffected_versions = ["> 0.32.1"] # last release
+patched_versions = []
+description = """
+** The `crust` crate repo was archived with no warning or explanation.**
+
+Given that it was archived with no warning or successor, there's not an
+official replacement but [`rust-libp2p`](https://github.com/libp2p/rust-libp2p)
+looks like it's got a similar feature set and is actively maintained.
+"""


### PR DESCRIPTION
Hi, I was looking into p2p crates and the crate with the highest number of downloads has been archived on github so, I thought it would be useful for anyone that uses it to know it's unmaintained.

Anyway, I think I followed the steps correctly. Let me know if there's anything I need to change.

Thanks!