### PR TITLE
.github: lint advisories after assigning ID

### DIFF
--- a/.github/workflows/assign-ids.yml
+++ b/.github/workflows/assign-ids.yml
@@ -24,6 +24,8 @@ jobs:
         fi
     - name: Assign IDs
       run: rustsec-admin assign-id
+    - name: Lint advisories
+      run: rustsec-admin lint
     - name: Create pull request
       uses: peter-evans/create-pull-request@v2
       with:


### PR DESCRIPTION
It seems that when using `peter-evans/create-pull-request` with the default `GITHUB_TOKEN` won't run the lint action after opening the pull request.

To make up for that, we can run the lint immediately prior to opening the pull request to make sure something didn't go wrong when assigning the ID.