### PR TITLE
Missing sanitazion in mozwire allows local file overwrite of files ending in .conf

### DIFF
--- a/crates/mozwire/RUSTSEC-0000-0000.toml
+++ b/crates/mozwire/RUSTSEC-0000-0000.toml
@@ -1,0 +1,20 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "mozwire"
+date = "2020-08-18"
+title = "Missing sanitazion in mozwire allows local file overwrite of files ending in .conf"
+url = "https://github.com/NilsIrl/MozWire/issues/14"
+categories = []
+keywords = ["file-overwrite"]
+description = """
+The client software downloaded a list of servers from mozilla's servers and created local files named
+after the hostname field in the json document.
+
+No verification of the content of the string was made, and it could therefore have included '../' leading to path traversal.
+
+This allows an attacker in controll of mozilla's servers to overwrite/create local files named .conf.
+
+The flaw was corrected by sanitizing the hostname field.
+"""
+[versions]
+patched = ["> 0.4.1"]


### PR DESCRIPTION
fix committed but not released yet.