### PR TITLE
net2 crate has been deprecated; use socket2 instead

### DIFF
--- a/crates/net2/RUSTSEC-0000-0000.toml
+++ b/crates/net2/RUSTSEC-0000-0000.toml
@@ -1,0 +1,15 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "net2"
+date = "2020-05-01" # date when deprecation was announced on project README
+title = "`net2` crate has been deprecated; use `socket2` instead"
+informational = "unmaintained"
+url = "https://github.com/deprecrated/net2-rs/commit/3350e3819adf151709047e93f25583a5df681091"
+description = """
+The [`net2`](https://crates.io/crates/net2) crate has been deprecated
+and users are encouraged to considered [`socket2`](https://crates.io/crates/socket2) instead.
+"""
+
+[versions]
+unaffected = []
+patched = []


### PR DESCRIPTION
Fixes #285