### PR TITLE
Add advisory for atom crate

### DIFF
--- a/crates/atom/RUSTSEC-0000-0000.toml
+++ b/crates/atom/RUSTSEC-0000-0000.toml
@@ -1,0 +1,15 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "atom"
+date = "2020-09-21"
+informational = "unsound"
+title = "Unsafe Send implementation in Atom allows data races"
+url = "https://github.com/slide-rs/atom/issues/13"
+description = """
+The `atom` crate contains a security issue revolving around its implementation
+of the Send trait. It incorrectly allows any arbitrary type to be sent across
+threads potentially leading to use-after-free issues through memory races.
+"""
+
+[versions]
+patched = []


### PR DESCRIPTION
Upstream issue: https://github.com/slide-rs/atom/issues/13

It looks like this vulnerability was fixed in the Github code but a new release was never pushed to cargo with it. The code snippet in the upstream issue presents an `Rc` used across thread-boundaries. Since this library is meant to be for concurrent/multi-thread access, this mistake of accidentally sending across a non `Send` type seems like an easy one to make and can lead to memory corruption issues.