### PR TITLE
Add unmaintained crate advisory for `block-cipher-trait` (RUSTSEC-2020-0018)

### DIFF
--- a/crates/block-cipher-trait/RUSTSEC-2020-0018.toml
+++ b/crates/block-cipher-trait/RUSTSEC-2020-0018.toml
@@ -1,9 +1,9 @@
 [advisory]
-id = "RUSTSEC-0000-0000"
+id = "RUSTSEC-2020-0018"
 package = "block-cipher-trait"
 title = "crate has been renamed to `block-cipher`"
 informational = "unmaintained"
-date = "2018-11-19"
+date = "2020-05-26"
 url = "https://github.com/RustCrypto/traits/pull/139"
 description = """
 This crate has been renamed from `block-cipher-trait` to `block-cipher`.


### PR DESCRIPTION
It's been renamed to `block-cipher`. See:

https://github.com/RustCrypto/traits/pull/139