### PR TITLE
fix: update patched version for 2019-0028

### DIFF
--- a/crates/flatbuffers/RUSTSEC-2019-0028.toml
+++ b/crates/flatbuffers/RUSTSEC-2019-0028.toml
@@ -15,5 +15,5 @@ allows to violate these requirements and invoke undefined behaviour in safe code
 "flatbuffers::Follow::follow" = [">= 0.4.0", "<= 0.6.0"]
 
 [versions]
-patched = []
+patched = [">= 0.6.1"]
 unaffected = ["< 0.4.0"]


### PR DESCRIPTION
This patch updates the `RUSTSEC-2019-0028` advisory to show a patched version is available. The patch was added [in PR 5554](https://github.com/google/flatbuffers/pull/5554), and released with version `0.6.1`.