### PR TITLE
added CVE numbers

### DIFF
--- a/crates/failure/RUSTSEC-2019-0036.toml
+++ b/crates/failure/RUSTSEC-2019-0036.toml
@@ -1,5 +1,6 @@
 [advisory]
 id = "RUSTSEC-2019-0036"
+aliases = ["CVE-2020-25575"]
 package = "failure"
 date = "2019-11-13"
 informational = "unsound"


### PR DESCRIPTION
looks like some confusion if the CVE is about this or RUSTSEC-2020-0036, but it looks like this is the actual security hole

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-25575