### PR TITLE
Correct affected version range on RUSTSEC-2019-003[34] to patched at 0.1.20

### DIFF
--- a/crates/http/RUSTSEC-2019-0033.toml
+++ b/crates/http/RUSTSEC-2019-0033.toml
@@ -13,12 +13,12 @@ the library will invoke `self.grow(0)` and start infinite probing.
 This allows an attacker who controls the argument to `reserve()`
 to cause a potential denial of service (DoS).
 
-The flaw was corrected in 0.2.0 release of `http` crate.
+The flaw was corrected in 0.1.20 release of `http` crate.
 """
-patched_versions = [">= 0.2.0"]
+patched_versions = [">= 0.1.20"]
 url = "https://github.com/hyperium/http/issues/352"
 categories = ["denial-of-service"]
 keywords = ["http", "integer-overflow", "DoS"]
 
 [affected.functions]
-"http::header::HeaderMap::reserve" = ["< 0.2.0"]
+"http::header::HeaderMap::reserve" = ["< 0.1.20"]

--- a/crates/http/RUSTSEC-2019-0034.toml
+++ b/crates/http/RUSTSEC-2019-0034.toml
@@ -10,11 +10,11 @@ which introduced unsoundness in its public safe API.
 [Failing to drop the Drain struct causes double-free](https://github.com/hyperium/http/issues/354),
 and [it is possible to violate Rust's alias rule and cause data race with Drain's Iterator implementation](https://github.com/hyperium/http/issues/355).
 
-The flaw was corrected in 0.2.0 release of `http` crate.
+The flaw was corrected in 0.1.20 release of `http` crate.
 """
-patched_versions = [">= 0.2.0"]
+patched_versions = [">= 0.1.20"]
 categories = ["memory-corruption"]
 keywords = ["memory-safety", "double-free", "unsound"]
 
 [affected.functions]
-"http::header::HeaderMap::drain" = ["< 0.2.0"]
+"http::header::HeaderMap::drain" = ["< 0.1.20"]


### PR DESCRIPTION
I believe these two vulnerabilities were patched at 0.1.20.

For RUSTSEC-2019-0033:

The advisory links to the bug: https://github.com/hyperium/http/issues/352
In that bug, the fixing PR was https://github.com/hyperium/http/pull/360
That PR merged the commit 81ceb61 to fix the bug; that commit, according to
GitHub, was first picked up by tag v0.1.20 ([commit][1]).

[1]: https://github.com/hyperium/http/commit/81ceb611cf96abe91d91693e813cd5ee36cdae02

For RUSTSEC-2019-0034:

This advisory is two separate GitHub issues against `HeaderMap::drain`,
http #354 and http #355.

For the first: the issue: https://github.com/hyperium/http/issues/354
In that bug, the fixing PR was https://github.com/hyperium/http/pull/357
That PR merged the commit 82d53db to fix the bug; that commit, according to
GitHub, was first picked up by tag v0.1.20 ([commit][2]).

[2]: https://github.com/hyperium/http/commit/82d53dbdfdb1ffbeb0323200a0bbd30b5f895fa7

For the second: the issue: https://github.com/hyperium/http/issues/355
In that bug, the fixing PR was https://github.com/hyperium/http/pull/362
That PR merged the commit 8ffe094 to fix the bug; that commit, according to
GitHub, was first picked up by tag v0.1.20 ([commit][3]).

[3]: https://github.com/hyperium/http/commit/8ffe094df1431321d450860cc56a22dd53175f5e