### PR TITLE
Add advisory for out-of-bounds read in array-queue.

### DIFF
--- a/crates/array-queue/RUSTSEC-0000-0000.toml
+++ b/crates/array-queue/RUSTSEC-0000-0000.toml
@@ -2,15 +2,17 @@
 id = "RUSTSEC-0000-0000"
 package = "array-queue"
 date = "2020-09-26"
-title = "array_queue pop_back allows an out-of-bounds read."
+title = "array_queue pop_back() may cause a use-after-free"
 url = "https://github.com/raviqqe/array-queue/issues/2"
 description = """
 array_queue implements a circular queue that wraps around an array. However, it
 fails to properly index into the array in the `pop_back` function allowing the
 reading of previously dropped or uninitialized memory.
 """
-keywords = ["memory-corruption", "uninitialized-memory"]
-
+keywords = ["memory-corruption", "uninitialized-memory", "use-after-free"]
+functions = { "array_queue::ArrayQueue::push_back" = [">= 0.3.0"] }
 
 [versions]
+
 patched = []
+unaffected = ["< 0.3.0"]

--- a/crates/array-queue/RUSTSEC-0000-0000.toml
+++ b/crates/array-queue/RUSTSEC-0000-0000.toml
@@ -12,7 +12,7 @@ reading of previously dropped or uninitialized memory.
 keywords = ["memory-corruption", "uninitialized-memory", "use-after-free"]
 
 [affected]
-functions = { "array_queue::ArrayQueue::push_back" = [">= 0.3.0"] }
+functions = { "array-queue::ArrayQueue::push_back" = [">= 0.3.0"] }
 
 [versions]
 

--- a/crates/array-queue/RUSTSEC-0000-0000.toml
+++ b/crates/array-queue/RUSTSEC-0000-0000.toml
@@ -10,6 +10,8 @@ fails to properly index into the array in the `pop_back` function allowing the
 reading of previously dropped or uninitialized memory.
 """
 keywords = ["memory-corruption", "uninitialized-memory", "use-after-free"]
+
+[affected]
 functions = { "array_queue::ArrayQueue::push_back" = [">= 0.3.0"] }
 
 [versions]

--- a/crates/array-queue/RUSTSEC-0000-0000.toml
+++ b/crates/array-queue/RUSTSEC-0000-0000.toml
@@ -11,9 +11,6 @@ reading of previously dropped or uninitialized memory.
 """
 keywords = ["memory-corruption", "uninitialized-memory", "use-after-free"]
 
-[affected]
-functions = { "array-queue::ArrayQueue::push_back" = [">= 0.3.0"] }
-
 [versions]
 
 patched = []

--- a/crates/array-queue/RUSTSEC-0000-0000.toml
+++ b/crates/array-queue/RUSTSEC-0000-0000.toml
@@ -1,0 +1,16 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "array-queue"
+date = "2020-09-26"
+title = "array_queue pop_back allows an out-of-bounds read."
+url = "https://github.com/raviqqe/array-queue/issues/2"
+description = """
+array_queue implements a circular queue that wraps around an array. However, it
+fails to properly index into the array in the `pop_back` function allowing the
+reading of previously dropped or uninitialized memory.
+"""
+keywords = ["memory-corruption", "uninitialized-memory"]
+
+
+[versions]
+patched = []


### PR DESCRIPTION
Upstream issue: https://github.com/raviqqe/array-queue/issues/2

There's an indexing problem in the `pop_back()` function allowing a read from uninitialized or previously dropped memory. As demonstrated on the upstream issue, this can be leveraged for an arbitrary read and potentially write.