### PR TITLE
.github: bump rustsec-admin cache key

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cargo/bin
-        key: rustsec-admin-v0.1.1
+        key: rustsec-admin-v0.2.0
 
     - name: Install rustsec-admin
       run: |


### PR DESCRIPTION
...to match the new `rustsec-admin` v0.2.0 release:

https://github.com/RustSec/rustsec-admin/pull/57