### PR TITLE
Fix wrong url

### DIFF
--- a/crates/libpulse-binding/RUSTSEC-2020-0055.md
+++ b/crates/libpulse-binding/RUSTSEC-2020-0055.md
@@ -3,7 +3,7 @@
 id = "RUSTSEC-2020-0055"
 package = "libpulse-binding"
 date = "2020-10-21"
-url = "https://rustsec.org/advisories/RUSTSEC-2018-0012.html"
+url = "https://rustsec.org/advisories/RUSTSEC-2018-0020.html"
 yanked = true
 
 [versions]


### PR DESCRIPTION
Mistake from fb2a1a6c4772485b519c21c10d1246e13e986f88