### PR TITLE
Informational advisory for rust-lang-nursery/failure#336

### DIFF
--- a/crates/failure/RUSTSEC-0000-0000.toml
+++ b/crates/failure/RUSTSEC-0000-0000.toml
@@ -3,14 +3,14 @@ id = "RUSTSEC-0000-0000"
 package = "failure"
 date = "2019-11-13"
 informational = "unsound"
-title = "__private_get_type_id__ can be overriden with safe Rust code"
+title = "Type confusion if __private_get_type_id__ is overriden"
 url = "https://github.com/rust-lang-nursery/failure/issues/336"
 keywords = ["unsound"]
 description = """
 Safe Rust code can implement malfunctioning `__private_get_type_id__` and cause
 type confusion when downcasting, which is an undefined behavior.
 
-Normal users of Failure library are not affected.
+Users who derive `Fail` trait are not affected.
 """
 
 [affected]

--- a/crates/failure/RUSTSEC-0000-0000.toml
+++ b/crates/failure/RUSTSEC-0000-0000.toml
@@ -1,0 +1,20 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "failure"
+date = "2019-11-13"
+informational = "unsound"
+title = "__private_get_type_id__ can be overriden with safe Rust code"
+url = "https://github.com/rust-lang-nursery/failure/issues/336"
+keywords = ["unsound"]
+description = """
+Safe Rust code can implement malfunctioning `__private_get_type_id__` and cause
+type confusion when downcasting, which is an undefined behavior.
+
+Normal users of Failure library are not affected.
+"""
+
+[affected]
+functions = { "failure::Fail::__private_get_type_id__" = [">= 0.1.0"] }
+
+[versions]
+patched = []


### PR DESCRIPTION
The current `Failure` API allows safe Rust code to implement malfunctioning `__private_get_type_id__` and cause type confusion when downcasting, which is an undefined behavior.

https://github.com/rust-lang-nursery/failure/issues/336