### PR TITLE
Add CVE mapping

### DIFF
--- a/crates/ammonia/RUSTSEC-2019-0001.toml
+++ b/crates/ammonia/RUSTSEC-2019-0001.toml
@@ -14,6 +14,7 @@ a pathologically nested input.
 
 The flaw was corrected by serializing the DOM tree iteratively instead.
 """
+aliases = ["CVE-2019-15542"]
 
 [affected.functions]
 "ammonia::clean" = ["< 2.1.0"]

--- a/crates/arrayfire/RUSTSEC-2018-0011.toml
+++ b/crates/arrayfire/RUSTSEC-2018-0011.toml
@@ -18,6 +18,7 @@ The issue seems to be interlinked with which version of Rust is being used.
 
 The issue was fixed in crate 3.6.0.
 """
+aliases = ["CVE-2018-20998"]
 
 [versions]
 patched = [">= 3.6.0"]

--- a/crates/asn1_der/RUSTSEC-2019-0007.toml
+++ b/crates/asn1_der/RUSTSEC-2019-0007.toml
@@ -12,6 +12,7 @@ This allows an attacker to trigger a SIGABRT by creating length fields that anno
  
 The flaw was corrected by not preallocating memory.
 """
+aliases = ["CVE-2019-15549"]
 
 [versions]
 patched = [">= 0.6.2"]

--- a/crates/blake2/RUSTSEC-2019-0019.toml
+++ b/crates/blake2/RUSTSEC-2019-0019.toml
@@ -17,6 +17,7 @@ The v0.8.1 release of the `blake2` crate uses the correct block sizes.
 Note that this advisory only impacts usage of BLAKE2 with HMAC, and does not
 impact `Digest` functionality.
 """
+aliases = ["CVE-2019-16143"]
 
 [versions]
 patched = [">= 0.8.1"]

--- a/crates/chttp/RUSTSEC-2019-0016.toml
+++ b/crates/chttp/RUSTSEC-2019-0016.toml
@@ -12,6 +12,7 @@ A fix was published in version 0.1.3.
 """
 url = "https://github.com/sagebind/isahc/issues/2"
 keywords = ["memory-management", "memory-corruption"]
+aliases = ["CVE-2019-16140"]
 
 [versions]
 patched = [">= 0.1.3"]

--- a/crates/claxon/RUSTSEC-2018-0004.toml
+++ b/crates/claxon/RUSTSEC-2018-0004.toml
@@ -19,6 +19,7 @@ the decode buffer size, and returning a format error if it does not. If an error
 is returned, the decode buffer is not exposed. Regression tests and an
 additional fuzzer have been added to prevent similar flaws in the future.
 """
+aliases = ["CVE-2018-20992"]
 
 [versions]
 patched = ["=0.3.2", ">= 0.4.1"]

--- a/crates/compact_arena/RUSTSEC-2019-0015.toml
+++ b/crates/compact_arena/RUSTSEC-2019-0015.toml
@@ -16,6 +16,7 @@ access into the memory reserved for the arena.
 
 The flaw was corrected by implementing generativity correctly in version 0.4.0.
 """
+aliases = ["CVE-2019-16139"]
 
 [affected.functions]
 "compact_arena::SmallArena::new" = ["< 0.4.0"]

--- a/crates/cookie/RUSTSEC-2017-0005.toml
+++ b/crates/cookie/RUSTSEC-2017-0005.toml
@@ -14,6 +14,7 @@ will panic if the value is greater than 2^64/1000 and less than or equal to
 This flaw was corrected by explicitly checking for the `Max-Age` being in this
 integer range and clamping the value to the maximum duration value.
 """
+aliases = ["CVE-2017-18589"]
 
 [versions]
 patched = ["< 0.6.0", "^0.6.2", ">= 0.7.6"]

--- a/crates/crossbeam/RUSTSEC-2018-0009.toml
+++ b/crates/crossbeam/RUSTSEC-2018-0009.toml
@@ -15,6 +15,7 @@ The flaw was corrected by wrapping elements inside queues in a
 
 Thanks to @c0gent for reporting the issue.
 """
+aliases = ["CVE-2018-20996"]
 
 [versions]
 patched = [">= 0.4.1"]

--- a/crates/hyper/RUSTSEC-2016-0002.toml
+++ b/crates/hyper/RUSTSEC-2016-0002.toml
@@ -17,6 +17,7 @@ CA-issued certificate, even if there's a hostname mismatch.
 The problem was addressed by leveraging rust-openssl's built-in support for
 hostname verification.
 """
+aliases = ["CVE-2016-10932"]
 
 [affected]
 os = ["windows"]

--- a/crates/hyper/RUSTSEC-2017-0002.toml
+++ b/crates/hyper/RUSTSEC-2017-0002.toml
@@ -13,6 +13,7 @@ is if an application constructs headers based on unsanitized user input.
 This issue was fixed by replacing all newline characters with a space during serialization of
 a header value.
 """
+aliases = ["CVE-2017-18587"]
 
 [versions]
 patched = [">= 0.10.2", "< 0.10.0, >= 0.9.18"]

--- a/crates/image/RUSTSEC-2019-0014.toml
+++ b/crates/image/RUSTSEC-2019-0014.toml
@@ -22,6 +22,7 @@ Starting from version `0.22`, a breaking change to the interface requires
 callers to pre-allocate the output buffer and pass a mutable slice instead,
 avoiding all unsafe code.
 """
+aliases = ["CVE-2019-16138"]
 
 [affected.functions]
 "image::hdr::HDRDecoder::read_image_transform" = ["< 0.21.3, >= 0.10.2"]

--- a/crates/libflate/RUSTSEC-2019-0010.toml
+++ b/crates/libflate/RUSTSEC-2019-0010.toml
@@ -12,6 +12,7 @@ This is equivalent to a use-after-free vulnerability and could allow an attacker
 
 The flaw was corrected by aborting immediately instead of unwinding the stack in case of panic within `MultiDecoder::read()`. The issue was discovered and fixed by Shnatsel.
 """
+aliases = ["CVE-2019-15552"]
 
 [affected.functions]
 "libflate::gzip::MultiDecoder::read" = ["< 0.1.25, >= 0.1.14"]

--- a/crates/libp2p-core/RUSTSEC-2019-0004.toml
+++ b/crates/libp2p-core/RUSTSEC-2019-0004.toml
@@ -9,6 +9,7 @@ Any signature with a correct length was considered valid.
 
 This allows an attacker to impersonate any node identity.
 """
+aliases = ["CVE-2019-15545"]
 
 [versions]
 patched = ["^0.7.1", ">= 0.8.1"]

--- a/crates/linea/RUSTSEC-2019-0021.toml
+++ b/crates/linea/RUSTSEC-2019-0021.toml
@@ -13,6 +13,7 @@ This allows an attacker to corrupt or take control of the memory.
  
 The flaw was corrected by Phosphorus15.
 """
+aliases = ["CVE-2019-16880"]
 
 [versions]
 patched = ["> 0.9.4"]

--- a/crates/memoffset/RUSTSEC-2019-0011.toml
+++ b/crates/memoffset/RUSTSEC-2019-0011.toml
@@ -10,6 +10,7 @@ They also could lead to uninitialized memory being dropped if the field for whic
 
 The flaw was corrected by using `MaybeUninit`.
 """
+aliases = ["CVE-2019-15553"]
 
 [versions]
 patched = [">= 0.5.0"]

--- a/crates/ncurses/RUSTSEC-2019-0006.toml
+++ b/crates/ncurses/RUSTSEC-2019-0006.toml
@@ -13,6 +13,7 @@ description = """
   input to execute a format string attack, which trivially allows writing
   arbitrary data to stack memory (functions in the `printw` family).
 """
+aliases = ["CVE-2019-15547", "CVE-2019-15548"]
 
 [affected.functions]
 "ncurses::instr" = [">= 0"]

--- a/crates/once_cell/RUSTSEC-2019-0017.toml
+++ b/crates/once_cell/RUSTSEC-2019-0017.toml
@@ -12,6 +12,7 @@ subsequent derefernces will execute `std::hints::unreachable_unchecked`.
 Applications with `panic = "abort"` are not affected, as there will be no
 subsequent dereferences.
 """
+aliases = ["CVE-2019-16141"]
 
 [affected.functions]
 "once_cell::unsync::Lazy::force" = ["< 1.0.1, >= 0.2.5"]

--- a/crates/openssl/RUSTSEC-2016-0001.toml
+++ b/crates/openssl/RUSTSEC-2016-0001.toml
@@ -18,6 +18,7 @@ by default and exposing APIs to perform hostname verification. Use the
 `SslConnector` and `SslAcceptor` types to take advantage of these new features
 (as opposed to the lower-level `SslContext` type).
 """
+aliases = ["CVE-2016-10931"]
 
 [versions]
 patched = [">= 0.9.0"]

--- a/crates/openssl/RUSTSEC-2018-0010.toml
+++ b/crates/openssl/RUSTSEC-2018-0010.toml
@@ -6,6 +6,7 @@ title = "Use after free in CMS Signing"
 url = "https://github.com/sfackler/rust-openssl/pull/942"
 keywords = ["memory-corruption"]
 description = "Affected versions of the OpenSSL crate used structures after they'd been freed."
+aliases = ["CVE-2018-20997"]
 
 [versions]
 patched = [">= 0.10.9"]

--- a/crates/orion/RUSTSEC-2018-0012.toml
+++ b/crates/orion/RUSTSEC-2018-0012.toml
@@ -11,6 +11,7 @@ Resetting a streaming state, without finalising it first, creates incorrect resu
  
 The flaw was corrected by not first checking if the state had already been reset, when calling reset().
 """
+aliases = ["CVE-2018-20999"]
 
 [versions]
 patched = [">= 0.11.2"]

--- a/crates/pancurses/RUSTSEC-2019-0005.toml
+++ b/crates/pancurses/RUSTSEC-2019-0005.toml
@@ -9,6 +9,7 @@ description = """
 allowing hostile input to execute a format string attack, which trivially allows writing
 arbitrary data to stack memory.
 """
+aliases = ["CVE-2019-15546"]
 
 [affected.functions]
 "pancurses::mvprintw" = [">= 0"]

--- a/crates/portaudio-rs/RUSTSEC-2019-0022.toml
+++ b/crates/portaudio-rs/RUSTSEC-2019-0022.toml
@@ -15,6 +15,7 @@ This allows an attacker to construct an arbitrary code execution .
  
 The flaw was reported by Phosphorus15.
 """
+aliases = ["CVE-2019-16881"]
 
 [versions]
 patched = ["> 0.3.1"]

--- a/crates/portaudio/RUSTSEC-2016-0003.toml
+++ b/crates/portaudio/RUSTSEC-2016-0003.toml
@@ -12,6 +12,7 @@ the portaudio source and build it.
 A Mallory in the middle can intercept the download with their own archive
 and get RCE.
 """
+aliases = ["CVE-2016-10933"]
 
 [versions]
 patched = []

--- a/crates/protobuf/RUSTSEC-2019-0003.toml
+++ b/crates/protobuf/RUSTSEC-2019-0003.toml
@@ -12,6 +12,7 @@ Affected versions of this crate called Vec::reserve() on user-supplied input.
 This allows an attacker to cause an Out of Memory condition while calling the
 vulnerable method on untrusted data.
 """
+aliases = ["CVE-2019-15544"]
 
 [affected.functions]
 "protobuf::stream::read_raw_bytes_into" = ["< 2.6.0"]

--- a/crates/renderdoc/RUSTSEC-2019-0018.toml
+++ b/crates/renderdoc/RUSTSEC-2019-0018.toml
@@ -15,6 +15,7 @@ without synchronization could lead to unexpected and unpredictable behavior.
 
 The flaw was corrected in release 0.5.0.
 """
+aliases = ["CVE-2019-16142"]
 
 [affected.functions]
 "renderdoc::api::RenderDocV110::trigger_multi_frame_capture" = ["< 0.5.0"]

--- a/crates/safe-transmute/RUSTSEC-2018-0013.toml
+++ b/crates/safe-transmute/RUSTSEC-2018-0013.toml
@@ -16,6 +16,7 @@ keywords = ["memory-corruption"]
 #[affected.functions]
 #"safe_transmute::guarded_transmute_vec_permissive" = [">= 0.4.0, <= 0.10.0"]
 #"safe_transmute::guarded_transmute_to_bytes_vec" = ["= 0.10.0"]
+aliases = ["CVE-2018-21000"]
 
 [versions]
 patched = [">= 0.10.1"]

--- a/crates/security-framework/RUSTSEC-2017-0003.toml
+++ b/crates/security-framework/RUSTSEC-2017-0003.toml
@@ -13,6 +13,7 @@ certificate.
 This issue was fixed by properly configuring the trust evaluation logic to
 perform that check.
 """
+aliases = ["CVE-2017-18588"]
 
 [versions]
 patched = [">= 0.1.12"]

--- a/crates/simd-json/RUSTSEC-2019-0008.toml
+++ b/crates/simd-json/RUSTSEC-2019-0008.toml
@@ -24,6 +24,7 @@ This allows an attacker to eventually crash a service.
 The flaw was corrected by using a padding buffer for the last read from the
 input. So that we are we never read over the boundary of the input data.
 """
+aliases = ["CVE-2019-15550"]
 
 [affected]
 arch = ["x86", "x86_64"]

--- a/crates/slice-deque/RUSTSEC-2018-0008.toml
+++ b/crates/slice-deque/RUSTSEC-2018-0008.toml
@@ -22,6 +22,7 @@ alter program execution.
 
 The flaw was corrected by properly updating the head and tail of the deque in
 this case. """
+aliases = ["CVE-2018-20995"]
 
 [versions]
 patched = [">= 0.1.16"]

--- a/crates/slice-deque/RUSTSEC-2019-0002.toml
+++ b/crates/slice-deque/RUSTSEC-2019-0002.toml
@@ -22,6 +22,7 @@ The flaw was corrected by using a pair of pointers to track the head and tail of
 the deque instead of a pair of indices. This pair of pointers are represented
 using a Rust slice.
 """
+aliases = ["CVE-2019-15543"]
 
 [versions]
 patched = [">= 0.2.0"]

--- a/crates/smallvec/RUSTSEC-2018-0003.toml
+++ b/crates/smallvec/RUSTSEC-2018-0003.toml
@@ -18,6 +18,7 @@ they will not be dropped more than once.
 
 Thank you to @Vurich for reporting this bug.
 """
+aliases = ["CVE-2018-20991"]
 
 [versions]
 unaffected = ["< 0.3.2"]

--- a/crates/smallvec/RUSTSEC-2019-0009.toml
+++ b/crates/smallvec/RUSTSEC-2019-0009.toml
@@ -12,6 +12,7 @@ An attacker that controls the value passed to `grow` may exploit this flaw to ob
 
 Credits to @ehuss for discovering, reporting and fixing the bug.
 """
+aliases = ["CVE-2019-15551"]
 
 [affected.functions]
 "smallvec::SmallVec::grow" = ["< 0.6.10, >= 0.6.5"]

--- a/crates/smallvec/RUSTSEC-2019-0012.toml
+++ b/crates/smallvec/RUSTSEC-2019-0012.toml
@@ -12,6 +12,7 @@ An attacker that controls the value passed to `grow` may exploit this flaw to ob
 
 Credits to @ehuss for discovering, reporting and fixing the bug.
 """
+aliases = ["CVE-2019-15554"]
 
 [affected.functions]
 "smallvec::SmallVec::grow" = ["< 0.6.10, >= 0.6.3"]

--- a/crates/spin/RUSTSEC-2019-0013.toml
+++ b/crates/spin/RUSTSEC-2019-0013.toml
@@ -14,6 +14,7 @@ On strongly ordered CPU architectures like x86, the only real way that this woul
 
 The flaw was corrected by https://github.com/mvdnes/spin-rs/pull/66.
 """
+aliases = ["CVE-2019-16137"]
 
 [affected.functions]
 "spin::RwLock::new" = ["< 0.5.2"]

--- a/crates/string-interner/RUSTSEC-2019-0023.toml
+++ b/crates/string-interner/RUSTSEC-2019-0023.toml
@@ -20,6 +20,7 @@ This patch implements `Clone` manually to the interner type, so that the interna
 PR #10 was also backported to the 0.6 release line in
 <https://github.com/Robbepop/string-interner/pull/14> and was released in 0.6.4.
 """
+aliases = ["CVE-2019-16882"]
 
 [versions]
 patched = ["^0.6.4", ">= 0.7.1"]

--- a/crates/tar/RUSTSEC-2018-0002.toml
+++ b/crates/tar/RUSTSEC-2018-0002.toml
@@ -21,6 +21,7 @@ This has been fixed in https://github.com/alexcrichton/tar-rs/pull/156 and is
 published as `tar` 0.4.16. Thanks to Max Justicz for discovering this and
 emailing about the issue!
 """
+aliases = ["CVE-2018-20990"]
 
 [versions]
 patched = [">= 0.4.16"]

--- a/crates/trust-dns-proto/RUSTSEC-2018-0007.toml
+++ b/crates/trust-dns-proto/RUSTSEC-2018-0007.toml
@@ -18,6 +18,7 @@ with Trust-DNS could cause stack overflow and crash the affected software.
 
 The flaw was corrected by trust-dns-proto 0.4.3 and upcoming 0.5.0 release.
 """
+aliases = ["CVE-2018-20994"]
 
 [versions]
 patched = [">= 0.4.3", ">= 0.5.0-alpha.3" ]

--- a/crates/untrusted/RUSTSEC-2018-0001.toml
+++ b/crates/untrusted/RUSTSEC-2018-0001.toml
@@ -18,6 +18,7 @@ The error in untrusted is fixed in release 0.6.2 released 2018-06-21. It's also
 advisable that users of untrusted check for their sources for cases where errors
 returned by untrusted are not handled correctly.
 """
+aliases = ["CVE-2018-20989"]
 
 [versions]
 patched = [">= 0.6.2"]

--- a/crates/yaml-rust/RUSTSEC-2018-0006.toml
+++ b/crates/yaml-rust/RUSTSEC-2018-0006.toml
@@ -14,6 +14,7 @@ that causes an abort while deserializing it.
 
 The flaw was corrected by checking the recursion depth.
 """
+aliases = ["CVE-2018-20993"]
 
 [versions]
 patched = [">= 0.4.1"]


### PR DESCRIPTION
Add aliases for all CVEs that link to RustSec advisories. Someone was kind enough to open CVEs for most RustSec issues: https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=rust

Advisories not processed (with reason for each one):

```
> find . -type f -name '*.toml' | parallel ~/add_cve_ref_to_toml.sh '{}' ~/cvemapping
parallel: reading inputs from standard input
'aliases' field already exists in ./crates/serde_yaml/RUSTSEC-2018-0005.toml
No corresponding CVE found for RustSec advisory "RUSTSEC-2019-0027"
No corresponding CVE found for RustSec advisory "RUSTSEC-2018-0016"
No corresponding CVE found for RustSec advisory "RUSTSEC-2019-0030"
No corresponding CVE found for RustSec advisory "RUSTSEC-2019-0028"
No corresponding CVE found for RustSec advisory "RUSTSEC-2019-0024"
No corresponding CVE found for RustSec advisory "RUSTSEC-2016-0004"
No corresponding CVE found for RustSec advisory "RUSTSEC-2020-0003"
No corresponding CVE found for RustSec advisory "RUSTSEC-2019-0029"
No corresponding CVE found for RustSec advisory "RUSTSEC-2016-0005"
No corresponding CVE found for RustSec advisory "RUSTSEC-2019-0025"
No corresponding CVE found for RustSec advisory "RUSTSEC-2020-0004"
No corresponding CVE found for RustSec advisory "RUSTSEC-2020-0002"
No corresponding CVE found for RustSec advisory "RUSTSEC-2019-0034"
No corresponding CVE found for RustSec advisory "RUSTSEC-2019-0033"
No corresponding CVE found for RustSec advisory "RUSTSEC-2020-0001"
'aliases' field already exists in ./crates/base64/RUSTSEC-2017-0004.toml
No corresponding CVE found for RustSec advisory "RUSTSEC-2018-0014"
No corresponding CVE found for RustSec advisory "RUSTSEC-2018-0015"
No corresponding CVE found for RustSec advisory "RUSTSEC-2019-0031"
No corresponding CVE found for RustSec advisory "RUSTSEC-2019-0032"
No corresponding CVE found for RustSec advisory "RUSTSEC-2017-0006"
No corresponding CVE found for RustSec advisory "RUSTSEC-2016-0006"
'aliases' field already exists in ./crates/sodiumoxide/RUSTSEC-2017-0001.toml
No corresponding CVE found for RustSec advisory "RUSTSEC-2019-0026"
'aliases' field already exists in ./rust/cargo/CVE-2019-16760.toml
No corresponding CVE found for RustSec advisory "CVE-2018-1000622"
No corresponding CVE found for RustSec advisory "CVE-2018-1000810"
No corresponding CVE found for RustSec advisory "CVE-2018-1000657"
No corresponding CVE found for RustSec advisory "CVE-2019-12083"
Failed to extract advisory ID from "./support.toml"
```

RUSTSEC-2019-0006 was being processed incorrectly, so I've fixed it up manually.

Scripts used:

Build RustSec<->CVE mapping:
```sh
#!/bin/bash

set -e

# Reads CVE IDs such as CVE-2020-5499 from stdin, one per line.
while read CVE_ID; do
    RUSTSEC_ID=$(curl -s "https://cve.mitre.org/cgi-bin/cvename.cgi?name=$CVE_ID" | grep --only-matching 'RUSTSEC-[0-9][0-9][0-9][0-9]-[0-9]\+' | head -n 1)
    if [ -n "$RUSTSEC_ID" ]; then
        echo "$CVE_ID $RUSTSEC_ID"
    else
        echo "$CVE_ID does not have an associated RUSTSEC entry" >&2
    fi
done
```
Update advisories with the mapping:
```sh
#!/bin/bash

set -e

ADVISORY_TOML_PATH="$1"
CVE_MAPPING_FILE="$2"

if grep -q 'aliases' "$ADVISORY_TOML_PATH"; then
    echo "'aliases' field already exists in $ADVISORY_TOML_PATH" >&2
    exit 2
fi

ADVISORY_ID=$(grep -m 1 'id' "$ADVISORY_TOML_PATH" | cut -d '"' -f 2)

if [ -z "$ADVISORY_ID" ]; then
    echo "Failed to extract advisory ID from \"$ADVISORY_TOML_PATH\"" >&2
    exit 3
fi

CVE_ID=$(grep "$ADVISORY_ID" "$CVE_MAPPING_FILE"| cut -d ' ' -f 1)

if [ -z "$CVE_ID" ]; then
    echo "No corresponding CVE found for RustSec advisory \"$ADVISORY_ID\"" >&2
    exit 4
fi

ADVISORY_TOML="$(cat "$ADVISORY_TOML_PATH")"
echo "$ADVISORY_TOML" | tr '\n' '\f' | sed 's/\f\f\[/\naliases = \["'$CVE_ID'"\]\n\n\[/' | tr '\f' '\n' > "$ADVISORY_TOML_PATH"
```
