### PR TITLE
RUSTSEC-2020-0015: remove wildcards

### DIFF
--- a/crates/openssl-src/RUSTSEC-2020-0015.md
+++ b/crates/openssl-src/RUSTSEC-2020-0015.md
@@ -8,8 +8,8 @@ date = "2020-04-25"
 url = "https://www.openssl.org/news/secadv/20200421.txt"
 
 [versions]
-patched = [">= 111.9.*"]
-unaffected = ["< 111.6.*"]
+patched = [">= 111.9"]
+unaffected = ["< 111.6"]
 ```
 
 # Crash causing Denial of Service attack


### PR DESCRIPTION
They're breaking the parser:

https://github.com/RustSec/rustsec-crate/pull/244/checks?check_run_id=1305962917