### PR TITLE
Migrate `rust/` advisories to V2 format

### DIFF
--- a/rust/cargo/CVE-2019-16760.toml
+++ b/rust/cargo/CVE-2019-16760.toml
@@ -3,7 +3,6 @@ id = "CVE-2019-16760"
 package = "cargo"
 date = "2019-09-30"
 aliases = ["GHSA-phjm-8x66-qw4r"]
-unaffected_versions = [">= 1.26.0"]
 url = "https://groups.google.com/forum/#!topic/rustlang-security-announcements/rVQ5e3TDnpQ"
 title = "Cargo prior to Rust 1.26.0 may download the wrong dependency"
 description = """
@@ -109,3 +108,6 @@ with our [security policy][5].
 [4]: https://gist.github.com/pietroalbini/0d293b24a44babbeb6187e06eebd4992
 [5]: https://www.rust-lang.org/policies/security
 """
+
+[versions]
+patched = [">= 1.26.0"]

--- a/rust/rustdoc/CVE-2018-1000622.toml
+++ b/rust/rustdoc/CVE-2018-1000622.toml
@@ -3,6 +3,9 @@ id = "CVE-2018-1000622"
 package = "rustdoc"
 date = "2018-07-05"
 title = "Uncontrolled search path element vulnerability in rustdoc plugins"
+categories = ["code-execution"]
+url = "https://groups.google.com/forum/#!topic/rustlang-security-announcements/4ybxYLTtXuM"
+cvss = "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
 description = """
 Rustdoc, if not passed the `--plugin-path` argument, defaults to
 `/tmp/rustdoc/plugins`. `/tmp` is world-writable on many systems, and so an
@@ -91,7 +94,6 @@ feedback on the patch itself. You can find their bug at [5].
 [4]: https://github.com/rust-lang/rust/commit/7b24efd6f333620ed2559d70b32da8f6f9957385
 [5]: https://bugzilla.redhat.com/show_bug.cgi?id=1597063
 """
-patched_versions = ["> 1.27.0"]
-categories = ["code-execution"]
-url = "https://groups.google.com/forum/#!topic/rustlang-security-announcements/4ybxYLTtXuM"
-cvss = "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+
+[versions]
+patched = ["> 1.27.0"]

--- a/rust/std/CVE-2018-1000657.toml
+++ b/rust/std/CVE-2018-1000657.toml
@@ -3,15 +3,17 @@ id = "CVE-2018-1000657"
 package = "std"
 date = "2018-08-20"
 title = "Buffer overflow vulnerability in VecDeque::reserve()"
+categories = ["code-execution", "denial-of-service"]
+url = "https://github.com/rust-lang/rust/issues/44800"
 description = """
 The `std::collections::vec_deque::VecDeque::reserve()` function contains a
 buffer overflow vulnerability that can potentially result in arbitrary code
 execution.
 """
-patched_versions = [">= 1.22.0"]
-unaffected_versions = ["< 1.3.0"]
-categories = ["code-execution", "denial-of-service"]
-url = "https://github.com/rust-lang/rust/issues/44800"
 
 [affected.functions]
 "std::collections::vec_deque::VecDeque::reserve" = ["< 1.22.0, >= 1.3.0"]
+
+[versions]
+patched = [">= 1.22.0"]
+unaffected = ["< 1.3.0"]

--- a/rust/std/CVE-2018-1000810.toml
+++ b/rust/std/CVE-2018-1000810.toml
@@ -3,6 +3,9 @@ id = "CVE-2018-1000810"
 package = "std"
 date = "2018-09-21"
 title = "Buffer overflow vulnerability in str::repeat()"
+url = "https://groups.google.com/forum/#!topic/rustlang-security-announcements/CmSuTm-SaU0"
+categories = ["denial-of-service", "memory-corruption"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 description = """
 The Rust team was recently notified of a security vulnerability affecting
 the `str::repeat` function in the standard library. If your code does not
@@ -91,11 +94,10 @@ accordance with our security policy https://www.rust-lang.org/security.html.
 [4]: https://github.com/rust-lang/rust/pull/54398
 [5]: https://github.com/rust-lang/rust/pull/54399
 """
-patched_versions = [">= 1.29.1"]
-unaffected_versions = ["< 1.26.0"]
-url = "https://groups.google.com/forum/#!topic/rustlang-security-announcements/CmSuTm-SaU0"
-categories = ["denial-of-service", "memory-corruption"]
-cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [affected.functions]
 "std::str::repeat" = ["< 1.29.1, >= 1.26.0"]
+
+[versions]
+patched = [">= 1.29.1"]
+unaffected = ["< 1.26.0"]

--- a/rust/std/CVE-2019-12083.toml
+++ b/rust/std/CVE-2019-12083.toml
@@ -3,6 +3,8 @@ id = "CVE-2019-12083"
 package = "std"
 date = "2019-05-13"
 title = "Memory safety vulnerabilities arising from `Error::type_id`"
+categories = ["memory-corruption"]
+url = "https://groups.google.com/forum/#!topic/rustlang-security-announcements/aZabeCMUv70"
 description = """
 The Rust team was recently notified of a security vulnerability affecting
 manual implementations of `Error::type_id` and their interaction with the
@@ -90,7 +92,7 @@ with our security policy https://www.rust-lang.org/policies/security.
 [4]: https://github.com/rust-lang/rust/pull/60786
 [5]: https://github.com/rust-lang/rust/pull/60787
 """
-patched_versions = ["> 1.34.1"]
-unaffected_versions = ["< 1.34.0"]
-categories = ["memory-corruption"]
-url = "https://groups.google.com/forum/#!topic/rustlang-security-announcements/aZabeCMUv70"
+
+[versions]
+patched = ["> 1.34.1"]
+unaffected = ["< 1.34.0"]


### PR DESCRIPTION
The migration in #236 only handled the `crates/` advisories, not the ones in `rust/`.

This commit completes the migration.