### PR TITLE
Add patched version for atom crate.

### DIFF
--- a/crates/atom/RUSTSEC-2020-0044.md
+++ b/crates/atom/RUSTSEC-2020-0044.md
@@ -7,7 +7,7 @@ informational = "unsound"
 url = "https://github.com/slide-rs/atom/issues/13"
 
 [versions]
-patched = []
+patched = [">= 0.3.6"]
 ```
 
 # Unsafe Send implementation in Atom allows data races


### PR DESCRIPTION
As per https://github.com/slide-rs/atom/issues/13#issuecomment-704110075, version `0.3.6` of atom now contains the fix for the soundness issue.