### PR TITLE
Rename RUSTSEC-2020-0055 to RUSTSEC-2018-0020

### DIFF
--- a/crates/libpulse-binding/RUSTSEC-2018-0020.md
+++ b/crates/libpulse-binding/RUSTSEC-2018-0020.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "RUSTSEC-2018-0020"
+package = "libpulse-binding"
+date = "2018-12-22"
+url = "https://github.com/jnqnfe/pulse-binding-rust/security/advisories/GHSA-f56g-chqp-22m9"
+categories = ["memory-corruption"]
+
+[versions]
+patched = [">= 2.5.0"]
+unaffected = ["< 1.0.5"]
+```
+
+# Possible use-after-free with `proplist::Iterator`
+
+Affected versions contained a possible use-after-free issue with property list iteration
+due to a lack of a lifetime constraint tying the lifetime of a `proplist::Iterator` to the
+`Proplist` object for which it was created. This made it possible for users, without
+experiencing a compiler error/warning, to destroy the `Proplist` object before the iterator,
+thus destroying the underlying C object the iterator works upon, before the iterator may be
+finished with it.
+
+This impacts all versions of the crate before `2.5.0` back to `1.0.5`. Before version
+`1.0.5` the function that produces the iterator was broken to the point of being useless.

--- a/crates/libpulse-binding/RUSTSEC-2020-0055.md
+++ b/crates/libpulse-binding/RUSTSEC-2020-0055.md
@@ -2,17 +2,15 @@
 [advisory]
 id = "RUSTSEC-2020-0055"
 package = "libpulse-binding"
-date = "2018-12-22"
-url = "https://github.com/jnqnfe/pulse-binding-rust/security/advisories/GHSA-f56g-chqp-22m9"
-categories = ["memory-corruption"]
+date = "2020-10-21"
+url = "https://rustsec.org/advisories/RUSTSEC-2018-0012.html"
+yanked = true
 
 [versions]
-patched = [">= 2.5.0"]
-unaffected = ["< 1.0.5"]
+patched = []
+unaffected = ["> 0"]
 ```
 
-# Possible use-after-free with `proplist::Iterator`
+# Please see RUSTSEC-2018-0020
 
-Affected versions contained a possible use-after-free issue with property list iteration due to a lack of a lifetime constraint tying the lifetime of a `proplist::Iterator` to the `Proplist` object for which it was created. This made it possible for users, without experiencing a compiler error/warning, to destroy the `Proplist` object before the iterator, thus destroying the underlying C object the iterator works upon, before the iterator may be finished with it.
-
-This impacts all versions of the crate before 2.5.0 back to 1.0.5. Before version 1.0.5 the function that produces the iterator was broken to the point of being useless.
+This vulnerability was misfiled under the wrong year and has been withdrawn.


### PR DESCRIPTION
It was accidentally filed under the wrong year.