### PR TITLE
RUSTSEC-2016-0005: move `md-5` crate to legacy algorithms

### DIFF
--- a/crates/rust-crypto/RUSTSEC-2016-0005.toml
+++ b/crates/rust-crypto/RUSTSEC-2016-0005.toml
@@ -30,7 +30,8 @@ which algorithms you need:
 - [RustCrypto GitHub Org]:
   - AEAD algorithms: [`aes-gcm`], [`aes-gcm-siv`], [`aes-siv`], [`chacha20poly1305`], [`xsalsa20poly1305`]
   - Block ciphers: [`aes`], [`cast5`], [`des`]
-  - Digest algorithms: [`sha2`], [`sha3`], [`blake2`], [`ripemd160`], [`md-5`] (legacy: [`sha-1`])
+  - Digest algorithms: [`sha2`], [`sha3`], [`blake2`], [`ripemd160`]
+    (legacy: [`sha-1`], [`md-5`])
   - Key derivation: [`hkdf`]
   - MACs: [`cmac`], [`hmac`], [`pmac`], [`poly1305`]
   - Password hashing: [`pbkdf2`]


### PR DESCRIPTION
https://www.kb.cert.org/vuls/id/836068/