### PR TITLE
Add unmaintained crate advisory for `quic-p2p`

### DIFF
--- a/crates/quic-p2p/RUSTSEC-0000-0000.md
+++ b/crates/quic-p2p/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "quic-p2p"
+date = "2020-11-02"
+informational = "unmaintained"
+url = "https://github.com/maidsafe/qp2p/pull/141"
+[versions]
+patched = []
+unaffected = []
+```
+
+# crate has been renamed to `qp2p`
+
+This crate has been renamed from `quic-p2p` to `qp2p`.
+
+The new repository location is:
+
+<https://github.com/maidsafe/qp2p>


### PR DESCRIPTION
It's been renamed to `qp2p`