### PR TITLE
Add advisory for notable UB fix in libpulse-binding v2.6.0

### DIFF
--- a/crates/libpulse-binding/RUSTSEC-0000-0000.md
+++ b/crates/libpulse-binding/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libpulse-binding"
+date = "2019-03-10"
+url = "https://github.com/jnqnfe/pulse-binding-rust/commit/7fd282aef7787577c385aed88cb25d004b85f494"
+categories = ["memory-corruption"]
+informational = "unsound"
+
+[versions]
+patched = [">= 2.6.0"]
+```
+
+# Fix for UB in failure to catch panics crossing FFI boundaries
+
+Affected versions of this crate failed to catch panics crossing FFI boundaries via callbacks, which
+is a form of UB. This flaw was corrected by [this commit][1] which was included in version 2.6.0.
+
+[1]: https://github.com/jnqnfe/pulse-binding-rust/commit/7fd282aef7787577c385aed88cb25d004b85f494


### PR DESCRIPTION
I wasn't sure how to differentiate an UB entry from a security entry... The reporting guidelines clearly say that unsoundness/UB issues can be reported regardless of whether or not they are vulnerabilities. I think this one counts as a noteworthy issue.