### PR TITLE
Add unaffected field to RUSTSEC-2020-0008.

### DIFF
--- a/crates/hyper/RUSTSEC-2020-0008.toml
+++ b/crates/hyper/RUSTSEC-2020-0008.toml
@@ -25,3 +25,4 @@ The flaw was corrected in hyper version 0.12.34.
 
 [versions]
 patched = [">= 0.12.34"]
+unaffected = ["< 0.11.0"]


### PR DESCRIPTION
It seems the issue was introduced in version 0.11. The code that handles content-length and transfer-encoding on  version 0.10 seems to be correct.

see https://github.com/hyperium/hyper/blob/0.10.x/src/http/h1.rs