### PR TITLE
Add misaligned-access soundness issue for dync crate

### DIFF
--- a/crates/dync/RUSTSEC-0000-0000.toml
+++ b/crates/dync/RUSTSEC-0000-0000.toml
@@ -1,0 +1,14 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "dync"
+date = "2020-09-27"
+informational = "unsound"
+title = "VecCopy allows misaligned access to elements"
+url = "https://github.com/elrnv/dync/issues/4"
+description = """
+`VecCopy::data` is created as a Vec of u8 but can be used to store and retrieve
+elements of different types leading to misaligned access.
+"""
+
+[versions]
+patched = []


### PR DESCRIPTION
Upstream issue: https://github.com/elrnv/dync/issues/4

This is an unsoundness informational advisory. As shown under miri in the issue above, the `VecCopy` type in the `dync` crate allows for misaligned access as it treats everything as a `u8` underneath.