### PR TITLE
obstack: Obstack generates unaligned references

### DIFF
--- a/crates/obstack/RUSTSEC-0000-0000.toml
+++ b/crates/obstack/RUSTSEC-0000-0000.toml
@@ -1,0 +1,13 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "obstack"
+date = "2020-09-03"
+informational = "unsound"
+title = "Obstack generates unaligned references"
+url = "https://github.com/petertodd/rust-obstack/issues/4"
+description = """
+Obstack generates unaligned references for types that require a large alignment.
+"""
+
+[versions]
+patched = []

--- a/crates/obstack/RUSTSEC-0000-0000.toml
+++ b/crates/obstack/RUSTSEC-0000-0000.toml
@@ -10,4 +10,4 @@ Obstack generates unaligned references for types that require a large alignment.
 """
 
 [versions]
-patched = []
+patched = [">= 0.1.4"]


### PR DESCRIPTION
Obstack generates unaligned references for types that require a large alignment.

Original issue report: https://github.com/petertodd/rust-obstack/issues/4