### PR TITLE
RUSTSEC-2020-0036: add fehler

### DIFF
--- a/crates/failure/RUSTSEC-2020-0036.toml
+++ b/crates/failure/RUSTSEC-2020-0036.toml
@@ -14,6 +14,7 @@ The following are some suggested actively developed alternatives to switch to:
 
 - [`anyhow`](https://crates.io/crates/anyhow)
 - [`eyre`](https://crates.io/crates/eyre)
+- [`fehler`](https://crates.io/crates/fehler)
 - [`snafu`](https://crates.io/crates/snafu)
 - [`thiserror`](https://crates.io/crates/thiserror)
 """


### PR DESCRIPTION
When I originally filed this I used the list of alternatives that were mentioned in the rust-internals announcement. That said, `fehler` is another notable one by the same author as `failure`.