### PR TITLE
Security advisory for bqv/ozone

### DIFF
--- a/crates/ozone/RUSTSEC-0000-0000.toml
+++ b/crates/ozone/RUSTSEC-0000-0000.toml
@@ -1,0 +1,12 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "ozone"
+date = "2020-07-04"
+title = "Ozone contains several memory safety issues"
+description = """
+Ozone contains several memory safety issues including [out-of-bound access](https://github.com/bqv/ozone/blob/e21f948b0178ab305f644118f18d87a838c618e0/src/buffer.rs#L38-L48)
+and dropping of [uninitialized memory](https://github.com/bqv/ozone/blob/e21f948b0178ab305f644118f18d87a838c618e0/src/map.rs#L94-L101).
+"""
+
+[versions]
+patched = []


### PR DESCRIPTION
Ozone contains several memory safety issues including [out-of-bound access](https://github.com/bqv/ozone/blob/e21f948b0178ab305f644118f18d87a838c618e0/src/buffer.rs#L38-L48) and dropping of [uninitialized memory](https://github.com/bqv/ozone/blob/e21f948b0178ab305f644118f18d87a838c618e0/src/map.rs#L94-L101).

---

I'm not sure whether this crate is popular enough to file an advisory. Is there any guideline in that aspect?