### PR TITLE
Rename `references` fields to `related`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ keywords = ["ssl", "mitm"]
 # Request a CVE for your RustSec vulns: https://iwantacve.org/
 #aliases = ["CVE-2018-XXXX"]
 
-# References to related vulnerabilities (optional)
+# Related vulnerabilities (optional)
 # e.g. CVE for a C library wrapped by a -sys crate)
-#references = ["CVE-2018-YYYY", "CVE-2018-ZZZZ"]
+#related = ["CVE-2018-YYYY", "CVE-2018-ZZZZ"]
 
 # Optional: metadata which narrows the scope of what this advisory affects
 [affected]

--- a/crates/hyper/RUSTSEC-2016-0002.md
+++ b/crates/hyper/RUSTSEC-2016-0002.md
@@ -2,11 +2,11 @@
 [advisory]
 id = "RUSTSEC-2016-0002"
 package = "hyper"
-aliases = ["CVE-2016-10932"]
-categories = ["crypto-failure"]
 date = "2016-05-09"
+aliases = ["CVE-2016-10932"]
+related = ["RUSTSEC-2016-0001"]
+categories = ["crypto-failure"]
 keywords = ["ssl", "mitm"]
-references = ["RUSTSEC-2016-0001"]
 url = "https://github.com/hyperium/hyper/blob/master/CHANGELOG.md#v094-2016-05-09"
 
 [affected]

--- a/crates/slice-deque/RUSTSEC-2019-0002.md
+++ b/crates/slice-deque/RUSTSEC-2019-0002.md
@@ -2,10 +2,11 @@
 [advisory]
 id = "RUSTSEC-2019-0002"
 package = "slice-deque"
-aliases = ["CVE-2019-15543"]
 date = "2019-05-07"
+aliases = ["CVE-2019-15543"]
+related = ["RUSTSEC-2018-0008"]
 keywords = ["memory-corruption", "rce"]
-references = ["RUSTSEC-2018-0008"]
+
 url = "https://github.com/gnzlbg/slice_deque/issues/57"
 
 [versions]

--- a/crates/tough/RUSTSEC-2020-0024.md
+++ b/crates/tough/RUSTSEC-2020-0024.md
@@ -2,9 +2,9 @@
 [advisory]
 id = "RUSTSEC-2020-0024"
 package = "tough"
-aliases = ["CVE-2020-15093", "GHSA-5q2r-92f9-4m49"]
 date = "2020-07-09"
-references = ["CVE-2020-6174"]
+aliases = ["CVE-2020-15093", "GHSA-5q2r-92f9-4m49"]
+related = ["CVE-2020-6174"]
 url = "https://github.com/awslabs/tough/security/advisories/GHSA-5q2r-92f9-4m49"
 
 [versions]


### PR DESCRIPTION
This frees up `references` to be used for tracking multiple URLs with additional information.

See also: RustSec/advisory-db#429