### PR TITLE
Fix patched version for RUSTSEC-2020-0008

### DIFF
--- a/crates/hyper/RUSTSEC-2020-0008.toml
+++ b/crates/hyper/RUSTSEC-2020-0008.toml
@@ -20,8 +20,8 @@ runtime.  This allows bypassing CORS restrictions.  In combination with other
 vulnerabilities, such as an exploitable web server listening on loopback, it may
 allow remote code execution.
 
-The flaw was corrected in hyper version 0.12.35.
+The flaw was corrected in hyper version 0.12.34.
 """
 
 [versions]
-patched = [">= 0.12.35"]
+patched = [">= 0.12.34"]


### PR DESCRIPTION
The vulnerability description for advisory RUSTSEC-2020-0008, "Flaw in
hyper allows request smuggling by sending a body in GET requests", lists
an incorrect patched version. The advisory states that the vulnerability
was fixed in `hyper` 0.12.35, but `hyper`'s changelog [shows][1] that 
the patch (hyperium/hyper@23fc8b0) was published in 0.12.34. I believe
that this means that `cargo audit` will incorrectly report patched 
versions as vulnerable.

This PR corrects the listed version.

[1]: https://github.com/hyperium/hyper/blob/master/CHANGELOG.md#v01234-2019-09-04