### PR TITLE
Add advisory for bigint

### DIFF
--- a/crates/bigint/RUSTSEC-0000-0000.toml
+++ b/crates/bigint/RUSTSEC-0000-0000.toml
@@ -1,0 +1,20 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+
+package = "bigint"
+
+date = "2020-05-07"
+
+title = "Undefined Behavior"
+
+categories = ["memory-corruption"]
+
+keywords = ["ub", "undefined", "uninit"]
+
+description = """
+Affected versions of this crate contained multiple Undefined Behaviours
+Triggering Undefined Behavior can produce unknown results and thus isn't safe to use
+"""
+
+[versions]
+patched = []


### PR DESCRIPTION
Hi,
The bigint library(https://github.com/paritytech/bigint) is a copy of very old code(written pre-1.0 in 2014) and contains a bunch of UB, including uninitialized memory, pointers out of bounds etc.

Even the simplest example triggers UB in miri: https://play.rust-lang.org/?version=stable&mode=debug&edition=2015&gist=5f059a27e245cad9f9e49be2b68678c8
(Sadly it seems that there's a bunch of cryptographic libraries depending on this https://crates.io/crates/bigint/reverse_dependencies )