### PR TITLE
CI: bump rustsec-admin to v0.3.0-pre2

### DIFF
--- a/.github/workflows/assign-ids.yml
+++ b/.github/workflows/assign-ids.yml
@@ -15,12 +15,12 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cargo/bin
-        key: rustsec-admin-v0.3.0-pre
+        key: rustsec-admin-v0.3.0-pre2
 
     - name: Install rustsec-admin
       run: |
         if [ ! -f $HOME/.cargo/bin/rustsec-admin ]; then
-            cargo install rustsec-admin --vers 0.3.0-pre
+            cargo install rustsec-admin --vers 0.3.0-pre2
         fi
 
     - name: Assign IDs

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,12 +16,12 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cargo/bin
-        key: rustsec-admin-v0.3.0-pre
+        key: rustsec-admin-v0.3.0-pre2
 
     - name: Install rustsec-admin
       run: |
         if [ ! -f $HOME/.cargo/bin/rustsec-admin ]; then
-            cargo install rustsec-admin --vers 0.3.0-pre
+            cargo install rustsec-admin --vers 0.3.0-pre2
         fi
 
     - name: Lint advisories


### PR DESCRIPTION
This version has the old TOML advisories fail lint, and also hopefully fixes automatic ID assignment.