### PR TITLE
Add unmaintained crate advisory for `ffi_utils`

### DIFF
--- a/crates/ffi_utils/RUSTSEC-0000-0000.md
+++ b/crates/ffi_utils/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "ffi_utils"
+date = "2020-11-02"
+informational = "unmaintained"
+url = "https://github.com/maidsafe/sn_ffi_utils/pull/45"
+[versions]
+patched = []
+unaffected = []
+```
+
+# crate has been renamed to `sn_ffi_utils`
+
+This crate has been renamed from `ffi_utils` to `sn_ffi_utils`.
+
+The new repository location is:
+
+<https://github.com/maidsafe/sn_ffi_utils>


### PR DESCRIPTION
It's been renamed to `sn_ffi_utils`