### PR TITLE
.github: fix rustsec-admin install caching

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   lint:
+    name: Lint advisories
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
@@ -18,7 +19,10 @@ jobs:
         key: rustsec-admin-v0.1.1
 
     - name: Install rustsec-admin
-      run: cargo install rustsec-admin
+      run: |
+        if [ ! -f $HOME/.cargo/bin/rustsec-admin ]; then
+            cargo install rustsec-admin
+        fi
 
     - name: Lint advisories
       run: rustsec-admin lint


### PR DESCRIPTION
Fixes use of the cached `rustsec-admin` binary, which was added in #237