### PR TITLE
RUSTSEC-2019-0031: add `conquer-once` as an alternative to `spin`

### DIFF
--- a/crates/spin/RUSTSEC-2019-0031.toml
+++ b/crates/spin/RUSTSEC-2019-0031.toml
@@ -10,6 +10,8 @@ patched_versions = []
 description = """
 The author of the `spin` crate does not have time or interest to maintain it.
 
-Consider [`lock_api`](https://crates.io/crates/lock_api) (a subproject of
-`parking_lot`) as an alternative which also supports `no_std` environments.
+Consider the following alternatives (both of which support `no_std`):
+
+- [`conquer-once`](https://github.com/oliver-giersch/conquer-once)
+- [`lock_api`](https://crates.io/crates/lock_api) (a subproject of `parking_lot`)
 """


### PR DESCRIPTION
https://github.com/oliver-giersch/conquer-once