### PR TITLE
Add tiny-http Request Smuggling

### DIFF
--- a/crates/tiny_http/RUSTSEC-2020-0000.toml
+++ b/crates/tiny_http/RUSTSEC-2020-0000.toml
@@ -4,7 +4,6 @@ package = "tiny_http"
 date = "2020-06-16"
 title = "HTTP Request smuggling through malformed Transfer Encoding headers"
 url = "https://github.com/tiny-http/tiny-http/issues/173"
-categories = ["format-injection"]
 keywords = ["http", "request-smuggling"]
 description = """
 HTTP pipelining issues and request smuggling attacks are possible due to incorrect 


### PR DESCRIPTION
Reopening this to add the RustSecDB, initially was hoping for a patch before making this into an advisory