### PR TITLE
Add advisory on mio SocketAddr casting

### DIFF
--- a/crates/mio/RUSTSEC-0000-0000.md
+++ b/crates/mio/RUSTSEC-0000-0000.md
@@ -9,6 +9,7 @@ informational = "unsound"
 
 [versions]
 patched = [">= 0.7.6"]
+unaffected = ["< 0.7.0"]
 ```
 
 # `mio` invalidly assumes the memory layout of std::net::SocketAddr

--- a/crates/mio/RUSTSEC-0000-0000.md
+++ b/crates/mio/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "mio"
+date = "2020-11-02"
+url = "https://github.com/tokio-rs/mio/issues/1386"
+keywords = ["memory", "layout", "cast"]
+informational = "unsound"
+
+[versions]
+patched = [">= 0.7.6"]
+```
+
+# `mio` invalidly assumes the memory layout of std::net::SocketAddr
+
+The [`mio`](https://crates.io/crates/mio) crate has assumed `std::net::SocketAddrV4`
+and `std::net::SocketAddrV6` have the same memory layout as the system C representation
+`sockaddr`. It has simply casted the pointers to convert the socket addresses to the
+system representation. The standard library does not say anything about the memory
+layout, and this will cause invalid memory access if the standard library
+changes the implementation. No warnings or errors will be emitted once the
+change happens.


### PR DESCRIPTION
Same as #507 

I realized one thing: When `patched` is filled in this way, it will only warn people with `0.7.x` versions in their lockfiles where `x<6`, right? It won't start alarming users of `mio 0.6` or other minor releases?