### PR TITLE
Add unmaintained crate advisory for `safe-nd`

### DIFF
--- a/crates/safe-nd/RUSTSEC-0000-0000.md
+++ b/crates/safe-nd/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "safe-nd"
+date = "2020-11-02"
+informational = "unmaintained"
+url = "https://github.com/maidsafe/sn_data_types/pull/218"
+[versions]
+patched = []
+unaffected = []
+```
+
+# crate has been renamed to `safe-nd`
+
+This crate has been renamed from `safe-nd` to `sn_data_types`.
+
+The new repository location is:
+
+<https://github.com/maidsafe/sn_data_types>


### PR DESCRIPTION
It's been renamed to `sn_data_types`