### PR TITLE
Add CVE and GHSA to RUSTSEC-2020-0052

### DIFF
--- a/crates/crossbeam-channel/RUSTSEC-2020-0052.md
+++ b/crates/crossbeam-channel/RUSTSEC-2020-0052.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2020-0052"
 package = "crossbeam-channel"
+aliases = ["CVE-2020-15254", "GHSA-v5m7-53cv-f3hx"]
 categories = ["memory-corruption"]
 date = "2020-06-26"
 url = "https://github.com/crossbeam-rs/crossbeam/pull/533"


### PR DESCRIPTION
Refs: https://github.com/crossbeam-rs/crossbeam/security/advisories/GHSA-v5m7-53cv-f3hx, [CVE-2020-15254](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-15254)