### PR TITLE
arr: Multiple security issues including data race, buffer overflow, and uninitialized memory drop

### DIFF
--- a/crates/arr/RUSTSEC-0000-0000.toml
+++ b/crates/arr/RUSTSEC-0000-0000.toml
@@ -1,0 +1,16 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "arr"
+date = "2020-08-25"
+title = "Multiple security issues including data race, buffer overflow, and uninitialized memory drop"
+url = "https://github.com/sjep/array/issues/1"
+description = """
+`arr` crate contains multiple security issues. Specifically,
+
+1. It incorrectly implements Sync/Send bounds, which allows to smuggle non-Sync/Send types across the thread boundary.
+2. `Index` and `IndexMut` implementation does not check the array bound.
+3. `Array::new_from_template()` drops uninitialized memory.
+"""
+
+[versions]
+patched = []


### PR DESCRIPTION
`arr` crate contains multiple security issues. Specifically,

1. It incorrectly implements Sync/Send bounds, which allows to smuggle non-Sync/Send types across the thread boundary.
2. `Index` and `IndexMut` implementation does not check the array bound.
3. `Array::new_from_template()` drops uninitialized memory.

Original issue report: https://github.com/sjep/array/issues/1