### PR TITLE
RUSTSEC-2020-0068: remove parameters from affected functions

### DIFF
--- a/crates/multihash/RUSTSEC-2020-0068.md
+++ b/crates/multihash/RUSTSEC-2020-0068.md
@@ -8,8 +8,8 @@ categories = ["denial-of-service"]
 keywords = ["parsing", "panic", "untrusted data"]
 
 [affected.functions]
-"multihash::digests::MultihashRefGeneric<T>::from_slice" = ["< 0.11.3"]
-"multihash::digests::MultihashGeneric<T>::from_bytes" = ["< 0.11.3"]
+"multihash::digests::MultihashRefGeneric::from_slice" = ["< 0.11.3"]
+"multihash::digests::MultihashGeneric::from_bytes" = ["< 0.11.3"]
 
 [versions]
 patched = [">= 0.11.3"]


### PR DESCRIPTION
It's breaking `cargo-deny` which hasn't updated to the new parser yet