### PR TITLE
Migrate all advisories to V2 format (closes #228)

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,21 +43,6 @@ date = "2019-10-01"
 # Single-line description of a vulnerability (mandatory)
 title = "Flaw in X allows Y"
 
-# Enter a short-form description of the vulnerability here (mandatory)
-description = """
-Affected versions of this crate did not properly X.
-
-This allows an attacker to Y.
- 
-The flaw was corrected by Z.
-"""
-
-# Versions which include fixes for this vulnerability (mandatory)
-patched_versions = [">= 1.2.0"]
-
-# Versions which were never vulnerable (optional)
-#unaffected_versions = ["< 1.1.0"]
-
 # URL to a long-form description of this issue, e.g. a GitHub issue/PR,
 # a change log entry, or a blogpost announcing the release (optional)
 url = "https://github.com/mystuff/mycrate/issues/123"
@@ -77,6 +62,15 @@ keywords = ["ssl", "mitm"]
 # References to related vulnerabilities (optional)
 # e.g. CVE for a C library wrapped by a -sys crate)
 #references = ["CVE-2018-YYYY", "CVE-2018-ZZZZ"]
+
+# Enter a short-form description of the vulnerability here (mandatory)
+description = """
+Affected versions of this crate did not properly X.
+
+This allows an attacker to Y.
+ 
+The flaw was corrected by Z.
+"""
 
 # Optional: metadata which narrows the scope of what this advisory affects
 [affected]
@@ -100,6 +94,13 @@ keywords = ["ssl", "mitm"]
 # The path syntax is `cratename::path::to::function`, without any
 # parameters or additional information, followed by a list of version reqs.
 functions = { "mycrate::MyType::vulnerable_function" = ["< 1.2.0, >= 1.1.0"] }
+
+# Versions which include fixes for this vulnerability (mandatory)
+[versions]
+patched = [">= 1.2.0"]
+
+# Versions which were never vulnerable (optional)
+#unaffected = ["< 1.1.0"]
 ```
 
 ## License

--- a/crates/ammonia/RUSTSEC-2019-0001.toml
+++ b/crates/ammonia/RUSTSEC-2019-0001.toml
@@ -3,6 +3,8 @@ id = "RUSTSEC-2019-0001"
 package = "ammonia"
 date = "2019-04-27"
 title = "Uncontrolled recursion leads to abort in HTML serialization"
+url = "https://github.com/rust-ammonia/ammonia/blob/master/CHANGELOG.md#210"
+keywords = ["stack-overflow", "crash"]
 description = """
 Affected versions of this crate did use recursion for serialization of HTML
 DOM trees.
@@ -12,11 +14,11 @@ a pathologically nested input.
 
 The flaw was corrected by serializing the DOM tree iteratively instead.
 """
-patched_versions = [">= 2.1.0"]
-url = "https://github.com/rust-ammonia/ammonia/blob/master/CHANGELOG.md#210"
-keywords = ["stack-overflow", "crash"]
 
 [affected.functions]
 "ammonia::clean" = ["< 2.1.0"]
 "ammonia::Document::to_string" = ["< 2.1.0"]
 "ammonia::Document::write_to" = ["< 2.1.0"]
+
+[versions]
+patched = [">= 2.1.0"]

--- a/crates/arrayfire/RUSTSEC-2018-0011.toml
+++ b/crates/arrayfire/RUSTSEC-2018-0011.toml
@@ -3,6 +3,9 @@ id = "RUSTSEC-2018-0011"
 package = "arrayfire"
 date = "2018-12-18"
 title = "Enum repr causing potential memory corruption"
+url = "https://github.com/arrayfire/arrayfire-rust/pull/177"
+categories = ["memory-corruption"]
+keywords = ["enum", "repr"]
 description = """
 The attribute repr() added to enums to be compatible with C-FFI caused
 memory corruption on MSVC toolchain.
@@ -15,11 +18,10 @@ The issue seems to be interlinked with which version of Rust is being used.
 
 The issue was fixed in crate 3.6.0.
 """
-patched_versions = [">= 3.6.0"]
-unaffected_versions = ["<= 3.5.0"]
-url = "https://github.com/arrayfire/arrayfire-rust/pull/177"
-categories = ["memory-corruption"]
-keywords = ["enum", "repr"]
+
+[versions]
+patched = [">= 3.6.0"]
+unaffected = ["<= 3.5.0"]
 
 [affected]
 arch = ["x86_64"]

--- a/crates/asn1_der/RUSTSEC-2019-0007.toml
+++ b/crates/asn1_der/RUSTSEC-2019-0007.toml
@@ -1,12 +1,10 @@
 [advisory]
 id = "RUSTSEC-2019-0007"
-
 package = "asn1_der"
-
 date = "2019-06-13"
-
 title = "Processing of maliciously crafted length fields causes memory allocation SIGABRTs"
-
+url = "https://github.com/KizzyCode/asn1_der/issues/1"
+keywords = ["dos"]
 description = """
 Affected versions of this crate tried to preallocate a vector for an arbitrary amount of bytes announced by the ASN.1-DER length field without further checks.
 
@@ -15,8 +13,5 @@ This allows an attacker to trigger a SIGABRT by creating length fields that anno
 The flaw was corrected by not preallocating memory.
 """
 
-patched_versions = [">= 0.6.2"]
-
-url = "https://github.com/KizzyCode/asn1_der/issues/1"
-
-keywords = ["dos"]
+[versions]
+patched = [">= 0.6.2"]

--- a/crates/base64/RUSTSEC-2017-0004.toml
+++ b/crates/base64/RUSTSEC-2017-0004.toml
@@ -4,7 +4,6 @@ package = "base64"
 date = "2017-05-03"
 url = "https://github.com/alicemaz/rust-base64/commit/24ead980daf11ba563e4fb2516187a56a71ad319"
 title = "Integer overflow leads to heap-based buffer overflow in encode_config_buf"
-patched_versions = [">= 0.5.2"]
 keywords = ["memory-corruption"]
 aliases = ["CVE-2017-1000430"]
 description = """
@@ -19,3 +18,6 @@ and possibly the execution of arbitrary code.
 This flaw was corrected by using checked arithmetic to calculate
 the size of the buffer.
 """
+
+[versions]
+patched = [">= 0.5.2"]

--- a/crates/blake2/RUSTSEC-2019-0019.toml
+++ b/crates/blake2/RUSTSEC-2019-0019.toml
@@ -3,6 +3,8 @@ id = "RUSTSEC-2019-0019"
 package = "blake2"
 date = "2019-08-25"
 title = "HMAC-BLAKE2 algorithms compute incorrect results"
+url = "https://github.com/RustCrypto/MACs/issues/19"
+categories = ["crypto-failure"]
 description = """
 When used in conjunction with the Hash-based Message Authentication Code (HMAC),
 the BLAKE2b and BLAKE2s implementations in `blake2` crate versions prior to
@@ -15,6 +17,6 @@ The v0.8.1 release of the `blake2` crate uses the correct block sizes.
 Note that this advisory only impacts usage of BLAKE2 with HMAC, and does not
 impact `Digest` functionality.
 """
-patched_versions = [">= 0.8.1"]
-url = "https://github.com/RustCrypto/MACs/issues/19"
-categories = ["crypto-failure"]
+
+[versions]
+patched = [">= 0.8.1"]

--- a/crates/cassandra/RUSTSEC-2016-0006.toml
+++ b/crates/cassandra/RUSTSEC-2016-0006.toml
@@ -5,8 +5,6 @@ title = "`cassandra` crate is unmaintained; use `cassandra-cpp` instead"
 informational = "unmaintained"
 date = "2016-12-15"
 url = "https://github.com/tupshin/cassandra-rs/issues/52"
-unaffected_versions = ["> 0.8.1"] # last release
-patched_versions = []
 description = """
 The `cassandra` crate has not seen a release since December 2016, and its author
 is unresponsive.
@@ -15,3 +13,7 @@ The `cassandra-cpp` crate is a maintained fork:
 
 https://github.com/Metaswitch/cassandra-rs
 """
+
+[versions]
+patched = []
+unaffected = ["> 0.8.1"] # last release

--- a/crates/chacha20/RUSTSEC-2019-0029.toml
+++ b/crates/chacha20/RUSTSEC-2019-0029.toml
@@ -3,6 +3,8 @@ id = "RUSTSEC-2019-0029"
 package = "chacha20"
 date = "2019-10-22"
 title = "ChaCha20 counter overflow can expose repetitions in the keystream"
+url = "https://github.com/RustCrypto/stream-ciphers/pull/64"
+categories = ["crypto-failure"]
 description = """
 The ChaCha20 stream cipher can produce a maximum of 2^32 blocks (~256GB)
 before the 32-bit counter overflows. Releases of the `chacha20` crate prior
@@ -18,6 +20,6 @@ Users of the `chacha20poly1305` crate are unaffected by this as this crate
 properly asserts the length of the plaintext is less than the maximum allowed
 (`P_MAX` as described in RFC 8439 Section 2.8).
 """
-patched_versions = [">= 0.2.3"]
-url = "https://github.com/RustCrypto/stream-ciphers/pull/64"
-categories = ["crypto-failure"]
+
+[versions]
+patched = [">= 0.2.3"]

--- a/crates/chan/RUSTSEC-2018-0014.toml
+++ b/crates/chan/RUSTSEC-2018-0014.toml
@@ -5,8 +5,6 @@ title = "chan is end-of-life; use crossbeam-channel instead"
 informational = "unmaintained"
 date = "2018-07-31"
 url = "https://github.com/BurntSushi/chan/commit/0a5c0d4ad4adc90a54ee04a427389acf2e157275"
-unaffected_versions = ["> 0.1.23"] # last release
-patched_versions = []
 description = """
 **`chan` has reached its end-of-life and is now deprecated.**
 
@@ -16,3 +14,7 @@ Its API is strikingly similar, but comes with a much better `select!` macro,
 better performance, a better test suite and an all-around better
 implementation.
 """
+
+[versions]
+unaffected = ["> 0.1.23"] # last release
+patched = []

--- a/crates/chttp/RUSTSEC-2019-0016.toml
+++ b/crates/chttp/RUSTSEC-2019-0016.toml
@@ -10,7 +10,9 @@ or be exploited to cause undefined behavior.
  
 A fix was published in version 0.1.3.
 """
-patched_versions = [">= 0.1.3"]
-unaffected_versions = ["< 0.1.1"]
 url = "https://github.com/sagebind/isahc/issues/2"
 keywords = ["memory-management", "memory-corruption"]
+
+[versions]
+patched = [">= 0.1.3"]
+unaffected = ["< 0.1.1"]

--- a/crates/claxon/RUSTSEC-2018-0004.toml
+++ b/crates/claxon/RUSTSEC-2018-0004.toml
@@ -3,6 +3,8 @@ id = "RUSTSEC-2018-0004"
 package = "claxon"
 date = "2018-08-25"
 title = "Malicious input could cause uninitialized memory to be exposed"
+url = "https://github.com/ruuda/claxon/commit/8f28ec275e412dd3af4f3cda460605512faf332c"
+keywords = ["uninitialized-memory"]
 description = """
 Affected versions of Claxon made an invalid assumption about the decode buffer
 size being a multiple of a value read from the bitstream. This could cause parts
@@ -17,6 +19,6 @@ the decode buffer size, and returning a format error if it does not. If an error
 is returned, the decode buffer is not exposed. Regression tests and an
 additional fuzzer have been added to prevent similar flaws in the future.
 """
-patched_versions = ["=0.3.2", ">= 0.4.1"]
-url = "https://github.com/ruuda/claxon/commit/8f28ec275e412dd3af4f3cda460605512faf332c"
-keywords = ["uninitialized-memory"]
+
+[versions]
+patched = ["=0.3.2", ">= 0.4.1"]

--- a/crates/compact_arena/RUSTSEC-2019-0015.toml
+++ b/crates/compact_arena/RUSTSEC-2019-0015.toml
@@ -3,6 +3,9 @@ id = "RUSTSEC-2019-0015"
 package = "compact_arena"
 date = "2019-05-21"
 title = "Flaw in generativity allows out-of-bounds access"
+url = "https://github.com/llogiq/compact_arena/issues/22"
+categories = ["memory-corruption"]
+keywords = ["uninitialized-memory"]
 description = """
 Affected versions of this crate did not properly implement the generativity,
 because the invariant lifetimes were not necessarily `drop`ped.
@@ -13,10 +16,9 @@ access into the memory reserved for the arena.
 
 The flaw was corrected by implementing generativity correctly in version 0.4.0.
 """
-patched_versions = [">= 0.4.0"]
-url = "https://github.com/llogiq/compact_arena/issues/22"
-categories = ["memory-corruption"]
-keywords = ["uninitialized-memory"]
 
 [affected.functions]
 "compact_arena::SmallArena::new" = ["< 0.4.0"]
+
+[versions]
+patched = [">= 0.4.0"]

--- a/crates/cookie/RUSTSEC-2017-0005.toml
+++ b/crates/cookie/RUSTSEC-2017-0005.toml
@@ -1,7 +1,6 @@
 [advisory]
 id = "RUSTSEC-2017-0005"
 package = "cookie"
-patched_versions = ["< 0.6.0", "^0.6.2", ">= 0.7.6"]
 keywords = ["crash"]
 url = "https://github.com/alexcrichton/cookie-rs/pull/86"
 title = "Large cookie Max-Age values can cause a denial of service"
@@ -15,3 +14,6 @@ will panic if the value is greater than 2^64/1000 and less than or equal to
 This flaw was corrected by explicitly checking for the `Max-Age` being in this
 integer range and clamping the value to the maximum duration value.
 """
+
+[versions]
+patched = ["< 0.6.0", "^0.6.2", ">= 0.7.6"]

--- a/crates/crossbeam/RUSTSEC-2018-0009.toml
+++ b/crates/crossbeam/RUSTSEC-2018-0009.toml
@@ -3,6 +3,8 @@ id = "RUSTSEC-2018-0009"
 package = "crossbeam"
 date = "2018-12-09"
 title = "MsQueue and SegQueue suffer from double-free"
+url = "https://github.com/crossbeam-rs/crossbeam-epoch/issues/82"
+keywords = ["concurrency", "memory-management", "memory-corruption"]
 description = """
 Even if an element is popped from a queue, crossbeam would run its
 destructor inside the epoch-based garbage collector. This is a source
@@ -13,7 +15,7 @@ The flaw was corrected by wrapping elements inside queues in a
 
 Thanks to @c0gent for reporting the issue.
 """
-patched_versions = [">= 0.4.1"]
-unaffected_versions = ["< 0.4.0"]
-url = "https://github.com/crossbeam-rs/crossbeam-epoch/issues/82"
-keywords = ["concurrency", "memory-management", "memory-corruption"]
+
+[versions]
+patched = [">= 0.4.1"]
+unaffected = ["< 0.4.0"]

--- a/crates/crust/RUSTSEC-2019-0032.toml
+++ b/crates/crust/RUSTSEC-2019-0032.toml
@@ -5,8 +5,6 @@ title = "crust repo has been archived; use libp2p instead"
 informational = "unmaintained"
 date = "2019-11-21"
 url = "https://github.com/maidsafe/crust"
-unaffected_versions = ["> 0.32.1"] # last release
-patched_versions = []
 description = """
 ** The `crust` crate repo was archived with no warning or explanation.**
 
@@ -14,3 +12,7 @@ Given that it was archived with no warning or successor, there's not an
 official replacement but [`rust-libp2p`](https://github.com/libp2p/rust-libp2p)
 looks like it's got a similar feature set and is actively maintained.
 """
+
+[versions]
+unaffected = ["> 0.32.1"] # last release
+patched = []

--- a/crates/flatbuffers/RUSTSEC-2019-0028.toml
+++ b/crates/flatbuffers/RUSTSEC-2019-0028.toml
@@ -1,8 +1,6 @@
 [advisory]
 id = "RUSTSEC-2019-0028"
 package = "flatbuffers"
-patched_versions = []
-unaffected_versions = ["< 0.4.0"]
 date = "2019-10-20"
 url = "https://github.com/google/flatbuffers/issues/5530"
 title = "Unsound `impl Follow for bool`"
@@ -13,5 +11,9 @@ In Rust `bool` has stringent requirements for its in-memory representation. Use 
 allows to violate these requirements and invoke undefined behaviour in safe code.
 """
 
-[affected]
-functions = { "flatbuffers::Follow::follow" = [">= 0.4.0", "<= 0.6.0"] }
+[affected.functions]
+"flatbuffers::Follow::follow" = [">= 0.4.0", "<= 0.6.0"]
+
+[versions]
+patched = []
+unaffected = ["< 0.4.0"]

--- a/crates/generator/RUSTSEC-2019-0020.toml
+++ b/crates/generator/RUSTSEC-2019-0020.toml
@@ -3,6 +3,8 @@ id = "RUSTSEC-2019-0020"
 package = "generator"
 date = "2019-09-06"
 title = "fix unsound APIs that could lead to UB"
+url = "https://github.com/Xudong-Huang/generator-rs/issues/9"
+keywords = ["memory-corruption"]
 description = """
 Affected versions of this crate API could use uninitialized memory with some APIs in special
 cases, like use the API in none generator context. This could lead to UB.
@@ -12,6 +14,6 @@ The flaw was corrected by <https://github.com/Xudong-Huang/generator-rs/issues/9
                           <https://github.com/Xudong-Huang/generator-rs/issues/14>                                                  
 This patch fixes all those issues above.
 """
-patched_versions = [">= 0.6.18"]
-url = "https://github.com/Xudong-Huang/generator-rs/issues/9"
-keywords = ["memory-corruption"]
+
+[versions]
+patched = [">= 0.6.18"]

--- a/crates/http/RUSTSEC-2019-0033.toml
+++ b/crates/http/RUSTSEC-2019-0033.toml
@@ -3,6 +3,9 @@ id = "RUSTSEC-2019-0033"
 package = "http"
 date = "2019-11-16"
 title = "Integer Overflow in HeaderMap::reserve() can cause Denial of Service"
+url = "https://github.com/hyperium/http/issues/352"
+categories = ["denial-of-service"]
+keywords = ["http", "integer-overflow", "DoS"]
 description = """
 `HeaderMap::reserve()` used `usize::next_power_of_two()` to calculate the increased capacity.
 However, `next_power_of_two()` silently overflows to 0 if given a sufficently large number
@@ -15,10 +18,9 @@ to cause a potential denial of service (DoS).
 
 The flaw was corrected in 0.1.20 release of `http` crate.
 """
-patched_versions = [">= 0.1.20"]
-url = "https://github.com/hyperium/http/issues/352"
-categories = ["denial-of-service"]
-keywords = ["http", "integer-overflow", "DoS"]
 
 [affected.functions]
 "http::header::HeaderMap::reserve" = ["< 0.1.20"]
+
+[versions]
+patched = [">= 0.1.20"]

--- a/crates/http/RUSTSEC-2019-0034.toml
+++ b/crates/http/RUSTSEC-2019-0034.toml
@@ -3,6 +3,8 @@ id = "RUSTSEC-2019-0034"
 package = "http"
 date = "2019-11-16"
 title = "HeaderMap::Drain API is unsound"
+categories = ["memory-corruption"]
+keywords = ["memory-safety", "double-free", "unsound"]
 description = """
 Affected versions of this crate incorrectly used raw pointer,
 which introduced unsoundness in its public safe API.
@@ -12,9 +14,9 @@ and [it is possible to violate Rust's alias rule and cause data race with Drain'
 
 The flaw was corrected in 0.1.20 release of `http` crate.
 """
-patched_versions = [">= 0.1.20"]
-categories = ["memory-corruption"]
-keywords = ["memory-safety", "double-free", "unsound"]
 
 [affected.functions]
 "http::header::HeaderMap::drain" = ["< 0.1.20"]
+
+[versions]
+patched = [">= 0.1.20"]

--- a/crates/hyper/RUSTSEC-2016-0002.toml
+++ b/crates/hyper/RUSTSEC-2016-0002.toml
@@ -6,7 +6,6 @@ url = "https://github.com/hyperium/hyper/blob/master/CHANGELOG.md#v094-2016-05-0
 title = "HTTPS MitM vulnerability due to lack of hostname verification"
 categories = ["crypto-failure"]
 keywords = ["ssl", "mitm"]
-patched_versions = [">= 0.9.4"]
 references = ["RUSTSEC-2016-0001"]
 description = """
 When used on Windows platforms, all versions of Hyper prior to 0.9.4 did not
@@ -21,3 +20,6 @@ hostname verification.
 
 [affected]
 os = ["windows"]
+
+[versions]
+patched = [">= 0.9.4"]

--- a/crates/hyper/RUSTSEC-2017-0002.toml
+++ b/crates/hyper/RUSTSEC-2017-0002.toml
@@ -1,7 +1,6 @@
 [advisory]
 id = "RUSTSEC-2017-0002"
 package = "hyper"
-patched_versions = [">= 0.10.2", "< 0.10.0, >= 0.9.18"]
 date = "2017-01-23"
 url = "https://github.com/hyperium/hyper/wiki/Security-001"
 title = "headers containing newline characters can split messages"
@@ -14,3 +13,6 @@ is if an application constructs headers based on unsanitized user input.
 This issue was fixed by replacing all newline characters with a space during serialization of
 a header value.
 """
+
+[versions]
+patched = [">= 0.10.2", "< 0.10.0, >= 0.9.18"]

--- a/crates/image/RUSTSEC-2019-0014.toml
+++ b/crates/image/RUSTSEC-2019-0014.toml
@@ -3,6 +3,8 @@ id = "RUSTSEC-2019-0014"
 package = "image"
 date = "2019-08-21"
 title = "Flaw in interface may drop uninitialized instance of arbitrary types"
+url = "https://github.com/image-rs/image/pull/985"
+keywords = ["drop", "use-after-free"]
 description = """
 Affected versions of this crate would call `Vec::set_len` on an uninitialized
 vector with user-provided type parameter, in an interface of the HDR image
@@ -20,10 +22,10 @@ Starting from version `0.22`, a breaking change to the interface requires
 callers to pre-allocate the output buffer and pass a mutable slice instead,
 avoiding all unsafe code.
 """
-patched_versions = [">= 0.21.3"]
-unaffected_versions = ["< 0.10.2"]
-url = "https://github.com/image-rs/image/pull/985"
-keywords = ["drop", "use-after-free"]
 
 [affected.functions]
 "image::hdr::HDRDecoder::read_image_transform" = ["< 0.21.3, >= 0.10.2"]
+
+[versions]
+patched = [">= 0.21.3"]
+unaffected = ["< 0.10.2"]

--- a/crates/libflate/RUSTSEC-2019-0010.toml
+++ b/crates/libflate/RUSTSEC-2019-0010.toml
@@ -3,6 +3,8 @@ id = "RUSTSEC-2019-0010"
 package = "libflate"
 date = "2019-07-04"
 title = "MultiDecoder::read() drops uninitialized memory of arbitrary type on panic in client code"
+url = "https://github.com/sile/libflate/issues/35"
+keywords = ["drop", "use-after-free"]
 description = """
 Affected versions of libflate have set a field of an internal structure with a generic type to an uninitialized value in `MultiDecoder::read()` and reverted it to the original value after the function completed. However, execution of `MultiDecoder::read()` could be interrupted by a panic in caller-supplied `Read` implementation. This would cause `drop()` to be called on uninitialized memory of a generic type implementing `Read`.
 
@@ -10,10 +12,10 @@ This is equivalent to a use-after-free vulnerability and could allow an attacker
 
 The flaw was corrected by aborting immediately instead of unwinding the stack in case of panic within `MultiDecoder::read()`. The issue was discovered and fixed by Shnatsel.
 """
-patched_versions = [">= 0.1.25"]
-unaffected_versions = ["< 0.1.14"]
-url = "https://github.com/sile/libflate/issues/35"
-keywords = ["drop", "use-after-free"]
 
 [affected.functions]
 "libflate::gzip::MultiDecoder::read" = ["< 0.1.25, >= 0.1.14"]
+
+[versions]
+patched = [">= 0.1.25"]
+unaffected = ["< 0.1.14"]

--- a/crates/libp2p-core/RUSTSEC-2019-0004.toml
+++ b/crates/libp2p-core/RUSTSEC-2019-0004.toml
@@ -9,5 +9,7 @@ Any signature with a correct length was considered valid.
 
 This allows an attacker to impersonate any node identity.
 """
-patched_versions = ["^0.7.1", ">= 0.8.1"]
-unaffected_versions = ["< 0.3"]
+
+[versions]
+patched = ["^0.7.1", ">= 0.8.1"]
+unaffected = ["< 0.3"]

--- a/crates/libsecp256k1/RUSTSEC-2019-0027.toml
+++ b/crates/libsecp256k1/RUSTSEC-2019-0027.toml
@@ -3,6 +3,8 @@ id = "RUSTSEC-2019-0027"
 package = "libsecp256k1"
 date = "2019-10-14"
 title = "Flaw in Scalar::check_overflow allows side-channel timing attack"
+categories = ["crypto-failure"]
+keywords = ["crypto", "sidechannel"]
 description = """
 Versions of `libsecp256k1` prior to `0.3.1` did not execute
 Scalar::check_overflow in constant time.
@@ -12,9 +14,9 @@ This allows an attacker to potentially leak information via a timing attack.
 The flaw was corrected by modifying Scalar::check_overflow to execute in
 constant time.
 """
-patched_versions = [">= 0.3.1"]
-categories = ["crypto-failure"]
-keywords = ["crypto", "sidechannel"]
 
 [affected.functions]
 "libsecp256k1::Scalar::check_overflow" = ["< 0.3.1"]
+
+[versions]
+patched = [">= 0.3.1"]

--- a/crates/libusb/RUSTSEC-2016-0004.toml
+++ b/crates/libusb/RUSTSEC-2016-0004.toml
@@ -4,8 +4,6 @@ package = "libusb"
 title = "libusb is unmaintained; use rusb instead"
 informational = "unmaintained"
 date = "2016-09-10"
-unaffected_versions = ["> 0.3.0"] # last release
-patched_versions = []
 url = "https://github.com/dcuddeback/libusb-rs/issues/33"
 description = """
 The `libusb` crate has not seen a release since September 2016, and its author
@@ -15,3 +13,7 @@ The `rusb` crate is a maintained fork:
 
 https://github.com/a1ien/rusb
 """
+
+[versions]
+patched = []
+unaffected = ["> 0.3.0"] # last release

--- a/crates/linea/RUSTSEC-2019-0021.toml
+++ b/crates/linea/RUSTSEC-2019-0021.toml
@@ -3,6 +3,9 @@ id = "RUSTSEC-2019-0021"
 package = "linea"
 date = "2019-09-14"
 title = "`Matrix::zip_elements` causes double free"
+url = "https://github.com/strake/linea.rs/issues/2"
+categories = ["memory-corruption"]
+keywords = ["double free"]
 description = """
 Affected versions of this crate did not properly implements the `Matrix::zip_elements` method, which causes an double free when the given trait implementation might panic.
 
@@ -10,7 +13,6 @@ This allows an attacker to corrupt or take control of the memory.
  
 The flaw was corrected by Phosphorus15.
 """
-patched_versions = ["> 0.9.4"]
-url = "https://github.com/strake/linea.rs/issues/2"
-categories = ["memory-corruption"]
-keywords = ["double free"]
+
+[versions]
+patched = ["> 0.9.4"]

--- a/crates/lucet-runtime-internals/RUSTSEC-2020-0004.toml
+++ b/crates/lucet-runtime-internals/RUSTSEC-2020-0004.toml
@@ -3,6 +3,8 @@ id = "RUSTSEC-2020-0004"
 package = "lucet-runtime-internals"
 date = "2020-01-24"
 title = "sigstack allocation bug can cause memory corruption or leak"
+url = "https://github.com/bytecodealliance/lucet/pull/401"
+categories = ["memory-corruption", "memory-exposure"]
 description = """
 An embedding using affected versions of lucet-runtime configured to use
 non-default Wasm globals sizes of more than 4KiB, or compiled in debug mode
@@ -12,6 +14,6 @@ guest programs or cause corruption of guest program memory.
 
 This flaw was resolved by correcting the sigstack allocation logic.
 """
-patched_versions = ["< 0.5.0, >= 0.4.3", ">= 0.5.1"]
-url = "https://github.com/bytecodealliance/lucet/pull/401"
-categories = ["memory-corruption", "memory-exposure"]
+
+[versions]
+patched = ["< 0.5.0, >= 0.4.3", ">= 0.5.1"]

--- a/crates/memoffset/RUSTSEC-2019-0011.toml
+++ b/crates/memoffset/RUSTSEC-2019-0011.toml
@@ -3,6 +3,7 @@ id = "RUSTSEC-2019-0011"
 package = "memoffset"
 date = "2019-07-16"
 title = "Flaw in offset_of and span_of causes SIGILL, drops uninitialized memory of arbitrary type on panic in client code"
+url = "https://github.com/Gilnaa/memoffset/issues/9#issuecomment-505461490"
 description = """
 Affected versions of this crate caused traps and/or memory unsafety by zero-initializing references.
 They also could lead to uninitialized memory being dropped if the field for which the offset is requested was behind a deref coercion, and that deref coercion caused a panic.
@@ -10,5 +11,5 @@ They also could lead to uninitialized memory being dropped if the field for whic
 The flaw was corrected by using `MaybeUninit`.
 """
 
-patched_versions = [">= 0.5.0"]
-url = "https://github.com/Gilnaa/memoffset/issues/9#issuecomment-505461490"
+[versions]
+patched = [">= 0.5.0"]

--- a/crates/ncurses/RUSTSEC-2019-0006.toml
+++ b/crates/ncurses/RUSTSEC-2019-0006.toml
@@ -3,6 +3,7 @@ id = "RUSTSEC-2019-0006"
 package = "ncurses"
 date = "2019-06-15"
 title = "Buffer overflow and format vulnerabilities in functions exposed without unsafe"
+url = "https://github.com/RustSec/advisory-db/issues/106"
 description = """
 `ncurses` exposes functions from the ncurses library which:
 
@@ -12,8 +13,6 @@ description = """
   input to execute a format string attack, which trivially allows writing
   arbitrary data to stack memory (functions in the `printw` family).
 """
-patched_versions = []
-url = "https://github.com/RustSec/advisory-db/issues/106"
 
 [affected.functions]
 "ncurses::instr" = [">= 0"]
@@ -21,3 +20,6 @@ url = "https://github.com/RustSec/advisory-db/issues/106"
 "ncurses::printw" = [">= 0"]
 "ncurses::mvprintw" = [">= 0"]
 "ncurses::mvwprintw" = [">= 0"]
+
+[versions]
+patched = []

--- a/crates/once_cell/RUSTSEC-2019-0017.toml
+++ b/crates/once_cell/RUSTSEC-2019-0017.toml
@@ -1,12 +1,10 @@
 [advisory]
 id = "RUSTSEC-2019-0017"
-
 package = "once_cell"
-
 date = "2019-09-01"
-
 title = "Panic during initialization of Lazy<T> might trigger undefined behavior"
-
+url = "https://github.com/matklad/once_cell/issues/46"
+keywords = ["undefined_behavior"]
 description = """
 If during the first dereference of Lazy<T> the initialization function panics,
 subsequent derefernces will execute `std::hints::unreachable_unchecked`.
@@ -15,16 +13,12 @@ Applications with `panic = "abort"` are not affected, as there will be no
 subsequent dereferences.
 """
 
-patched_versions = [">= 1.0.1"]
-
-unaffected_versions = ["< 0.2.5"]
-
-url = "https://github.com/matklad/once_cell/issues/46"
-
-keywords = ["undefined_behavior"]
-
 [affected.functions]
 "once_cell::unsync::Lazy::force" = ["< 1.0.1, >= 0.2.5"]
 "once_cell::unsync::Lazy::deref" = ["< 1.0.1, >= 0.2.5"]
 "once_cell::sync::Lazy::force" = ["< 1.0.1, >= 0.2.5"]
 "once_cell::sync::Lazy::deref" = ["< 1.0.1, >= 0.2.5"]
+
+[versions]
+patched = [">= 1.0.1"]
+unaffected = ["< 0.2.5"]

--- a/crates/openssl/RUSTSEC-2016-0001.toml
+++ b/crates/openssl/RUSTSEC-2016-0001.toml
@@ -1,7 +1,6 @@
 [advisory]
 id = "RUSTSEC-2016-0001"
 package = "openssl"
-patched_versions = [">= 0.9.0"]
 date = "2016-11-05"
 keywords = ["ssl", "mitm"]
 url = "https://github.com/sfackler/rust-openssl/releases/tag/v0.9.0"
@@ -19,3 +18,6 @@ by default and exposing APIs to perform hostname verification. Use the
 `SslConnector` and `SslAcceptor` types to take advantage of these new features
 (as opposed to the lower-level `SslContext` type).
 """
+
+[versions]
+patched = [">= 0.9.0"]

--- a/crates/openssl/RUSTSEC-2018-0010.toml
+++ b/crates/openssl/RUSTSEC-2018-0010.toml
@@ -1,20 +1,12 @@
 [advisory]
 id = "RUSTSEC-2018-0010"
-
 package = "openssl"
-
 date = "2018-06-01"
-
 title = "Use after free in CMS Signing"
-
-description = """
-Affected versions of the OpenSSL crate used structures after they'd been freed.
-"""
-
-patched_versions = [">= 0.10.9"]
-
-unaffected_versions = ["< 0.10.8"]
-
 url = "https://github.com/sfackler/rust-openssl/pull/942"
-
 keywords = ["memory-corruption"]
+description = "Affected versions of the OpenSSL crate used structures after they'd been freed."
+
+[versions]
+patched = [">= 0.10.9"]
+unaffected = ["< 0.10.8"]

--- a/crates/orion/RUSTSEC-2018-0012.toml
+++ b/crates/orion/RUSTSEC-2018-0012.toml
@@ -1,12 +1,9 @@
 [advisory]
 id = "RUSTSEC-2018-0012"
-
 package = "orion"
-
 date = "2018-12-20"
-
 title = "Flaw in streaming state reset() functions can create incorrect results."
-
+url = "https://github.com/brycx/orion/issues/46"
 description = """
 Affected versions of this crate did not properly reset a streaming state.
 
@@ -15,6 +12,5 @@ Resetting a streaming state, without finalising it first, creates incorrect resu
 The flaw was corrected by not first checking if the state had already been reset, when calling reset().
 """
 
-patched_versions = [">= 0.11.2"]
-
-url = "https://github.com/brycx/orion/issues/46"
+[versions]
+patched = [">= 0.11.2"]

--- a/crates/pancurses/RUSTSEC-2019-0005.toml
+++ b/crates/pancurses/RUSTSEC-2019-0005.toml
@@ -3,14 +3,16 @@ id = "RUSTSEC-2019-0005"
 package = "pancurses"
 date = "2019-06-15"
 title = "Format string vulnerabilities in `pancurses`"
+url = "https://github.com/RustSec/advisory-db/issues/106"
 description = """
 `pancurses::mvprintw` and `pancurses::printw` passes a pointer from a rust `&str` to C,
 allowing hostile input to execute a format string attack, which trivially allows writing
 arbitrary data to stack memory.
 """
-patched_versions = []
-url = "https://github.com/RustSec/advisory-db/issues/106"
 
 [affected.functions]
 "pancurses::mvprintw" = [">= 0"]
 "pancurses::printw" = [">= 0"]
+
+[versions]
+patched = []

--- a/crates/portaudio-rs/RUSTSEC-2019-0022.toml
+++ b/crates/portaudio-rs/RUSTSEC-2019-0022.toml
@@ -3,6 +3,9 @@ id = "RUSTSEC-2019-0022"
 package = "portaudio-rs"
 date = "2019-09-14"
 title = "Stream callback function is not unwind safe"
+url = "https://github.com/mvdnes/portaudio-rs/issues/20"
+categories = ["code-execution", "memory-corruption"]
+keywords = ["audio", "ffi"]
 description = """
 Affected versions of this crate is not panic safe within callback functions `stream_callback` and `stream_finished_callback`.
 
@@ -12,7 +15,6 @@ This allows an attacker to construct an arbitrary code execution .
  
 The flaw was reported by Phosphorus15.
 """
-patched_versions = ["> 0.3.1"]
-url = "https://github.com/mvdnes/portaudio-rs/issues/20"
-categories = ["code-execution", "memory-corruption"]
-keywords = ["audio", "ffi"]
+
+[versions]
+patched = ["> 0.3.1"]

--- a/crates/portaudio/RUSTSEC-2016-0003.toml
+++ b/crates/portaudio/RUSTSEC-2016-0003.toml
@@ -3,6 +3,8 @@ id = "RUSTSEC-2016-0003"
 package = "portaudio"
 date = "2016-08-01"
 title = "HTTP download and execution allows MitM RCE"
+url = "https://github.com/RustAudio/rust-portaudio/issues/144"
+keywords = ["ssl", "mitm"]
 description = """
 The build script in the portaudio crate will attempt to download via HTTP
 the portaudio source and build it.
@@ -10,6 +12,6 @@ the portaudio source and build it.
 A Mallory in the middle can intercept the download with their own archive
 and get RCE.
 """
-patched_versions = []
-url = "https://github.com/RustAudio/rust-portaudio/issues/144"
-keywords = ["ssl", "mitm"]
+
+[versions]
+patched = []

--- a/crates/prost/RUSTSEC-2020-0002.toml
+++ b/crates/prost/RUSTSEC-2020-0002.toml
@@ -3,6 +3,9 @@ id = "RUSTSEC-2020-0002"
 package = "prost"
 date = "2020-01-16"
 title = "Parsing a specially crafted message can result in a stack overflow"
+url = "https://github.com/danburkert/prost/issues/267"
+categories = ["denial-of-service", "memory-corruption"]
+keywords = ["stack overflow"]
 description = """
 Affected versions of this crate contained a bug in which decoding untrusted
 input could overflow the stack.
@@ -14,7 +17,6 @@ overflowing the stack is unsound and can result in potential memory corruption
  
 The flaw was quickly corrected by @danburkert and released in version 0.6.1.
 """
-patched_versions = [">= 0.6.1"]
-url = "https://github.com/danburkert/prost/issues/267"
-categories = ["denial-of-service", "memory-corruption"]
-keywords = ["stack overflow"]
+
+[versions]
+patched = [">= 0.6.1"]

--- a/crates/protobuf/RUSTSEC-2019-0003.toml
+++ b/crates/protobuf/RUSTSEC-2019-0003.toml
@@ -3,16 +3,18 @@ id = "RUSTSEC-2019-0003"
 package = "protobuf"
 date = "2019-06-08"
 title = "Out of Memory in stream::read_raw_bytes_into()"
+url = "https://github.com/stepancheg/rust-protobuf/issues/411"
+categories = ["denial-of-service"]
+keywords = ["oom", "panic"]
 description = """
 Affected versions of this crate called Vec::reserve() on user-supplied input.
 
 This allows an attacker to cause an Out of Memory condition while calling the
 vulnerable method on untrusted data.
 """
-url = "https://github.com/stepancheg/rust-protobuf/issues/411"
-categories = ["denial-of-service"]
-keywords = ["oom", "panic"]
-patched_versions = ["^1.7.5", ">= 2.6.0"]
 
 [affected.functions]
 "protobuf::stream::read_raw_bytes_into" = ["< 2.6.0"]
+
+[versions]
+patched = ["^1.7.5", ">= 2.6.0"]

--- a/crates/quickersort/RUSTSEC-2018-0016.toml
+++ b/crates/quickersort/RUSTSEC-2018-0016.toml
@@ -5,11 +5,14 @@ date = "2018-06-30"
 title = "quickersort is deprecated and unmaintained"
 informational = "unmaintained"
 url = "https://github.com/notriddle/quickersort/commit/0bc164366315801f0c6b31f4081b7df9fc894076"
-unaffected_versions = ["> 3.0.1"]
-patched_versions = []
-
 description = """
 The author of the `quickersort` crate has deprecated it and does not recommend using it anymore.
 
-Everything in it has been incorporated into [std::sort_unstable](https://doc.rust-lang.org/stable/std/primitive.slice.html#method.sort_unstable) in the standard library as of Rust 1.20
+Everything in it has been incorporated into [std::sort_unstable] in the standard library as of Rust 1.20.
+
+[std::sort_unstable]: https://doc.rust-lang.org/stable/std/primitive.slice.html#method.sort_unstable
 """
+
+[versions]
+patched = []
+unaffected = ["> 3.0.1"]

--- a/crates/renderdoc/RUSTSEC-2019-0018.toml
+++ b/crates/renderdoc/RUSTSEC-2019-0018.toml
@@ -3,6 +3,8 @@ id = "RUSTSEC-2019-0018"
 package = "renderdoc"
 date = "2019-09-02"
 title = "Internally mutating methods take immutable ref self"
+url = "https://github.com/ebkalderon/renderdoc-rs/pull/32"
+keywords = ["undefined_behavior"]
 description = """
 Affected versions of this crate exposed several methods which took `self` by
 immutable reference, despite the requesting the RenderDoc API to set a mutable
@@ -13,10 +15,10 @@ without synchronization could lead to unexpected and unpredictable behavior.
 
 The flaw was corrected in release 0.5.0.
 """
-patched_versions = [">= 0.5.0"]
-url = "https://github.com/ebkalderon/renderdoc-rs/pull/32"
-keywords = ["undefined_behavior"]
 
 [affected.functions]
 "renderdoc::api::RenderDocV110::trigger_multi_frame_capture" = ["< 0.5.0"]
 "renderdoc::api::RenderDocV120::set_capture_file_comments" = ["< 0.5.0"]
+
+[versions]
+patched = [">= 0.5.0"]

--- a/crates/rmpv/RUSTSEC-2017-0006.toml
+++ b/crates/rmpv/RUSTSEC-2017-0006.toml
@@ -3,6 +3,9 @@ id = "RUSTSEC-2017-0006"
 package = "rmpv"
 date = "2017-11-21"
 title = "Unchecked vector pre-allocation"
+url = "https://github.com/3Hren/msgpack-rust/issues/151"
+categories = ["denial-of-service"]
+keywords = ["memory", "dos", "msgpack", "serialization", "deserialization"]
 description = """
 Affected versions of this crate pre-allocate memory on deserializing raw
 buffers without checking whether there is sufficient data available.
@@ -10,7 +13,6 @@ buffers without checking whether there is sufficient data available.
 This allows an attacker to do denial-of-service attacks by sending small
 msgpack messages that allocate gigabytes of memory.
 """
-patched_versions = [">= 0.4.2"]
-url = "https://github.com/3Hren/msgpack-rust/issues/151"
-categories = ["denial-of-service"]
-keywords = ["memory", "dos", "msgpack", "serialization", "deserialization"]
+
+[versions]
+patched = [">= 0.4.2"]

--- a/crates/rust-crypto/RUSTSEC-2016-0005.toml
+++ b/crates/rust-crypto/RUSTSEC-2016-0005.toml
@@ -5,8 +5,6 @@ title = "rust-crypto is unmaintained; switch to a modern alternative"
 informational = "unmaintained"
 date = "2016-09-06" # last GitHub commit
 url = "https://github.com/DaGenix/rust-crypto/issues/440"
-unaffected_versions = ["> 0.2.36"] # last release
-patched_versions = []
 description = """
 The `rust-crypto` crate has not seen a release or GitHub commit since 2016,
 and its author is unresponsive.
@@ -89,3 +87,7 @@ which algorithms you need:
 [`xsalsa20poly1305`]: https://crates.io/crates/xsalsa20poly1305
 [`orion`]: https://crates.io/crates/orion
 """
+
+[versions]
+unaffected = ["> 0.2.36"] # last release
+patched = []

--- a/crates/rust_sodium/RUSTSEC-2020-0003.toml
+++ b/crates/rust_sodium/RUSTSEC-2020-0003.toml
@@ -12,6 +12,8 @@ someone else to take ownership of it.
 We recommend you switch to an alternative crate such as:
 - [`sodiumoxide`](https://crates.io/crates/sodiumoxide)
 """
-patched_versions = []
-unaffected_versions = ["> 0.10.2"]
 url = "https://github.com/maidsafe/rust_sodium/pull/117"
+
+[versions]
+patched = []
+unaffected = ["> 0.10.2"]

--- a/crates/rustsec-example-crate/RUSTSEC-2019-0024.toml
+++ b/crates/rustsec-example-crate/RUSTSEC-2019-0024.toml
@@ -1,7 +1,6 @@
 [advisory]
 id = "RUSTSEC-2019-0024"
 package = "rustsec-example-crate"
-patched_versions = [">= 1.0.0"]
 date = "2019-10-08"
 url = "https://github.com/RustSec/advisory-db/issues/158"
 title = "Test advisory with associated example crate"
@@ -23,3 +22,6 @@ identical to the v0.0.1 release)
 [v0.0.1]: https://crates.io/crates/rustsec-example-crate/0.0.1
 [v1.0.0]: https://crates.io/crates/rustsec-example-crate/1.0.0
 """
+
+[versions]
+patched = [">= 1.0.0"]

--- a/crates/safe-transmute/RUSTSEC-2018-0013.toml
+++ b/crates/safe-transmute/RUSTSEC-2018-0013.toml
@@ -9,8 +9,6 @@ which could lead to memory corruption or data leakage.
 
 The flaw was corrected by using the constructor correctly.
 """
-patched_versions = [">= 0.10.1"]
-unaffected_versions = ["< 0.4.0"]
 url = "https://github.com/nabijaczleweli/safe-transmute-rs/pull/36"
 keywords = ["memory-corruption"]
 
@@ -18,3 +16,7 @@ keywords = ["memory-corruption"]
 #[affected.functions]
 #"safe_transmute::guarded_transmute_vec_permissive" = [">= 0.4.0, <= 0.10.0"]
 #"safe_transmute::guarded_transmute_to_bytes_vec" = ["= 0.10.0"]
+
+[versions]
+patched = [">= 0.10.1"]
+unaffected = ["< 0.4.0"]

--- a/crates/security-framework/RUSTSEC-2017-0003.toml
+++ b/crates/security-framework/RUSTSEC-2017-0003.toml
@@ -1,7 +1,6 @@
 [advisory]
 id = "RUSTSEC-2017-0003"
 package = "security-framework"
-patched_versions = [">= 0.1.12"]
 date = "2017-03-15"
 keywords = ["mitm"]
 url = "https://github.com/sfackler/rust-security-framework/pull/27"
@@ -14,3 +13,6 @@ certificate.
 This issue was fixed by properly configuring the trust evaluation logic to
 perform that check.
 """
+
+[versions]
+patched = [">= 0.1.12"]

--- a/crates/serde_cbor/RUSTSEC-2019-0025.toml
+++ b/crates/serde_cbor/RUSTSEC-2019-0025.toml
@@ -3,6 +3,9 @@ id = "RUSTSEC-2019-0025"
 package = "serde_cbor"
 date = "2019-10-03"
 title = "Flaw in CBOR deserializer allows stack overflow"
+url = "https://github.com/pyfisch/cbor/releases/tag/v0.10.2"
+categories = ["crypto-failure"]
+keywords = ["stack-overflow", "crash", "denial-of-service"]
 description = """
 Affected versions of this crate did not properly check if semantic tags were nested excessively during deserialization.
 
@@ -10,7 +13,6 @@ This allows an attacker to craft small (< 1 kB) CBOR documents that cause a stac
  
 The flaw was corrected by limiting the allowed number of nested tags.
 """
-patched_versions = [">= 0.10.2"]
-url = "https://github.com/pyfisch/cbor/releases/tag/v0.10.2"
-categories = ["crypto-failure"]
-keywords = ["stack-overflow", "crash", "denial-of-service"]
+
+[versions]
+patched = [">= 0.10.2"]

--- a/crates/serde_yaml/RUSTSEC-2018-0005.toml
+++ b/crates/serde_yaml/RUSTSEC-2018-0005.toml
@@ -3,6 +3,8 @@ id = "RUSTSEC-2018-0005"
 package = "serde_yaml"
 date = "2018-09-17"
 title = "Uncontrolled recursion leads to abort in deserialization"
+url = "https://github.com/dtolnay/serde-yaml/pull/105"
+keywords = ["crash"]
 description = """
 Affected versions of this crate did not properly check for recursion
 while deserializing aliases.
@@ -12,7 +14,7 @@ to itself causing an abort.
 
 The flaw was corrected by checking the recursion depth.
 """
-patched_versions = [">= 0.8.4"]
-unaffected_versions = ["< 0.6.0-rc1"]
-url = "https://github.com/dtolnay/serde-yaml/pull/105"
-keywords = ["crash"]
+
+[versions]
+patched = [">= 0.8.4"]
+unaffected = ["< 0.6.0-rc1"]

--- a/crates/simd-json/RUSTSEC-2019-0008.toml
+++ b/crates/simd-json/RUSTSEC-2019-0008.toml
@@ -3,6 +3,8 @@ id = "RUSTSEC-2019-0008"
 package = "simd-json"
 date = "2019-06-24"
 title = "Flaw in string parsing can lead to crashes due to invalid memory access."
+url = "https://github.com/Licenser/simdjson-rs/pull/27"
+keywords = ["simd"]
 description = """
 The affected version of this crate did not guard against accessing memory
 beyond the range of its input data. A pointer cast to read the data into
@@ -22,10 +24,10 @@ This allows an attacker to eventually crash a service.
 The flaw was corrected by using a padding buffer for the last read from the
 input. So that we are we never read over the boundary of the input data.
 """
-patched_versions = [">= 0.1.15"]
-unaffected_versions = ["<= 0.1.13"]
-url = "https://github.com/Licenser/simdjson-rs/pull/27"
-keywords = ["simd"]
 
 [affected]
 arch = ["x86", "x86_64"]
+
+[versions]
+patched = [">= 0.1.15"]
+unaffected = ["<= 0.1.13"]

--- a/crates/slice-deque/RUSTSEC-2018-0008.toml
+++ b/crates/slice-deque/RUSTSEC-2018-0008.toml
@@ -2,7 +2,6 @@
 id = "RUSTSEC-2018-0008"
 package = "slice-deque"
 date = "2018-12-05"
-patched_versions = [">= 0.1.16"]
 url = "https://github.com/gnzlbg/slice_deque/issues/57"
 keywords = ["memory-corruption", "rce"]
 title = "Bug in SliceDeque::move_head_unchecked allows read of corrupted memory"
@@ -23,3 +22,6 @@ alter program execution.
 
 The flaw was corrected by properly updating the head and tail of the deque in
 this case. """
+
+[versions]
+patched = [">= 0.1.16"]

--- a/crates/slice-deque/RUSTSEC-2019-0002.toml
+++ b/crates/slice-deque/RUSTSEC-2019-0002.toml
@@ -3,12 +3,10 @@ id = "RUSTSEC-2019-0002"
 package = "slice-deque"
 date = "2019-05-07"
 title = "Bug in SliceDeque::move_head_unchecked corrupts its memory"
-patched_versions = [">= 0.2.0"]
 url = "https://github.com/gnzlbg/slice_deque/issues/57"
 keywords = ["memory-corruption", "rce"]
 references = ["RUSTSEC-2018-0008"]
 description = """
-
 Affected versions of this crate entered a corrupted state if
 `mem::size_of::<T>() % allocation_granularity() != 0` and a specific allocation
 pattern was used: sufficiently shifting the deque elements over the mirrored
@@ -22,4 +20,8 @@ whose value representation is not meaningful). This is undefined behavior.
  
 The flaw was corrected by using a pair of pointers to track the head and tail of
 the deque instead of a pair of indices. This pair of pointers are represented
-using a Rust slice."""
+using a Rust slice.
+"""
+
+[versions]
+patched = [">= 0.2.0"]

--- a/crates/smallvec/RUSTSEC-2018-0003.toml
+++ b/crates/smallvec/RUSTSEC-2018-0003.toml
@@ -1,8 +1,6 @@
 [advisory]
 id = "RUSTSEC-2018-0003"
 package = "smallvec"
-unaffected_versions = ["< 0.3.2"]
-patched_versions = [">= 0.6.3", "^0.3.4", "^0.4.5", "^0.5.1"]
 url = "https://github.com/servo/rust-smallvec/issues/96"
 keywords = ["memory-corruption"]
 title = "Possible double free during unwinding in SmallVec::insert_many"
@@ -20,3 +18,7 @@ they will not be dropped more than once.
 
 Thank you to @Vurich for reporting this bug.
 """
+
+[versions]
+unaffected = ["< 0.3.2"]
+patched = [">= 0.6.3", "^0.3.4", "^0.4.5", "^0.5.1"]

--- a/crates/smallvec/RUSTSEC-2019-0009.toml
+++ b/crates/smallvec/RUSTSEC-2019-0009.toml
@@ -3,6 +3,8 @@ id = "RUSTSEC-2019-0009"
 package = "smallvec"
 date = "2019-06-06"
 title = "Double-free and use-after-free in SmallVec::grow()"
+url = "https://github.com/servo/rust-smallvec/issues/148"
+keywords = ["double free", "use after free", "arbitrary code execution"]
 description = """
 Attempting to call `grow` on a spilled SmallVec with a value equal to the current capacity causes it to free the existing data. This performs a double free immediately and may lead to use-after-free on subsequent accesses to the SmallVec contents.
 
@@ -10,10 +12,10 @@ An attacker that controls the value passed to `grow` may exploit this flaw to ob
 
 Credits to @ehuss for discovering, reporting and fixing the bug.
 """
-patched_versions = [">= 0.6.10"]
-unaffected_versions = ["< 0.6.5"]
-url = "https://github.com/servo/rust-smallvec/issues/148"
-keywords = ["double free", "use after free", "arbitrary code execution"]
 
 [affected.functions]
 "smallvec::SmallVec::grow" = ["< 0.6.10, >= 0.6.5"]
+
+[versions]
+patched = [">= 0.6.10"]
+unaffected = ["< 0.6.5"]

--- a/crates/smallvec/RUSTSEC-2019-0012.toml
+++ b/crates/smallvec/RUSTSEC-2019-0012.toml
@@ -3,6 +3,8 @@ id = "RUSTSEC-2019-0012"
 package = "smallvec"
 date = "2019-07-19"
 title = "Memory corruption in SmallVec::grow()"
+url = "https://github.com/servo/rust-smallvec/issues/149"
+categories = ["code-execution", "memory-corruption"]
 description = """
 Attempting to call `grow` on a spilled SmallVec with a value less than the current capacity causes corruption of memory allocator data structures.
 
@@ -10,10 +12,10 @@ An attacker that controls the value passed to `grow` may exploit this flaw to ob
 
 Credits to @ehuss for discovering, reporting and fixing the bug.
 """
-patched_versions = [">= 0.6.10"]
-unaffected_versions = ["< 0.6.3"]
-url = "https://github.com/servo/rust-smallvec/issues/149"
-categories = ["code-execution", "memory-corruption"]
 
 [affected.functions]
 "smallvec::SmallVec::grow" = ["< 0.6.10, >= 0.6.3"]
+
+[versions]
+patched = [">= 0.6.10"]
+unaffected = ["< 0.6.3"]

--- a/crates/sodiumoxide/RUSTSEC-2017-0001.toml
+++ b/crates/sodiumoxide/RUSTSEC-2017-0001.toml
@@ -1,7 +1,6 @@
 [advisory]
 id = "RUSTSEC-2017-0001"
 package = "sodiumoxide"
-patched_versions = [">= 0.0.14"]
 aliases = ["CVE-2017-1000168"]
 date = "2017-01-26"
 keywords = ["cryptography"]
@@ -15,3 +14,6 @@ secret will always be zero regardless of the private key used.
 This issue was fixed by checking for this class of keys and rejecting them
 if they are used.
 """
+
+[versions]
+patched = [">= 0.0.14"]

--- a/crates/sodiumoxide/RUSTSEC-2019-0026.toml
+++ b/crates/sodiumoxide/RUSTSEC-2019-0026.toml
@@ -2,6 +2,7 @@
 id = "RUSTSEC-2019-0026"
 package = "sodiumoxide"
 date = "2019-10-11"
+keywords = ["cryptography"]
 url = "https://github.com/sodiumoxide/sodiumoxide/pull/381"
 
 title = "generichash::Digest::eq always return true"
@@ -10,9 +11,10 @@ PartialEq implementation for generichash::Digest has compared itself to itself.
 
 Digest::eq always returns true and Digest::ne always returns false. 
 """
-patched_versions = [">= 0.2.5"]
-keywords = ["cryptography"]
 
 [affected.functions]
 "sodiumoxide::crypto::generichash::Digest::eq" = ["< 0.2.5, >= 0.2.0"]
 "sodiumoxide::crypto::generichash::Digest::ne" = ["< 0.2.5, >= 0.2.0"]
+
+[versions]
+patched = [">= 0.2.5"]

--- a/crates/spin/RUSTSEC-2019-0013.toml
+++ b/crates/spin/RUSTSEC-2019-0013.toml
@@ -3,6 +3,8 @@ id = "RUSTSEC-2019-0013"
 package = "spin"
 date = "2019-08-27"
 title = "Wrong memory orderings in RwLock potentially violates mutual exclusion"
+url = "https://github.com/mvdnes/spin-rs/issues/65"
+keywords = ["atomic", "ordering", "spin", "lock", "mutex", "rwlock"]
 description = """
 Wrong memory orderings inside the RwLock implementation allow for two writers to acquire the lock at the same time. The drop implementation used Ordering::Relaxed, which allows the compiler or CPU to reorder a mutable access on the locked data after the lock has been yielded.
 
@@ -12,9 +14,9 @@ On strongly ordered CPU architectures like x86, the only real way that this woul
 
 The flaw was corrected by https://github.com/mvdnes/spin-rs/pull/66.
 """
-patched_versions = [">= 0.5.2"]
-url = "https://github.com/mvdnes/spin-rs/issues/65"
-keywords = ["atomic", "ordering", "spin", "lock", "mutex", "rwlock"]
 
 [affected.functions]
 "spin::RwLock::new" = ["< 0.5.2"]
+
+[versions]
+patched = [">= 0.5.2"]

--- a/crates/spin/RUSTSEC-2019-0031.toml
+++ b/crates/spin/RUSTSEC-2019-0031.toml
@@ -5,8 +5,6 @@ title = "spin is no longer actively maintained"
 informational = "unmaintained"
 date = "2019-11-21"
 url = "https://github.com/mvdnes/spin-rs/commit/7516c80"
-unaffected_versions = ["> 0.5.2"] # last release
-patched_versions = []
 description = """
 The author of the `spin` crate does not have time or interest to maintain it.
 
@@ -15,3 +13,7 @@ Consider the following alternatives (both of which support `no_std`):
 - [`conquer-once`](https://github.com/oliver-giersch/conquer-once)
 - [`lock_api`](https://crates.io/crates/lock_api) (a subproject of `parking_lot`)
 """
+
+[versions]
+patched = []
+unaffected = ["> 0.5.2"] # last release

--- a/crates/streebog/RUSTSEC-2019-0030.toml
+++ b/crates/streebog/RUSTSEC-2019-0030.toml
@@ -3,11 +3,13 @@ id = "RUSTSEC-2019-0030"
 package = "streebog"
 date = "2019-10-06"
 title = "Incorrect implementation of the Streebog hash functions"
+url = "https://github.com/RustCrypto/hashes/pull/91"
+categories = ["crypto-failure"]
 description = """
 Internal `update-sigma` function was implemented incorrectly and depending on
 `debug-assertions` it could've caused an incorrect result or panic for certain
 inputs.
 """
-patched_versions = [">= 0.8.0"]
-url = "https://github.com/RustCrypto/hashes/pull/91"
-categories = ["crypto-failure"]
+
+[versions]
+patched = [">= 0.8.0"]

--- a/crates/string-interner/RUSTSEC-2019-0023.toml
+++ b/crates/string-interner/RUSTSEC-2019-0023.toml
@@ -3,6 +3,8 @@ id = "RUSTSEC-2019-0023"
 package = "string-interner"
 date = "2019-08-24"
 title = "Cloned interners may read already dropped strings"
+url = "https://github.com/Robbepop/string-interner/issues/9"
+keywords = ["use after free"]
 description = """
 Affected versions of this crate did not clone contained strings when an interner is cloned.
 Interners have raw pointers to the contained strings, and they keep pointing the strings which the old interner owns, after the interner is cloned.
@@ -18,6 +20,6 @@ This patch implements `Clone` manually to the interner type, so that the interna
 PR #10 was also backported to the 0.6 release line in
 <https://github.com/Robbepop/string-interner/pull/14> and was released in 0.6.4.
 """
-patched_versions = ["^0.6.4", ">= 0.7.1"]
-url = "https://github.com/Robbepop/string-interner/issues/9"
-keywords = ["use after free"]
+
+[versions]
+patched = ["^0.6.4", ">= 0.7.1"]

--- a/crates/tar/RUSTSEC-2018-0002.toml
+++ b/crates/tar/RUSTSEC-2018-0002.toml
@@ -1,8 +1,6 @@
 [advisory]
 id = "RUSTSEC-2018-0002"
 package = "tar"
-unaffected_versions = []
-patched_versions = [">= 0.4.16"]
 keywords = ["file-overwrite"]
 url = "https://github.com/alexcrichton/tar-rs/pull/156"
 title = "Links in archives can overwrite any existing file"
@@ -23,3 +21,7 @@ This has been fixed in https://github.com/alexcrichton/tar-rs/pull/156 and is
 published as `tar` 0.4.16. Thanks to Max Justicz for discovering this and
 emailing about the issue!
 """
+
+[versions]
+patched = [">= 0.4.16"]
+unaffected = []

--- a/crates/term/RUSTSEC-2018-0015.toml
+++ b/crates/term/RUSTSEC-2018-0015.toml
@@ -5,8 +5,6 @@ title = "term is looking for a new maintainer"
 informational = "unmaintained"
 date = "2018-11-19"
 url = "https://github.com/Stebalien/term/issues/93"
-unaffected_versions = ["> 0.6.1"] # last release
-patched_versions = []
 description = """
 The author of the `term` crate does not have time to maintain it and is looking
 for a new maintainer.
@@ -18,3 +16,7 @@ on your needs:
 - [`termcolor`](https://crates.io/crates/termcolor)
 - [`yansi`](https://crates.io/crates/yansi)
 """
+
+[versions]
+patched = []
+unaffected = ["> 0.6.1"] # last release

--- a/crates/trust-dns-proto/RUSTSEC-2018-0007.toml
+++ b/crates/trust-dns-proto/RUSTSEC-2018-0007.toml
@@ -3,6 +3,7 @@ id = "RUSTSEC-2018-0007"
 package = "trust-dns-proto"
 date = "2018-10-09"
 title = "Stack overflow when parsing malicious DNS packet"
+keywords = [ "stack-overflow", "crash" ]
 description = """
 There's a stack overflow leading to a crash when Trust-DNS's parses a
 malicious DNS packet.
@@ -17,5 +18,6 @@ with Trust-DNS could cause stack overflow and crash the affected software.
 
 The flaw was corrected by trust-dns-proto 0.4.3 and upcoming 0.5.0 release.
 """
-patched_versions = [">= 0.4.3", ">= 0.5.0-alpha.3" ]
-keywords = [ "stack-overflow", "crash" ]
+
+[versions]
+patched = [">= 0.4.3", ">= 0.5.0-alpha.3" ]

--- a/crates/trust-dns-server/RUSTSEC-2020-0001.toml
+++ b/crates/trust-dns-server/RUSTSEC-2020-0001.toml
@@ -18,8 +18,10 @@ Prior to 0.16.0 the additional record processing was not supported by trust-dns-
 Are no known issues with upgrading from 0.16 or 0.17 to 0.18.1. The remidy should be to upgrade to
 0.18.1. If unable to do so, MX, SRV or other record types with a target to the null type, should be avoided.
 """
-patched_versions = [">= 0.18.1"]
-unaffected_versions = ["< 0.16.0"]
 url = "https://github.com/bluejekyll/trust-dns/issues/980"
 categories = ["denial-of-service"]
 keywords = [ "stack-overflow", "crash" ]
+
+[versions]
+patched = [">= 0.18.1"]
+unaffected = ["< 0.16.0"]

--- a/crates/untrusted/RUSTSEC-2018-0001.toml
+++ b/crates/untrusted/RUSTSEC-2018-0001.toml
@@ -1,8 +1,6 @@
 [advisory]
 id = "RUSTSEC-2018-0001"
 package = "untrusted"
-unaffected_versions = []
-patched_versions = [">= 0.6.2"]
 url = "https://github.com/briansmith/untrusted/pull/20"
 keywords = ["crash"]
 title = "An integer underflow could lead to panic"
@@ -20,3 +18,7 @@ The error in untrusted is fixed in release 0.6.2 released 2018-06-21. It's also
 advisable that users of untrusted check for their sources for cases where errors
 returned by untrusted are not handled correctly.
 """
+
+[versions]
+patched = [">= 0.6.2"]
+unaffected = []

--- a/crates/yaml-rust/RUSTSEC-2018-0006.toml
+++ b/crates/yaml-rust/RUSTSEC-2018-0006.toml
@@ -3,6 +3,8 @@ id = "RUSTSEC-2018-0006"
 package = "yaml-rust"
 date = "2018-09-17"
 title = "Uncontrolled recursion leads to abort in deserialization"
+url = "https://github.com/chyh1990/yaml-rust/pull/109"
+keywords = ["crash"]
 description = """
 Affected versions of this crate did not prevent deep recursion while
 deserializing data structures.
@@ -12,6 +14,6 @@ that causes an abort while deserializing it.
 
 The flaw was corrected by checking the recursion depth.
 """
-patched_versions = [">= 0.4.1"]
-url = "https://github.com/chyh1990/yaml-rust/pull/109"
-keywords = ["crash"]
+
+[versions]
+patched = [">= 0.4.1"]


### PR DESCRIPTION
As announced in #228, this commit migrates all advisories to the new V2 format, which splits version information into a separate section, and now has a structure which corresponds to the internal code structure of the `rustsec` crate.

This is a breaking change for users of `cargo-audit` < 0.9, and anyone who has written a 3rd party advisory format parser.