### PR TITLE
Add unmaintained crate advisory for `safe_bindgen`

### DIFF
--- a/crates/safe_bindgen/RUSTSEC-0000-0000.md
+++ b/crates/safe_bindgen/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "safe_bindgen"
+date = "2020-11-02"
+informational = "unmaintained"
+url = "https://github.com/maidsafe/sn_bindgen/pull/67"
+[versions]
+patched = []
+unaffected = []
+```
+
+# crate has been renamed to `sn_bindgen`
+
+This crate has been renamed from `safe_bindgen` to `sn_bindgen`.
+
+The new repository location is:
+
+<https://github.com/maidsafe/sn_bindgen>


### PR DESCRIPTION
It's been renamed to `sn_bindgen`