### PR TITLE
RUSTSEC-2020-0015: use wildcards in version req

### DIFF
--- a/crates/openssl-src/RUSTSEC-2020-0015.md
+++ b/crates/openssl-src/RUSTSEC-2020-0015.md
@@ -8,8 +8,8 @@ date = "2020-04-25"
 url = "https://www.openssl.org/news/secadv/20200421.txt"
 
 [versions]
-patched = [">= 111.9.0+1.1.1g"]
-unaffected = ["< 111.6.0+1.1.1d"]
+patched = [">= 111.9.*"]
+unaffected = ["< 111.6.*"]
 ```
 
 # Crash causing Denial of Service attack


### PR DESCRIPTION
`semver` v0.11 is having trouble parsing these requirements.