### PR TITLE
StrcCtx deallocates a memory region that it doesn't own

### DIFF
--- a/crates/alpm-rs/RUSTSEC-0000-0000.toml
+++ b/crates/alpm-rs/RUSTSEC-0000-0000.toml
@@ -1,0 +1,14 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "alpm-rs"
+date = "2020-08-20"
+informational = "unsound"
+title = "StrcCtx deallocates a memory region that it doesn't own"
+issue_url = "https://github.com/pigeonhands/rust-arch/issues/2"
+description = """
+`StrcCtx` deallocate a memory region that it doesn't own when `StrcCtx` is created without using `StrcCtx::new`.
+This can introduce memory safety issues such as double-free and use-after-free to client programs.
+"""
+
+[versions]
+patched = []

--- a/crates/alpm-rs/RUSTSEC-0000-0000.toml
+++ b/crates/alpm-rs/RUSTSEC-0000-0000.toml
@@ -4,7 +4,7 @@ package = "alpm-rs"
 date = "2020-08-20"
 informational = "unsound"
 title = "StrcCtx deallocates a memory region that it doesn't own"
-issue_url = "https://github.com/pigeonhands/rust-arch/issues/2"
+url = "https://github.com/pigeonhands/rust-arch/issues/2"
 description = """
 `StrcCtx` deallocate a memory region that it doesn't own when `StrcCtx` is created without using `StrcCtx::new`.
 This can introduce memory safety issues such as double-free and use-after-free to client programs.


### PR DESCRIPTION
`StrcCtx` deallocate a memory region that it doesn't own when `StrcCtx` is created without using `StrcCtx::new`.
This can introduce memory safety issues such as double-free and use-after-free to client programs.

Original issue report: https://github.com/pigeonhands/rust-arch/issues/2