### PR TITLE
RUSTSEC-2020-0011: make obsolete (closes #275)

### DIFF
--- a/crates/plutonium/RUSTSEC-2020-0011.toml
+++ b/crates/plutonium/RUSTSEC-2020-0011.toml
@@ -2,6 +2,7 @@
 id = "RUSTSEC-2020-0011"
 package = "plutonium"
 date = "2020-04-23"
+obsolete = true
 informational = "notice"
 title = "Library exclusively intended to obfuscate code."
 url = "https://docs.rs/plutonium/0.2.2/plutonium/"


### PR DESCRIPTION
See discussion in https://github.com/RustSec/advisory-db/issues/275

Fundamentally, this is a bug in `cargo-geiger`. If `cargo-geiger` users care about this, they should either retool `cargo-geiger` to handle this, or have the tool notice this crate itself and handle it specially. Unsafe is not a security issue, it is a security _smell_, and this database is about security issues. 

I also strongly agree with @CAD97's comment [here](https://github.com/RustSec/advisory-db/issues/275#issuecomment-619446580), we should stick to objective advisories. There are other tools for dealing with crate trust. I feel like the inclusion of this crate in this database feels like a lowering of standards, and for a security database to work it needs to have people to trust its objectivity.

I think it is a very bad idea to get in the business of deciding what crates are good and bad.