### PR TITLE
Add advisory for deprecated/unmaintained quickersort

### DIFF
--- a/crates/quickersort/RUSTSEC-0000-0000.toml
+++ b/crates/quickersort/RUSTSEC-0000-0000.toml
@@ -9,7 +9,7 @@ unaffected_versions = ["> 3.0.1"]
 patched_versions = []
 
 description = """
-The author of the `quickersort` crate has deprecated it and do not recommend using it anymore.
+The author of the `quickersort` crate has deprecated it and does not recommend using it anymore.
 
 Everything in it has been incorporated into [std::sort_unstable](https://doc.rust-lang.org/stable/std/primitive.slice.html#method.sort_unstable) in the standard library as of Rust 1.20
 """

--- a/crates/quickersort/RUSTSEC-0000-0000.toml
+++ b/crates/quickersort/RUSTSEC-0000-0000.toml
@@ -1,0 +1,15 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "quickersort"
+date = "2019-12-19"
+title = "quickersort is deprecated and unmaintained"
+informational = "unmaintained"
+url = "https://github.com/notriddle/quickersort/commit/0bc164366315801f0c6b31f4081b7df9fc894076"
+unaffected_versions = ["> 3.0.1"]
+patched_versions = []
+
+description = """
+The author of the `quickersort` crate has deprecated it and do not recommend using it anymore.
+
+Everything in it has been incorporated into [std::sort_unstable](https://doc.rust-lang.org/stable/std/primitive.slice.html#method.sort_unstable) in the standard library as of Rust 1.20
+"""


### PR DESCRIPTION
The author of the [`quickersort`](https://crates.io/crates/quickersort) crate has deprecated it and do not recommend using it anymore.

Everything in it has been incorporated into std::sort_unstable in the standard library as of Rust 1.20.