### PR TITLE
RUSTSEC-2020-0011: rename `obsolete` to `yanked`

### DIFF
--- a/crates/plutonium/RUSTSEC-2020-0011.toml
+++ b/crates/plutonium/RUSTSEC-2020-0011.toml
@@ -2,7 +2,7 @@
 id = "RUSTSEC-2020-0011"
 package = "plutonium"
 date = "2020-04-23"
-obsolete = true
+yanked = true
 informational = "notice"
 title = "Library exclusively intended to obfuscate code."
 url = "https://docs.rs/plutonium/0.2.2/plutonium/"


### PR DESCRIPTION
This field name has changed