### PR TITLE
Informational advisory for SergioBenitez/Rocket#1312

### DIFF
--- a/crates/rocket/RUSTSEC-0000-0000.toml
+++ b/crates/rocket/RUSTSEC-0000-0000.toml
@@ -1,0 +1,20 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rocket"
+date = "2020-05-27"
+title = "`LocalRequest::clone` creates multiple mutable references to the same object"
+url = "https://github.com/SergioBenitez/Rocket/issues/1312"
+description = """
+The affected version of `rocket` contains a `Clone` trait implementation of
+`LocalRequest` that reuses the pointer to inner `Request` object.
+This causes data race in rare combinations of APIs if the original and the
+cloned objects are modified at the same time.
+"""
+
+[affected]
+# TODO: confirm that this path is correct
+functions = { "rocket::local::LocalRequest::Clone::clone" = ["< 0.4.5, >= 0.4.0"] }
+
+[versions]
+patched = [">= 0.4.5"]
+unaffected = ["< 0.4.0"]

--- a/crates/rocket/RUSTSEC-0000-0000.toml
+++ b/crates/rocket/RUSTSEC-0000-0000.toml
@@ -2,6 +2,7 @@
 id = "RUSTSEC-0000-0000"
 package = "rocket"
 date = "2020-05-27"
+informational = "unsound"
 title = "`LocalRequest::clone` creates multiple mutable references to the same object"
 url = "https://github.com/SergioBenitez/Rocket/issues/1312"
 description = """
@@ -12,8 +13,7 @@ cloned objects are modified at the same time.
 """
 
 [affected]
-# TODO: confirm that this path is correct
-functions = { "rocket::local::LocalRequest::Clone::clone" = ["< 0.4.5, >= 0.4.0"] }
+functions = { "rocket::local::LocalRequest::clone" = ["< 0.4.5, >= 0.4.0"] }
 
 [versions]
 patched = [">= 0.4.5"]


### PR DESCRIPTION
The affected version of `rocket` contains a `Clone` trait implementation of `LocalRequest` that reuses the pointer to inner `Request` object. This causes data race in rare combinations of APIs if the original and the cloned objects are modified at the same time.

https://github.com/SergioBenitez/Rocket/issues/1312