### PR TITLE
Add advisory for hyperium/http/issues/354,355

### DIFF
--- a/crates/http/RUSTSEC-0000-0000.toml
+++ b/crates/http/RUSTSEC-0000-0000.toml
@@ -1,0 +1,78 @@
+# Before you submit a PR using this template, **please delete the comments**
+# explaining each field, as well as any unused fields.
+
+[advisory]
+# Identifier for the advisory (mandatory). Will be assigned a "RUSTSEC-YYYY-NNNN"
+# identifier e.g. RUSTSEC-2018-0001. Please use "RUSTSEC-0000-0000" in PRs.
+id = "RUSTSEC-0000-0000"
+
+# Name of the affected crate (mandatory)
+package = "http"
+
+# Disclosure date of the advisory as an RFC 3339 date (mandatory)
+date = "2019-11-16"
+
+# Single-line description of a vulnerability (mandatory)
+title = "HeaderMap::Drain API is unsound"
+
+# Enter a short-form description of the vulnerability here (mandatory)
+description = """
+Affected versions of this crate incorrectly used raw pointer,
+which introduced unsoundness in its public safe API.
+
+[Failing to drop the Drain struct causes double-free](https://github.com/hyperium/http/issues/354),
+and [it is possible to violate Rust's alias rule and cause data race with Drain's Iterator implementation](https://github.com/hyperium/http/issues/355).
+
+The flaw was corrected in 0.2.0 release of `http` crate.
+"""
+
+# Versions which include fixes for this vulnerability (mandatory)
+patched_versions = [">= 0.2.0"]
+
+# Versions which were never vulnerable (optional)
+#unaffected_versions = ["< 1.1.0"]
+
+# URL to a long-form description of this issue, e.g. a GitHub issue/PR,
+# a change log entry, or a blogpost announcing the release (optional)
+# Is it possible to put multiple URLs here?
+# url = "https://github.com/hyperium/http/issues/354"
+# url = "https://github.com/hyperium/http/issues/355"
+
+# Optional: Categories this advisory falls under. Valid categories are:
+# "code-execution", "crypto-failure", "denial-of-service", "file-disclosure"
+# "format-injection", "memory-corruption", "memory-exposure", "privilege-escalation"
+categories = ["memory-corruption"]
+
+# Freeform keywords which describe this vulnerability, similar to Cargo (optional)
+keywords = ["memory-safety", "double-free", "unsound"]
+
+# Vulnerability aliases, e.g. CVE IDs (optional but recommended)
+# Request a CVE for your RustSec vulns: https://iwantacve.org/
+#aliases = ["CVE-2018-XXXX"]
+
+# References to related vulnerabilities (optional)
+# e.g. CVE for a C library wrapped by a -sys crate)
+#references = ["CVE-2018-YYYY", "CVE-2018-ZZZZ"]
+
+# Optional: metadata which narrows the scope of what this advisory affects
+[affected]
+# CPU architectures impacted by this vulnerability (optional).
+# Only use this if the vulnerability is specific to a particular CPU architecture,
+# e.g. the vulnerability is in x86 assembly.
+# For a list of CPU architecture strings, see the "platforms" crate:
+# <https://docs.rs/platforms/latest/platforms/target/enum.Arch.html>
+#arch = ["x86", "x86_64"]
+
+# Operating systems impacted by this vulnerability (optional)
+# Only use this if the vulnerable is specific to a particular OS, e.g. it was
+# located in a binding to a Windows-specific API.
+# For a list of OS strings, see the "platforms" crate:
+# <https://docs.rs/platforms/latest/platforms/target/enum.OS.html>
+#os = ["windows"]
+
+# Table of canonical paths to vulnerable functions (optional)
+# mapping to which versions impacted by this advisory used that particular
+# name (e.g. if the function was renamed between versions). 
+# The path syntax is `cratename::path::to::function`, without any
+# parameters or additional information, followed by a list of version reqs.
+functions = { "http::header::HeaderMap::drain" = ["< 0.2.0"] }


### PR DESCRIPTION
Affected versions of this crate incorrectly used raw pointer, which introduced unsoundness in its public safe API.

[Failing to drop the Drain struct causes double-free](https://github.com/hyperium/http/issues/354), and [it is possible to violate Rust's alias rule and cause data race with Drain's Iterator implementation](https://github.com/hyperium/http/issues/355).

The flaw was corrected in 0.2.0 release of `http` crate.