### PR TITLE
Unexpected panic in multihash `from_slice` parsing code

### DIFF
--- a/crates/multihash/RUSTSEC-0000-0000.md
+++ b/crates/multihash/RUSTSEC-0000-0000.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "multihash"
-date = "2020-11-09"
+date = "2020-11-08"
 url = "https://github.com/multiformats/rust-multihash/pull/72"
 categories = ["denial-of-service"]
 keywords = ["parsing", "panic", "untrusted data"]

--- a/crates/multihash/RUSTSEC-0000-0000.md
+++ b/crates/multihash/RUSTSEC-0000-0000.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "multihash"
+date = "2020-11-09"
+url = "https://github.com/multiformats/rust-multihash/pull/72"
+categories = ["denial-of-service"]
+keywords = ["parsing", "panic", "untrusted data"]
+
+[affected.functions]
+"digests::MultihashRefGeneric<T>::from_slice" = ["< 0.11.3"]
+"digests::MultihashGeneric<T>::from_bytes" = ["< 0.11.3"]
+
+[versions]
+patched = [">= 0.11.3"]
+unaffected = []
+```
+
+# Unexpected panic in multihash `from_slice` parsing code
+
+In versions prior 0.11.3 it's possible to make `from_slice` panic by feeding it certain malformed input.
+It's never documented that `from_slice` (and `from_bytes` which wraps it) can panic, and its' return type (`Result<Self, DecodeError>`) suggests otherwise.
+
+In practice, `from_slice`/`from_bytes` is frequently used in networking code (for example [in rust-libp2p](https://github.com/libp2p/rust-libp2p/blob/7b415d5e7040e45c541f76f2c409e63d4d3249c6/core/src/peer_id.rs#L89)) and is being called with unsanitized data from untrusted sources.
+This can allow attackers to cause DoS by causing an unexpected `panic` in the network client's code.

--- a/crates/multihash/RUSTSEC-0000-0000.md
+++ b/crates/multihash/RUSTSEC-0000-0000.md
@@ -8,8 +8,8 @@ categories = ["denial-of-service"]
 keywords = ["parsing", "panic", "untrusted data"]
 
 [affected.functions]
-"digests::MultihashRefGeneric<T>::from_slice" = ["< 0.11.3"]
-"digests::MultihashGeneric<T>::from_bytes" = ["< 0.11.3"]
+"multihash::digests::MultihashRefGeneric<T>::from_slice" = ["< 0.11.3"]
+"multihash::digests::MultihashGeneric<T>::from_bytes" = ["< 0.11.3"]
 
 [versions]
 patched = [">= 0.11.3"]


### PR DESCRIPTION
This has been fixed for a while now (see the [url from the report](https://github.com/multiformats/rust-multihash/pull/72)), but it only recently occurred to us that it can cause a remotely-triggered DoS in libp2p and other consumers.

So I put today into the `date` field; feel free to correct me, a fixed version of `multihash` has been released on August 29, 2020.