### PR TITLE
RUSTSEC-2016-0005: add note about rust-crypto vs RustCrypto

### DIFF
--- a/crates/rust-crypto/RUSTSEC-2016-0005.toml
+++ b/crates/rust-crypto/RUSTSEC-2016-0005.toml
@@ -11,6 +11,10 @@ description = """
 The `rust-crypto` crate has not seen a release or GitHub commit since 2016,
 and its author is unresponsive.
 
+*NOTE: The (old) `rust-crypto` crate (with hyphen) should not be confused with
+similarly named (new) [RustCrypto GitHub Org] (without hyphen). The GitHub Org
+is actively maintained.*
+
 We recommend you switch to one of the following crates instead, depending on
 which algorithms you need:
 


### PR DESCRIPTION
The `rust-crypto` crate and RustCrypto org have confusingly similar names, which has caused confusion about this advisory in practice:

https://www.reddit.com/r/rust/comments/e29sxc/ann_rustcryptoaead_v020_heapless_symmetric_aead/f8ujyxm/

This commit adds a small note to disambiguate them and note that RustCrypto-the-GitHub-org is still maintained.