### PR TITLE
Add `rustsec` crate advisory for breaking changes to advisory format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RustSec Advisory Database
 
 [![Build Status][build-image]][build-link]
-![Maintained: Q3 2020][maintained-image]
+![Maintained: Q4 2020][maintained-image]
 [![Gitter Chat][gitter-image]][gitter-link]
 
 The RustSec Advisory Database is a repository of security advisories filed

--- a/crates/rustsec/RUSTSEC-0000-0000.toml
+++ b/crates/rustsec/RUSTSEC-0000-0000.toml
@@ -1,0 +1,20 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rustsec"
+title = "Obsolete versions of the `rustsec` crate do not support the new V3 advisory format"
+date = "2020-10-01"
+url = "https://github.com/RustSec/advisory-db/issues/414"
+description = """
+If you are seeing this message, you are running an obsolete version of
+`cargo-audit` which does not support the new V3 advisory format.
+These versions are end-of-life.
+
+This advisory is a notice that that it will soon be unable to parse the
+advisory database.
+
+Please upgrade `cargo-audit` to a newer release.
+"""
+
+[versions]
+unaffected = [">= 0.19.0"]
+patched = []


### PR DESCRIPTION
In theory this advisory should trigger this feature of `cargo-audit` which checks for advisories filed against the `rustsec` crate:

https://github.com/RustSec/cargo-audit/blob/783f221/src/auditor.rs#L178-L199

After merging, I will test with an older `cargo-audit` version to see if it has the intended effect.