### PR TITLE
Add patch version for the unsoundness issue in dync

### DIFF
--- a/crates/dync/RUSTSEC-2020-0050.md
+++ b/crates/dync/RUSTSEC-2020-0050.md
@@ -7,10 +7,14 @@ informational = "unsound"
 url = "https://github.com/elrnv/dync/issues/4"
 
 [versions]
-patched = []
+patched = [">= 0.5.0"]
 ```
 
 # VecCopy allows misaligned access to elements
 
 `VecCopy::data` is created as a Vec of u8 but can be used to store and retrieve
 elements of different types leading to misaligned access.
+
+The issue was resolved in v0.5.0 by replacing data being stored by `Vec<u8>` with a custom managed
+pointer.  Elements are now stored and retrieved using types with proper alignment corresponding to
+original types.


### PR DESCRIPTION
The [soundness issue](https://github.com/elrnv/dync/issues/4) was resolved in a newly published version, which removes the need to store underlying data in `Vec<u8>` altogether.

The short explanation is that data is now represented using a void pointer and correctly manipulated using custom properly aligned types.

The presented example which found the issue is now included as a test which runs in CI.
Also remaining tests are now run through miri in CI.