### PR TITLE
Unyank RUSTSEC-2020-0011

### DIFF
--- a/crates/plutonium/RUSTSEC-2020-0011.md
+++ b/crates/plutonium/RUSTSEC-2020-0011.md
@@ -4,8 +4,7 @@ id = "RUSTSEC-2020-0011"
 package = "plutonium"
 date = "2020-04-23"
 informational = "notice"
-url = "https://docs.rs/plutonium/0.2.2/plutonium/"
-yanked = true
+url = "https://docs.rs/plutonium"
 
 [versions]
 patched = []


### PR DESCRIPTION
This advisory is featured in the `plutonium` rustdoc:

https://docs.rs/plutonium/

It'd be a shame to have the link 404.