### PR TITLE
make memoffset advisory informational

### DIFF
--- a/crates/memoffset/RUSTSEC-2019-0011.toml
+++ b/crates/memoffset/RUSTSEC-2019-0011.toml
@@ -2,6 +2,7 @@
 id = "RUSTSEC-2019-0011"
 package = "memoffset"
 date = "2019-07-16"
+informational = "unsound"
 title = "Flaw in offset_of and span_of causes SIGILL, drops uninitialized memory of arbitrary type on panic in client code"
 url = "https://github.com/Gilnaa/memoffset/issues/9#issuecomment-505461490"
 description = """


### PR DESCRIPTION
To cause the drop of uninit memory clients had to panic in a `Deref` implementation. That sounds like a sufficiently "uncommon" library usage to me that this probably should be just informational.