### PR TITLE
Fix patched version of RUSTSEC-2019-0037

### DIFF
--- a/crates/pnet/RUSTSEC-2019-0037.md
+++ b/crates/pnet/RUSTSEC-2019-0037.md
@@ -8,9 +8,9 @@ date = "2019-06-11"
 keywords = ["segfault"]
 url = "https://github.com/libpnet/libpnet/issues/449"
 [affected.functions]
-"pnet::transport::IcmpTransportChannelIterator" = ["< 0.26.0"]
+"pnet::transport::IcmpTransportChannelIterator" = ["< 0.27.2"]
 [versions]
-patched = [">= 0.26.0"]
+patched = [">= 0.27.2"]
 ```
 
 # Compiler optimisation for next_with_timeout in pnet::transport::IcmpTransportChannelIterator flaws to SEGFAULT


### PR DESCRIPTION
See https://github.com/RustSec/advisory-db/pull/335#discussion_r531670273