### PR TITLE
magnetic: MPMCConsumer/Producer allows sending non-Send type across threads

### DIFF
--- a/crates/magnetic/RUSTSEC-0000-0000.md
+++ b/crates/magnetic/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "magnetic"
+date = "2020-11-29"
+url = "https://github.com/johnshaw/magnetic/issues/9"
+
+[versions]
+patched = [">= 2.0.1"]
+```
+
+# MPMCConsumer/Producer allows sending non-Send type across threads
+
+Affected versions of this crate unconditionally implemented `Sync` and `Send` traits for `MPMCConsumer` and `MPMCProducer` types.
+
+This allows users to send types that do not implement `Send` trait across thread boundaries, which can cause a data race.
+
+The flaw was corrected in the 2.0.1 release by adding `T: Send` bound to affected Sync/Send trait implementations.


### PR DESCRIPTION
Original issue report: https://github.com/johnshaw/magnetic/issues/9