### PR TITLE
failure: add informational "unmaintained" advisory

### DIFF
--- a/crates/failure/RUSTSEC-0000-0000.toml
+++ b/crates/failure/RUSTSEC-0000-0000.toml
@@ -1,0 +1,23 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "failure"
+title = "failure is officially deprecated/unmaintained"
+informational = "unmaintained"
+date = "2020-05-02"
+url = "https://github.com/rust-lang-nursery/failure/pull/347"
+description = """
+The `failure` crate is officially end-of-life: it has been marked as deprecated
+by the former maintainer, who has announced that there will be no updates or
+maintenance work on it going forward.
+
+The following are some suggested actively developed alternatives to switch to:
+
+- [`anyhow`](https://crates.io/crates/anyhow)
+- [`eyre`](https://crates.io/crates/eyre)
+- [`snafu`](https://crates.io/crates/snafu)
+- [`thiserror`](https://crates.io/crates/thiserror)
+"""
+
+[versions]
+unaffected = []
+patched = []


### PR DESCRIPTION
Closes #284. See also:

- https://internals.rust-lang.org/t/failure-crate-maintenance/12087
- https://github.com/rust-lang-nursery/failure/pull/347