### PR TITLE
Make the example advisory more descriptive

### DIFF
--- a/EXAMPLE_ADVISORY.md
+++ b/EXAMPLE_ADVISORY.md
@@ -34,8 +34,8 @@ of the vulnerability, will be converted into HTML and rendered at
 
 A well structured advisory will include information like:
 
-Affected versions of this crate did not properly X.
+Affected versions of this crate did not properly check for integer overflow when allocating a buffer in `MyBuffer::with_capacity()` (bug description/location/root cause).
 
-This allows an attacker to Y.
- 
-The flaw was corrected by Z.
+This can result in a memory corruption (consequence of the bug) when large integer is given to the parameter (trigger condition).
+
+The flaw was corrected in commit abc123 by using `saturating_mul()` when calculating the buffer size (fix description).


### PR DESCRIPTION
Perhaps we could be a little more descriptive about the desired properties of good advisories in the example.

The main motivation for this PR is an observation of a few cases where people interpret the last line as to give credits to the bug reporter in advisories, which I believe unintentional.
- [RUSTSEC-2019-0021](https://github.com/RustSec/advisory-db/blob/master/crates/linea/RUSTSEC-2019-0021.md)
- [RUSTSEC-2019-0035](https://github.com/RustSec/advisory-db/blob/master/crates/rand_core/RUSTSEC-2019-0035.md)
- [RUSTSEC-2020-0069](https://github.com/RustSec/advisory-db/blob/master/crates/lettre/RUSTSEC-2020-0069.md)

These are the properties that I can think of right now. Please provide feedback and suggestions. And as always, thank you for all the maintenance effort :)