### PR TITLE
Report soundness bug with concurrency in futures-intrusive

### DIFF
--- a/crates/futures-intrusive/RUSTSEC-0000-0000.md
+++ b/crates/futures-intrusive/RUSTSEC-0000-0000.md
@@ -1,0 +1,29 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "futures-intrusive"
+date = "2020-10-31"
+url = "https://github.com/Matthias247/futures-intrusive/issues/53"
+categories = ["memory-corruption"]
+keywords = ["concurrency"]
+informational = "unsound"
+
+[versions]
+patched = []
+```
+
+# GenericMutexGuard allows data races of non-Sync types across threads
+
+`GenericMutexGuard<T>` was given the `Sync` auto trait as long as `T` is `Send`
+due to its contained members. However, since the guard is supposed to represent
+an **acquired lock** and allows concurrent access to the underlying data from
+different threads, it should only be `Sync` when the underlying data is.
+
+This is a soundness issue and allows data races, potentially leading to crashes
+and segfaults from safe Rust code.
+
+The flaw was corrected by adding a `T: Send + Sync` bound for
+`GenericMutexGuard`'s `Sync` trait.
+
+This bug is [similar to one](https://github.com/rust-lang/rust/issues/41622) in
+`std::sync::Mutex`.


### PR DESCRIPTION
Upstream issue: https://github.com/Matthias247/futures-intrusive/issues/53

This is a soundness issue with a `Sync` trait that allows data races with the lock guard object. Very similar to one reported in the standard library's [own mutex guard](https://github.com/rust-lang/rust/issues/41622).