### PR TITLE
Add advisory for data race in aovec

### DIFF
--- a/crates/aovec/RUSTSEC-0000-0000.md
+++ b/crates/aovec/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "aovec"
+date = "2020-12-10"
+categories = ["memory-corruption"]
+keywords = ["concurrency"]
+
+[versions]
+patched = []
+```
+
+# Aovec<T> lacks bound on its Send and Sync traits allowing data races
+
+`aovec::Aovec<T>` is a vector type that implements `Send` and `Sync` for all
+types `T`.
+
+This allows non-Send types such as `Rc` and non-Sync types such as `Cell` to
+be used across thread boundaries which can trigger undefined behavior and
+memory corruption.


### PR DESCRIPTION
Crate: https://crates.io/crates/aovec

Much like #523, the repo for this crate seems to 404 now so there's no upstream issue here. The vector provided by this crate implements `Send` and `Sync` unconditionally which allows for data races.

Here's a simple demonstration that segfaults safe Rust code using this crate:
```rust
#![forbid(unsafe_code)]

use aovec::Aovec;
use std::rc::Rc;

fn main() {
    let vec = Aovec::new(1);

    let rc = Rc::new(42);
    vec.push(rc.clone());

    std::thread::spawn(move || {
        println!("Thread: {:p}", vec[0]);
        for _ in 0..100_000_000 {
            vec[0].clone();
        }
    });

    println!("Main:   {:p}", rc);
    for _ in 0..100_000_000 {
        rc.clone();
    }
}
```

Output:
```
Main:   0x5639ef979b50
Thread: 0x5639ef979b50

Terminated with signal 4 (SIGILL)
```