### PR TITLE
.github: cache installation of rustsec-admin

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,7 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+
+    - name: Cache cargo bin
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/bin
+        key: rustsec-admin-v0.1.1
+
     - name: Install rustsec-admin
       run: cargo install rustsec-admin
+
     - name: Lint advisories
       run: rustsec-admin lint


### PR DESCRIPTION
Installing `rustsec-admin` to lint the advisory DB takes an awfully long time. This caches it with a key labeled with the version so it can reuse the cached version if available.