### PR TITLE
Add advisory for data race fix in futures-util

### DIFF
--- a/crates/futures-util/RUSTSEC-0000-0000.md
+++ b/crates/futures-util/RUSTSEC-0000-0000.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "futures-util"
+date = "2020-10-22"
+url = "https://github.com/rust-lang/futures-rs/issues/2239"
+categories = ["memory-corruption"]
+keywords = ["concurrency", "memory-corruption", "memory-management"]
+
+[affected]
+functions = { "futures_util::lock::MutexGuard::map" = [">= 0.3.2"] }
+
+[versions]
+patched = [">= 0.3.7"]
+unaffected = ["< 0.3.2"]
+```
+
+# MutexGuard::map can cause a data race in safe code
+Affected versions of the crate had a Send/Sync implementation for MappedMutexGuard that only considered variance on T, while MappedMutexGuard dereferenced to U.
+
+This could of led to data races in safe Rust code when a closure used in MutexGuard::map() returns U that is unrelated to T.
+
+The issue was fixed by fixing `Send` and `Sync` implementations, and by adding a `PhantomData<&'a mut U>` marker to the `MappedMutexGuard` type to tell the compiler that the guard is over
+U too.


### PR DESCRIPTION
Adds an advisory to cover a [recently discovered data race](https://github.com/rust-lang/futures-rs/issues/2239) in `future-util`'s `MappedMutexGuard` API.

1/4 of https://github.com/RustSec/advisory-db/issues/454