### PR TITLE
Assign RUSTSEC-2020-0052 to crossbeam-channel

### DIFF
--- a/crates/crossbeam-channel/RUSTSEC-2020-0052.md
+++ b/crates/crossbeam-channel/RUSTSEC-2020-0052.md
@@ -1,6 +1,6 @@
 ```toml
 [advisory]
-id = "RUSTSEC-0000-0000"
+id = "RUSTSEC-2020-0052"
 package = "crossbeam-channel"
 categories = ["memory-corruption"]
 date = "2020-06-26"


### PR DESCRIPTION
manually, since automatic assignment is broken