### PR TITLE
Add unmaintained crate advisory for `fake_clock`

### DIFF
--- a/crates/fake_clock/RUSTSEC-0000-0000.md
+++ b/crates/fake_clock/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "fake_clock"
+date = "2020-11-02"
+informational = "unmaintained"
+url = "https://github.com/maidsafe/sn_fake_clock/pull/38"
+[versions]
+patched = []
+unaffected = []
+```
+
+# crate has been renamed to `sn_fake_clock`
+
+This crate has been renamed from `fake_clock` to `sn_fake_clock`.
+
+The new repository location is:
+
+<https://github.com/maidsafe/sn_fake_clock>


### PR DESCRIPTION
It's been renamed to `sn_fake_clock`