### PR TITLE
Minor changes to wording of RUSTSEC-2020-0082

### DIFF
--- a/crates/ordered-float/RUSTSEC-2020-0082.md
+++ b/crates/ordered-float/RUSTSEC-2020-0082.md
@@ -14,10 +14,10 @@ unaffected = ["< 0.2.2"]
 [affected]
 ```
 
-# ordered_float:NotNan may contain NaN after unwinding in assignment operators
+# ordered_float:NotNan may contain NaN after panic in assignment operators
 
 After using an assignment operators such as `NotNan::add_assign`, `NotNan::mul_assign`, etc., it was possible for the resulting `NotNan` value to contain a `NaN`.  This could cause undefined behavior in safe code, because the safe `NotNan::cmp` method contains internal unsafe code that assumes the value is never `NaN`.  (It could also cause undefined behavior in third-party unsafe code that makes the same assumption, as well as logic errors in safe code.)
 
-This was mitigated starting in version 0.4.0, by panicking if the assigned value is NaN.  However, in affected versions from 0.4.0 onward, code that continued after using unwinding to catch this panic could still observe the invalid value and trigger undefined behavior.
+This was mitigated starting in version 0.4.0, by panicking if the assigned value is NaN.  However, in affected versions from 0.4.0 onward, code that uses the `NotNan` value during unwinding, or that continues after catching the panic, could still observe the invalid value and trigger undefined behavior.
 
 The flaw is fully corrected in versions 1.1.1 and 2.0.1, by ensuring that the assignment operators panic without modifying the operand, if the result would be `NaN`.


### PR DESCRIPTION
Follow-up to #514.  Clarify that UB can happen during unwinding, and not only after catching a panic.