### PR TITLE
Add advisory on socket2 about casting SocketAddr

### DIFF
--- a/crates/socket2/RUSTSEC-0000-0000.md
+++ b/crates/socket2/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "socket2"
+date = "2020-11-06"
+url = "https://github.com/rust-lang/socket2-rs/issues/119"
+keywords = ["memory", "layout", "cast"]
+informational = "unsound"
+
+[versions]
+patched = [">= 0.3.16"]
+```
+
+# `socket2` invalidly assumes the memory layout of std::net::SocketAddr
+
+The [`socket2`](https://crates.io/crates/socket2) crate has assumed `std::net::SocketAddrV4`
+and `std::net::SocketAddrV6` have the same memory layout as the system C representation
+`sockaddr`. It has simply casted the pointers to convert the socket addresses to the
+system representation. The standard library does not say anything about the memory
+layout, and this will cause invalid memory access if the standard library
+changes the implementation. No warnings or errors will be emitted once the
+change happens.


### PR DESCRIPTION
Same thing as #503 

I found I had spelled "addresses" wrong in the last advisory on `net2`. But since you said the CI might not handle two crates at the same time I did not fix it here and now.