### PR TITLE
Add advisory for use-after-free in futures_task::waker

### DIFF
--- a/crates/futures-task/RUSTSEC-0000-0000.md
+++ b/crates/futures-task/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "futures-task"
+date = "2020-09-04"
+url = "https://github.com/rust-lang/futures-rs/pull/2206"
+categories = ["code-execution", "memory-corruption"]
+keywords = ["use-after-free", "arbitrary code execution", "memory-corruption", "memory-management"]
+
+[versions]
+patched = [">= 0.3.6"]
+unaffected = ["<= 0.2.1"]
+
+[affected]
+functions = { "futures_task::waker" = [">= 0.3.0"] }
+```
+
+# futures_task::waker may cause a use-after-free if used on a type that isn't 'static
+
+Affected versions of the crate did not properly implement a `'static` lifetime bound on the `waker` function.
+This resulted in a use-after-free if `Waker::wake()` is called after original data had been dropped.
+
+The flaw was corrected by adding `'static` lifetime bound to the data `waker` takes.


### PR DESCRIPTION
Adds an advisory to cover a potential use-after-free  in future-task's `waker` API that never received an advisory when it was fixed a month ago.

Edit: The workspace of `futures` threw me off with the original crate name.

2/4 of #454