### PR TITLE
Add advisory for unsound Sync impl on FuturesUnordered in futures-util

### DIFF
--- a/crates/futures-util/RUSTSEC-0000-0000.md
+++ b/crates/futures-util/RUSTSEC-0000-0000.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "futures-util"
+date = "2020-01-24"
+url = "https://github.com/rust-lang/futures-rs/issues/2050"
+categories = ["memory-corruption"]
+keywords = ["concurrency", "memory-corruption", "memory-management"]
+
+[affected]
+functions = { "futures_util::stream::FuturesUnordered" = [">= 0.3.0"] }
+
+[versions]
+patched = [">= 0.3.2"]
+unaffected = ["< 0.3.0"]
+```
+
+# Improper `Sync` implementation on `FuturesUnordered` in futures-utils can cause data corruption
+Affected versions of the crate had an unsound `Sync` implementation on the `FuturesUnordered` structure, which used a `Cell` for
+interior mutablity without any code to handle synchronized access to the underlying task list's length and head safely.
+
+This could of lead to data corruption since two threads modifying the list at once could see incorrect values due to the lack
+of access synchronization.
+
+The issue was fixed by adding access synchronization code around insertion of tasks into the list.


### PR DESCRIPTION
Adds an advisory for an [unsound `Sync` implementation](https://github.com/rust-lang/futures-rs/pull/2054) on `futures_util::stream::FuturesUnordered` that could cause memory corruption when insertions occur from >1 thread at the same time.

No advisory was added for this issue when it was originally fixed back in January this year.

4/4 of #454 
Closes #454