### PR TITLE
dirs and directories crates are unmaintained

### DIFF
--- a/crates/directories/RUSTSEC-0000-0000.md
+++ b/crates/directories/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "directories"
+date = "2020-10-16"
+informational = "unmaintained"
+url = "https://github.com/dirs-dev/directories-rs"
+
+[versions]
+patched = []
+```
+
+# directories is unmaintained, use directoriess-next instead
+
+The `directories` crate is not maintained any more;
+use [`directories-next`](https://crates.io/crates/directories-next) instead.

--- a/crates/dirs/RUSTSEC-0000-0000.md
+++ b/crates/dirs/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "dirs"
+date = "2020-10-16"
+informational = "unmaintained"
+url = "https://github.com/dirs-dev/dirs-rs"
+
+[versions]
+patched = []
+```
+
+# dirs is unmaintained, use dirs-next instead
+
+The `dirs` crate is not maintained any more;
+use [`dirs-next`](https://crates.io/crates/dirs-next) instead.


### PR DESCRIPTION
Both of these crates have had their repos archived and unarchived a few times which prompted the forks. The forked crates look to be drop in replacements and I have not run into issues with them so far.