### PR TITLE
Security advisory for AtheMathmo/rulinalg#201

### DIFF
--- a/crates/rulinalg/RUSTSEC-0000-0000.toml
+++ b/crates/rulinalg/RUSTSEC-0000-0000.toml
@@ -1,0 +1,22 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rulinalg"
+date = "2020-02-11"
+title = "Lifetime boundary for `raw_slice` and `raw_slice_mut` are incorrect"
+url = "https://github.com/AtheMathmo/rulinalg/issues/201"
+description = """
+The affected version of `rulinalg` has incorrect lifetime boundary definitions
+for `RowMut::raw_slice` and `RowMut::raw_slice_mut`. They do not conform with
+Rust's borrowing rule and allows the user to create multiple mutable references
+to the same location.
+"""
+
+[affected]
+functions = {
+    "rulinalg::matrix::RowMut::raw_slice" = [">= 0.4.0"],
+    "rulinalg::matrix::RowMut::raw_slice_mut" = [">= 0.4.0"],
+}
+
+[versions]
+patched = []
+unaffected = ["< 0.4.0"]

--- a/crates/rulinalg/RUSTSEC-0000-0000.toml
+++ b/crates/rulinalg/RUSTSEC-0000-0000.toml
@@ -8,7 +8,8 @@ description = """
 The affected version of `rulinalg` has incorrect lifetime boundary definitions
 for `RowMut::raw_slice` and `RowMut::raw_slice_mut`. They do not conform with
 Rust's borrowing rule and allows the user to create multiple mutable references
-to the same location.
+to the same location. This may result in unexpected calculation result and data
+race if both references are used at the same time.
 """
 
 [affected]

--- a/crates/rulinalg/RUSTSEC-0000-0000.toml
+++ b/crates/rulinalg/RUSTSEC-0000-0000.toml
@@ -12,10 +12,10 @@ to the same location.
 """
 
 [affected]
-functions = {
-    "rulinalg::matrix::RowMut::raw_slice" = [">= 0.4.0"],
-    "rulinalg::matrix::RowMut::raw_slice_mut" = [">= 0.4.0"],
-}
+
+    [affected.functions]
+    "rulinalg::matrix::RowMut::raw_slice" = [">= 0.4.0"]
+    "rulinalg::matrix::RowMut::raw_slice_mut" = [">= 0.4.0"]
 
 [versions]
 patched = []


### PR DESCRIPTION
The affected version of `rulinalg` has incorrect lifetime boundary definitions for `RowMut::raw_slice` and `RowMut::raw_slice_mut`. They do not conform with Rust's borrowing rule and allows the user to create multiple mutable references to the same location.

https://github.com/AtheMathmo/rulinalg/issues/201

The incorrectness of `raw_slice_mut()` is straightforward. However, I'm not completely sure about `raw_slice()`. [Naively downgrading mut refs to shared refs is semantically incorrect](https://github.com/pretzelhammer/rust-blog/blob/master/posts/common-rust-lifetime-misconceptions.md#9-downgrading-mut-refs-to-shared-refs-is-safe), and that's why I think `raw_slice()` should be fixed, too. However, I'm not completely sure about it and any input to this is appreciated.

Also, there was a comment in the original issue that recommends `nalgebra` instead of `rulinalg`. Maybe we need to consider filing an informational advisory for that.