### PR TITLE
Add advisory for potential null pointer deref in futures-task

### DIFF
--- a/crates/futures-task/RUSTSEC-0000-0000.md
+++ b/crates/futures-task/RUSTSEC-0000-0000.md
@@ -1,0 +1,32 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "futures-task"
+date = "2020-05-03"
+url = "https://github.com/rust-lang/futures-rs/issues/2091"
+categories = ["denial-of-service"]
+keywords = ["NULL pointer dereference", "memory-management"]
+[versions]
+patched = [">= 0.3.5"]
+[affected]
+functions = { "futures_task::noop_waker_ref" = [">= 0.3.0"] }
+```
+
+# futures_task::noop_waker_ref can segfault due to dereferencing a NULL pointer
+
+Affected versions of the crate used a `UnsafeCell` in thread-local storage to return a noop waker reference,
+assuming that the reference would never be returned from another thread.
+
+This resulted in a segmentation fault crash if `Waker::wake_by_ref()` was called on a waker returned from another thread due to 
+it attempting to dereference a pointer that wasn't accesible from the main thread.
+
+Reproduction Example (from issue):
+```rust
+use futures_task::noop_waker_ref;
+fn main() {
+    let waker = std::thread::spawn(|| noop_waker_ref()).join().unwrap();
+    waker.wake_by_ref();
+}
+```
+
+The flaw was corrected by using a `OnceCell::Lazy<>` wrapper around the noop waker instead of thread-local storage.


### PR DESCRIPTION
Adds an advisory for a [potential sefault due to a null pointer dereference](https://github.com/rust-lang/futures-rs/pull/2095) in futures-task when the waker  from `noop_waker_ref()` has `wake_by_ref` called on it from a different thread then it was created on. 

An advisory was never added for it back when it was fixed in March.

3/4 of #454 