### PR TITLE
RUSTSEC-2019-0031: spin is maintained

### DIFF
--- a/crates/spin/RUSTSEC-2019-0031.md
+++ b/crates/spin/RUSTSEC-2019-0031.md
@@ -9,7 +9,7 @@ yanked = true
 
 [versions]
 patched = []
-unaffected = ["> 0.5.2"]
+unaffected = [">= 0"] # workaround for `yanked = true` not removing the advisory
 ```
 
 # spin is no longer actively maintained


### PR DESCRIPTION
We added `yanked = true` to the advisory, however it doesn't seem to behaving the intended effect (the query for unmaintained crates is probably failing to exclude the yanked advisories)

This is another workaround which makes the `unaffected` requirement match all versions. Hopefully this means that `spin` will stop being reported as unmaintained.