### PR TITLE
Add unmaintained crate advisory for `block-cipher`

### DIFF
--- a/crates/block-cipher/RUSTSEC-0000-0000.md
+++ b/crates/block-cipher/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "block-cipher"
+date = "2020-10-15"
+informational = "unmaintained"
+url = "https://github.com/RustCrypto/traits/pull/337"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# crate has been renamed to `cipher`
+
+This crate has been renamed from `block-cipher` to `cipher`.
+
+The new repository location is at:
+
+<https://github.com/RustCrypto/traits/tree/master/cipher>


### PR DESCRIPTION
It's been renamed to `cipher`.