### PR TITLE
Add advisory for rusqlite

### DIFF
--- a/crates/rusqlite/RUSTSEC-0000-0000.toml
+++ b/crates/rusqlite/RUSTSEC-0000-0000.toml
@@ -1,0 +1,25 @@
+
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rusqlite"
+date = "2020-04-23"
+title = "Various memory safety issues"
+url = "https://github.com/rusqlite/rusqlite/releases/tag/0.23.0"
+
+description = """
+Several memory safety issues have been uncovered in an audit of
+rusqlite.
+
+See https://github.com/rusqlite/rusqlite/releases/tag/0.23.0 for a complete list.
+"""
+
+[affected.functions]
+"rusqlite::trace::log" = ["< 0.23.0"]
+"rusqlite::Connection::set_aux" = ["< 0.23.0"]
+"rusqlite::Connection::get_aux" = ["< 0.23.0"]
+"rusqlite::vtab::create_module" = ["< 0.23.0"]
+"rusqlite::session::Session::attach" = ["< 0.23.0"]
+"rusqlite::session::Session::diff" = ["< 0.23.0"]
+
+[versions]
+patched = [">= 0.23.0"]


### PR DESCRIPTION
For work I completed an audit of rusqlite's unsafe code. There were a number of issues for various issues, most of them in uncommonly used APIs, but they could be fairly severe nonetheless.

I'd... prefer not to split this out among N separate advisories. Mostly because I'm lazy, but I also don't really see the benefit it would give. (Aside from making the `description` better, I guess)

Note that while VTab/VTabCursor not being unsafe traits isn't listed in the `functions`, you need to use `create_module` in order to expose that so it should be fine.