### PR TITLE
Add advisory for internment

### DIFF
--- a/crates/internment/RUSTSEC-0000-0000.toml
+++ b/crates/internment/RUSTSEC-0000-0000.toml
@@ -1,0 +1,24 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+
+package = "internment"
+
+date = "2020-05-28"
+
+title = "Use after free in ArcIntern::drop"
+
+url = "https://github.com/droundy/internment/issues/11"
+
+categories = ["memory-corruption"]
+
+description = """
+`ArcIntern::drop` has a race condition where it can release memory
+which is about to get another user. The new user will get a reference
+to freed memory.
+
+Versions prior to 0.3.12 used stronger locking which avoided the problem.
+"""
+
+functions = { "internment::ArcIntern::drop" = [">= 0.3.12"] }
+
+unaffected = ["< 0.3.12"]


### PR DESCRIPTION
`internment` 0.3.12 has a race condition in ArcIntern::drop which can
result in use-after-free.