### PR TITLE
Add `md5` to RustCrypto digest crates

### DIFF
--- a/crates/rust-crypto/RUSTSEC-2016-0005.toml
+++ b/crates/rust-crypto/RUSTSEC-2016-0005.toml
@@ -30,7 +30,7 @@ which algorithms you need:
 - [RustCrypto GitHub Org]:
   - AEAD algorithms: [`aes-gcm`], [`aes-gcm-siv`], [`aes-siv`], [`chacha20poly1305`], [`xsalsa20poly1305`]
   - Block ciphers: [`aes`], [`cast5`], [`des`]
-  - Digest algorithms: [`sha2`], [`sha3`], [`blake2`], [`ripemd160`] (legacy: [`sha-1`])
+  - Digest algorithms: [`sha2`], [`sha3`], [`blake2`], [`ripemd160`], [`md-5`] (legacy: [`sha-1`])
   - Key derivation: [`hkdf`]
   - MACs: [`cmac`], [`hmac`], [`pmac`], [`poly1305`]
   - Password hashing: [`pbkdf2`]


### PR DESCRIPTION
When migrating a codebase off of rust-crypto, I encountered a few uses of the md5 digest, and realized that it was missing from this advisory.

Since deprecations are good onboarding tasks for folks new to rust (like me), I figured it would be helpful to explicitly state here that RustCrypto has an `md-5` crate you can use as (almost) a drop-in replacement