### PR TITLE
chunky: Chunk API does not respect align requirement

### DIFF
--- a/crates/chunky/RUSTSEC-0000-0000.toml
+++ b/crates/chunky/RUSTSEC-0000-0000.toml
@@ -1,0 +1,13 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "chunky"
+date = "2020-08-25"
+informational = "unsound"
+title = "Chunk API does not respect align requirement"
+url = "https://github.com/aeplay/chunky/issues/2"
+description = """
+Chunk API does not respect the align requirement of types. Unaligned reference can be created with the API, which is an undefined behavior.
+"""
+
+[versions]
+patched = []


### PR DESCRIPTION
Chunk API does not respect the align requirement of types. Unaligned reference can be created with the API, which is an undefined behavior.

Original issue report: https://github.com/aeplay/chunky/issues/2