### PR TITLE
Add unmaintained crate advisory for `routing`

### DIFF
--- a/crates/routing/RUSTSEC-0000-0000.md
+++ b/crates/routing/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "routing"
+date = "2020-11-02"
+informational = "unmaintained"
+url = "https://github.com/maidsafe/sn_routing/pull/2190"
+[versions]
+patched = []
+unaffected = []
+```
+
+# crate has been renamed to `sn_routing`
+
+This crate has been renamed from `routing` to `sn_routing`.
+
+The new repository location is:
+
+<https://github.com/maidsafe/sn_routing>


### PR DESCRIPTION
Has been renamed to `sn_routing`.