### PR TITLE
Add advisory for data race in thex

### DIFF
--- a/crates/thex/RUSTSEC-0000-0000.md
+++ b/crates/thex/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "thex"
+date = "2020-12-08"
+categories = ["memory-corruption"]
+keywords = ["concurrency"]
+
+[versions]
+patched = []
+```
+
+# Thex<T> allows data races of non-Send types across threads
+
+`thex::Thex<T>` implements `Sync` for all types `T`. However, it is missing a
+bound for `T: Send`.
+
+This allows non-Send types such as `Rc` to be sent across thread boundaries
+which can trigger undefined behavior and memory corruption.


### PR DESCRIPTION
Crate: https://crates.io/crates/thex

No upstream issue for this since the repository for this crate seems to have vanished. It used to be at https://github.com/krl/thex but it seems to have been deleted and there hasn't been a release for a long time. (Pinging @krl, not sure if this repo has moved but just fyi you can [yank](https://doc.rust-lang.org/cargo/commands/cargo-yank.html) old unmaintained crates)

Here's a quick little proof-of-concept that segfaults from safe rust code:
```rust
#![forbid(unsafe_code)]

use thex::Thex;
use std::rc::Rc;

fn main() {
    let rc = Rc::new(());
    let rc_clone = rc.clone();

    let thex = Thex::new(rc_clone);
    std::thread::spawn(move || {
        let smuggled_rc = thex.shared();

        println!("Thread: {:p}", *smuggled_rc);
        // Race the refcount with the main thread.
        for _ in 0..100_000_000 {
            smuggled_rc.clone();
        }
    });

    println!("Main:   {:p}", rc);
    for _ in 0..100_000_000 {
        rc.clone();
    }
}
```

Output:
```
Main:   0x559653d9cb50
Thread: 0x559653d9cb50

Terminated with signal 4 (SIGILL)
```