### PR TITLE
bigint is unmaintained

### DIFF
--- a/crates/bigint/RUSTSEC-0000-0000.toml
+++ b/crates/bigint/RUSTSEC-0000-0000.toml
@@ -1,0 +1,14 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "bigint"
+title = "bigint is unmaintained, use uint instead"
+informational = "unmaintained"
+date = "2020-05-07"
+url = "https://github.com/paritytech/bigint/commit/7e71521a61b009afc94c91135353102658550d42"
+description = """
+The `bigint` crate is not maintained any more and contains several known bugs (including a soundness bug);
+use [`uint`](https://crates.io/crates/uint) instead.
+"""
+
+[versions]
+patched = []


### PR DESCRIPTION
This is an alternative to https://github.com/RustSec/advisory-db/pull/290.

Cc @ordian