### PR TITLE
simple-slab: `index()` allows out-of-bound read and `remove()` has off-by-one error

### DIFF
--- a/crates/simple-slab/RUSTSEC-0000-0000.toml
+++ b/crates/simple-slab/RUSTSEC-0000-0000.toml
@@ -1,0 +1,12 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "simple-slab"
+date = "2020-09-03"
+title = "`index()` allows out-of-bound read and `remove()` has off-by-one error"
+url = "https://github.com/nathansizemore/simple-slab/issues/2"
+description = """
+`Slab::index()` does not perform the boundary checking, which leads to out-of-bound read access. `Slab::remove()` copies an element from an invalid address due to off-by-one error, resulting in memory leakage and uninitialized memory drop.
+"""
+
+[versions]
+patched = []


### PR DESCRIPTION
`Slab::index()` does not perform the boundary checking, which leads to out-of-bound read access. `Slab::remove()` copies an element from an invalid address due to off-by-one error, resulting in memory leakage and uninitialized memory drop.

Original issue report: https://github.com/nathansizemore/simple-slab/issues/2