### PR TITLE
tempdir crate has been deprecated since 2018-02-13

### DIFF
--- a/crates/tempdir/RUSTSEC-0000-0000.toml
+++ b/crates/tempdir/RUSTSEC-0000-0000.toml
@@ -1,0 +1,15 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tempdir"
+date = "2018-02-13" # date when deprecation was announced on project README
+title = "`tempdir` crate has been deprecated; use `tempfile` instead"
+informational = "unmaintained"
+url = "https://github.com/rust-lang-deprecated/tempdir/pull/46"
+description = """
+The [`tempdir`](https://crates.io/crates/tempdir) crate has been deprecated
+and the functionality is merged into [`tempfile`](https://crates.io/crates/tempfile).
+"""
+
+[versions]
+unaffected = []
+patched = []


### PR DESCRIPTION
The functionality of `tempdir` crate has been merged into `tempfile` which should be used instead.