### PR TITLE
Add advisory on net2 making invalid memory assumptions

### DIFF
--- a/crates/net2/RUSTSEC-0000-0000.md
+++ b/crates/net2/RUSTSEC-0000-0000.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "net2"
+date = "2020-11-07"
+url = "https://github.com/deprecrated/net2-rs/issues/105"
+keywords = ["memory", "layout", "cast"]
+
+[versions]
+patched = [">= 0.2.36"]
+```
+
+# `net2` invalidly assumes the memory layout of std::net::SocketAddr
+
+The [`net2`](https://crates.io/crates/net2) crate has converted `std::net::SocketAddr`
+instances into C `sockaddr` pointers simply by casting the pointer. This will cause
+invalid memory access if/when the standard library ever changes the implementation.
+No warnings or errors will be emitted once the change happens.
+
+Please stop using `net2` completely (it's deprecated, use `socket2`) or at least
+upgrade to version `0.2.36` where the socket address conversion is done safely.

--- a/crates/net2/RUSTSEC-0000-0000.md
+++ b/crates/net2/RUSTSEC-0000-0000.md
@@ -5,6 +5,7 @@ package = "net2"
 date = "2020-11-07"
 url = "https://github.com/deprecrated/net2-rs/issues/105"
 keywords = ["memory", "layout", "cast"]
+informational = "unsound"
 
 [versions]
 patched = [">= 0.2.36"]

--- a/crates/net2/RUSTSEC-0000-0000.md
+++ b/crates/net2/RUSTSEC-0000-0000.md
@@ -12,10 +12,13 @@ patched = [">= 0.2.36"]
 
 # `net2` invalidly assumes the memory layout of std::net::SocketAddr
 
-The [`net2`](https://crates.io/crates/net2) crate has converted `std::net::SocketAddr`
-instances into C `sockaddr` pointers simply by casting the pointer. This will cause
-invalid memory access if/when the standard library ever changes the implementation.
-No warnings or errors will be emitted once the change happens.
+The [`net2`](https://crates.io/crates/net2) crate has assumed `std::net::SocketAddrV4`
+and `std::net::SocketAddrV6` have the same memory layout as the system C representation
+`sockaddr`. It has simply casted the pointers to convert the socket addresess to the
+system representation. The standard library does not say anything about the memory
+layout, and this will cause invalid memory access if the standard library
+changes the implementation. No warnings or errors will be emitted once the
+change happens.
 
-Please stop using `net2` completely (it's deprecated, use `socket2`) or at least
+Please stop using `net2` completely (it is deprecated, use `socket2`) or at least
 upgrade to version `0.2.36` where the socket address conversion is done safely.

--- a/crates/net2/RUSTSEC-0000-0000.md
+++ b/crates/net2/RUSTSEC-0000-0000.md
@@ -20,6 +20,3 @@ system representation. The standard library does not say anything about the memo
 layout, and this will cause invalid memory access if the standard library
 changes the implementation. No warnings or errors will be emitted once the
 change happens.
-
-Please stop using `net2` completely (it is deprecated, use `socket2`) or at least
-upgrade to version `0.2.36` where the socket address conversion is done safely.


### PR DESCRIPTION
Hello! This "vulnerability" is not exploitable right now. But it will cause invalid memory access when the standard library changes how `SocketAddr` is implemented. See https://github.com/rust-lang/rust/pull/78802 for details.

I'm aiming to follow this advisory up with very similar ones on `socket2`, `miow` and `mio` since they contain more or less the exact same problem. But I will start with one until we have agreed on the content and format since they will likely be very similar. I can add all the others to the same PR if you prefer that.

I was not sure what `categories` to apply to this, if any. Since it's a little bit unclear how this could be exploitable in the future. It more or less depends on what the standard library changes the memory representation into. But since it was optional I left it out.