### PR TITLE
Add unmaintained crate informational advisory: rust_sodium

### DIFF
--- a/crates/rust_sodium/RUSTSEC-0000-0000.toml
+++ b/crates/rust_sodium/RUSTSEC-0000-0000.toml
@@ -1,0 +1,23 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+
+package = "rust_sodium"
+
+date = "2020-01-20"
+
+title = "rust_sodium is unmaintained; switch to a modern alternative"
+
+description = """
+The `rust_sodium` crate is no longer maintained by its current owner, who
+advise in the repository readme that they are looking for
+someone else to take ownership of it.
+
+We recommend you switch to an alternative crate such as:
+- [`sodiumoxide`]: https://crates.io/crates/sodiumoxide
+"""
+
+patched_versions = []
+
+unaffected_versions = ["> 0.10.2"]
+
+url = "https://github.com/maidsafe/rust_sodium/pull/117"


### PR DESCRIPTION
rust_sodium is unmaintained, as per [repository readme](https://github.com/maidsafe/rust_sodium#please-note-that-the-rust_sodium-crate-is-no-longer-maintained-switch-to-a-modern-alternative)