### PR TITLE
Add advisory for out-of-bounds write in stack crate

### DIFF
--- a/crates/stack/RUSTSEC-0000-0000.toml
+++ b/crates/stack/RUSTSEC-0000-0000.toml
@@ -1,0 +1,14 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "stack"
+date = "2020-09-24"
+title = "Missing check in ArrayVec leads to out-of-bounds write."
+url = "https://github.com/arcnmx/stack-rs/issues/4"
+description = """
+ArrayVec::insert allows insertion of an element into the array object into the
+specified index. Due to a missing check on the upperbound of this index, it is
+possible to write out of bounds.
+"""
+
+[versions]
+patched = []

--- a/crates/stack/RUSTSEC-0000-0000.toml
+++ b/crates/stack/RUSTSEC-0000-0000.toml
@@ -11,4 +11,4 @@ possible to write out of bounds.
 """
 
 [versions]
-patched = []
+patched = [">= 0.3.1"]


### PR DESCRIPTION
Upstream issue: https://github.com/arcnmx/stack-rs/issues/4

It's a fairly simple out-of-bounds write caused by a missing check on the array's length.