### PR TITLE
Add lucet-runtime-internals sigstack allocation vuln advisory

### DIFF
--- a/crates/lucet-runtime-internals/RUSTSEC-0000-0000.toml
+++ b/crates/lucet-runtime-internals/RUSTSEC-0000-0000.toml
@@ -17,7 +17,7 @@ guest programs or cause corruption of guest program memory.
 This flaw was resolved by correcting the sigstack allocation logic.
 """
 
-patched_versions = ["< 0.5.0, >= 0.4.3", “>= 0.5.1”]
+patched_versions = ["< 0.5.0, >= 0.4.3", ">= 0.5.1"]
 
 url = "https://github.com/bytecodealliance/lucet/pull/401”
 

--- a/crates/lucet-runtime-internals/RUSTSEC-0000-0000.toml
+++ b/crates/lucet-runtime-internals/RUSTSEC-0000-0000.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+
+package = "lucet-runtime-internals"
+
+date = "2020-01-24"
+
+title = "sigstack allocation bug can cause memory corruption or leak"
+
+description = """
+An embedding using affected versions of lucet-runtime configured to use
+non-default Wasm globals sizes of more than 4KiB, or compiled in debug mode
+without optimizations, could leak data from the signal handler stack to guest
+programs. This can potentially cause data from the embedding host to leak to
+guest programs or cause corruption of guest program memory.
+
+This flaw was resolved by correcting the sigstack allocation logic.
+"""
+
+patched_versions = ["< 0.5.0, >= 0.4.3", “>= 0.5.1”]
+
+url = "https://github.com/bytecodealliance/lucet/pull/401”
+
+categories = ["memory-corruption", "memory-exposure"]

--- a/crates/lucet-runtime-internals/RUSTSEC-0000-0000.toml
+++ b/crates/lucet-runtime-internals/RUSTSEC-0000-0000.toml
@@ -19,6 +19,6 @@ This flaw was resolved by correcting the sigstack allocation logic.
 
 patched_versions = ["< 0.5.0, >= 0.4.3", ">= 0.5.1"]
 
-url = "https://github.com/bytecodealliance/lucet/pull/401”
+url = "https://github.com/bytecodealliance/lucet/pull/401"
 
 categories = ["memory-corruption", "memory-exposure"]


### PR DESCRIPTION
Hello,

This PR is for a security advisory in https://github.com/bytecodealliance/lucet, /cc @acfoltzer.

I am not sure about the format used in the `patched_versions` value. If that is incorrect could you please advise?

If you need anything else on this just let me know.

Thanks,
Jon