### PR TITLE
try-mutex: TryMutex<T> allows sending non-Send type across threads

### DIFF
--- a/crates/try-mutex/RUSTSEC-0000-0000.md
+++ b/crates/try-mutex/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "try-mutex"
+date = "2020-11-17"
+url = "https://github.com/mpdn/try-mutex/issues/2"
+
+[versions]
+patched = [">= 0.3.0"]
+```
+
+# TryMutex<T> allows sending non-Send type across threads
+
+Affected versions of this crate unconditionally implemented Sync trait for `TryMutex<T>` type.
+
+This allows users to put non-Send `T` type in `TryMutex` and send it to another thread, which can cause a data race.
+
+The flaw was corrected in the 0.3.0 release by adding `T: Send` bound for the Sync trait implementation.


### PR DESCRIPTION
Original issue report: https://github.com/mpdn/try-mutex/issues/2