### PR TITLE
CI: use rustsec-admin v0.3.0-pre in assign-ids step

### DIFF
--- a/.github/workflows/assign-ids.yml
+++ b/.github/workflows/assign-ids.yml
@@ -15,20 +15,23 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cargo/bin
-        key: rustsec-admin-v0.2.1
+        key: rustsec-admin-v0.3.0-pre
 
     - name: Install rustsec-admin
       run: |
         if [ ! -f $HOME/.cargo/bin/rustsec-admin ]; then
-            cargo install rustsec-admin
+            cargo install rustsec-admin --vers 0.3.0-pre
         fi
+
     - name: Assign IDs
       id: assign
       run: |
         message=$(rustsec-admin assign-id --github-actions-output)
         echo "::set-output name=commit_message::${message}"
+
     - name: Lint advisories
       run: rustsec-admin lint
+
     - name: Create pull request
       uses: peter-evans/create-pull-request@v2
       with:


### PR DESCRIPTION
I imagine it might still be broken after this... will take a look if so