### PR TITLE
string-interner-0.6.4 also fixes RUSTSEC-2019-0023

### DIFF
--- a/crates/string-interner/RUSTSEC-2019-0023.toml
+++ b/crates/string-interner/RUSTSEC-2019-0023.toml
@@ -14,7 +14,10 @@ An attacker can do brute force attack to get the data pointed by the dangling po
 
 The flaw was corrected by <https://github.com/Robbepop/string-interner/pull/10>.
 This patch implements `Clone` manually to the interner type, so that the internal raw pointers always point the strings owned by the same interner.
+
+PR #10 was also backported to the 0.6 release line in
+<https://github.com/Robbepop/string-interner/pull/14> and was released in 0.6.4.
 """
-patched_versions = [">= 0.7.1"]
+patched_versions = ["^0.6.4", ">= 0.7.1"]
 url = "https://github.com/Robbepop/string-interner/issues/9"
 keywords = ["use after free"]


### PR DESCRIPTION
The fix https://github.com/Robbepop/string-interner/pull/10 released in 0.7.1 was also backported to the 0.6 release line in https://github.com/Robbepop/string-interner/pull/14 and released in 0.6.4.