### PR TITLE
Insufficient size checks in outgoing buffer in `ws` allows remote attacker to run the process out of memory

### DIFF
--- a/crates/ws/RUSTSEC-0000-0000.toml
+++ b/crates/ws/RUSTSEC-0000-0000.toml
@@ -1,0 +1,21 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "ws"
+date = "2019-09-25"
+title = "Insufficient size checks in outgoing buffer in ws allows remote attacker to run the process out of memory"
+
+url = "https://github.com/housleyjk/ws-rs/issues/291"
+
+categories = ["denial-of-service"]
+keywords = ["websocket", "dos", "ddos","oom", "memory", "remotely"]
+
+description = """
+Affected versions of this crate did not properly check and cap the growth of the outgoing buffer.
+
+This allows a remote attacker to take down the process by growing the buffer of their (single) connection until the process runs out of memory it can allocate and is killed.
+
+The flaw was corrected in the [`parity-ws` fork](https://crates.io/crates/parity-ws) (>0.10.0) by [disconnecting a client when the buffer runs full](https://github.com/housleyjk/ws-rs/pull/328).
+"""
+
+[versions]
+patched = []

--- a/crates/ws/RUSTSEC-0000-0000.toml
+++ b/crates/ws/RUSTSEC-0000-0000.toml
@@ -1,7 +1,7 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "ws"
-date = "2019-09-25"
+date = "2020-09-25"
 title = "Insufficient size checks in outgoing buffer in ws allows remote attacker to run the process out of memory"
 
 url = "https://github.com/housleyjk/ws-rs/issues/291"


### PR DESCRIPTION
We've recently been made aware that the memory leak we were seeing in the rpc components in one of our software comes from the `ws`-crate and can even be exploited to kill the process by forcing it to allocate too much memory.

Unfortunately, despite us attempting to contact the original authors of the crate, and the providing a patch, a fixed version has not been published yet. We have a published [a fork](https://crates.io/crates/parity-ws) with the [patch applied however](https://github.com/housleyjk/ws-rs/pull/328), but the advisory format doesn't quite allow us to specify that. The [problem itself has been reported over a year ago on the repository](https://github.com/housleyjk/ws-rs/issues/291) and is included in the latest published version. An [attempt to hand over maintainership has not been successful so far](https://github.com/housleyjk/ws-rs/issues/315) and it is unclear when a fix to the original crate will be provided, so we took the hard decision to go public with this vulnerability to not put the community and others building upon it to risk. 