### PR TITLE
Add advisory for UB in crossbeam-channel 0.4.3

### DIFF
--- a/crates/crossbeam-channel/RUSTSEC-0000-0000.md
+++ b/crates/crossbeam-channel/RUSTSEC-0000-0000.md
@@ -1,0 +1,15 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "crossbeam-channel"
+date = "2020-06-26"
+url = "https://github.com/crossbeam-rs/crossbeam/pull/533"
+
+[versions]
+patched = [">= 0.4.4"]
+unaffected = ["< 0.4.3"]
+```
+
+# Undefined Behavior in bounded channel
+
+The affected version of this crate's the `bounded` channel incorrectly assumes that `Vec::from_iter` has allocated capacity that same as the number of iterator elements. `Vec::from_iter` does not actually guarantee that and may allocate extra memory. The destructor of the `bounded` channel reconstructs `Vec` from the raw pointer based on the incorrect assumes described above. This is unsound and causing deallocation with the incorrect capacity when `Vec::from_iter` has allocated different sizes with the number of iterator elements.

--- a/crates/crossbeam-channel/RUSTSEC-0000-0000.md
+++ b/crates/crossbeam-channel/RUSTSEC-0000-0000.md
@@ -4,7 +4,6 @@ id = "RUSTSEC-0000-0000"
 package = "crossbeam-channel"
 categories = ["memory-corruption"]
 date = "2020-06-26"
-informational = "unsound"
 url = "https://github.com/crossbeam-rs/crossbeam/pull/533"
 
 [versions]

--- a/crates/crossbeam-channel/RUSTSEC-0000-0000.md
+++ b/crates/crossbeam-channel/RUSTSEC-0000-0000.md
@@ -2,7 +2,9 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "crossbeam-channel"
+categories = ["memory-corruption"]
 date = "2020-06-26"
+informational = "unsound"
 url = "https://github.com/crossbeam-rs/crossbeam/pull/533"
 
 [versions]


### PR DESCRIPTION
The affected version of this crate's the `bounded` channel incorrectly assumes that `Vec::from_iter` has allocated capacity that same as the number of iterator elements. `Vec::from_iter` does not actually guarantee that and may allocate extra memory. The destructor of the `bounded` channel reconstructs `Vec` from the raw pointer based on the incorrect assumes described above. This is unsound and causing deallocation with the incorrect capacity when `Vec::from_iter` has allocated different sizes with the number of iterator elements.

Refs: https://github.com/crossbeam-rs/crossbeam/pull/533, https://github.com/crossbeam-rs/crossbeam/issues/539 (Both issues are mainly saying about crossbeam-queue, but crossbeam-queue including this UB, has not been released and only crossbeam-channel is affected.)