### PR TITLE
RUSTSEC-2020-0011: make wording more objective

### DIFF
--- a/crates/plutonium/RUSTSEC-2020-0011.toml
+++ b/crates/plutonium/RUSTSEC-2020-0011.toml
@@ -3,14 +3,12 @@ id = "RUSTSEC-2020-0011"
 package = "plutonium"
 date = "2020-04-23"
 informational = "notice"
-title = "Crate intended to hide unsafe use."
-url = "https://www.reddit.com/r/rust/comments/g5rsuh/show_me_the_most_illegal_rust_code_youve_ever/fo88z2d?utm_source=share&utm_medium=web2x"
+title = "Library exclusively intended to obfuscate code."
+url = "https://docs.rs/plutonium/0.2.2/plutonium/"
 description = """
-This crate allows calling unsafe functions without using the keyword "unsafe". It further
-deliberately makes this undetectable with cargo-geiger.
+This crate allows you to write safe functions with unsafe bodies without the `unsafe` keyword.
 
-In the API docs the author also states their intend to disable `#![forbid(unsafe)]`. No
-production code should ever have it in their dependency graph.
+The value this adds is questionable, and hides `unsafe` usages from naive analysis.
 """
 [versions]
 patched = []


### PR DESCRIPTION
I still personally believe this advisory should be marked obsolete with a note in the description along the lines of explaining how it got in and pointing people to use `cargo-crev` for this kind of concern.

However, this rewording of the advisory seems objectively better and more correct about what `plutonium` actually offers.