### PR TITLE
concread: Send/Sync bound needed on V in `impl Send/Sync for ARCache<K, V>`

### DIFF
--- a/crates/concread/RUSTSEC-0000-0000.md
+++ b/crates/concread/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "concread"
+date = "2020-11-13"
+url = "https://github.com/kanidm/concread/issues/48"
+informational = "unsound"
+
+[versions]
+patched = [">= 0.2.6"]
+```
+
+# Send/Sync bound needed on V in `impl Send/Sync for ARCache<K, V>`
+
+Affected versions of this crate unconditionally implemented `Send`/`Sync` traits for `ARCache<K, V>` type.
+
+This allows users to send/access types that do not implement `Send`/`Sync`, which can cause a data race.
+
+The flaw was corrected in the 0.2.6 release by adding bounds `K: Send + Sync` & `V: Send + Sync` to affected `Send`/`Sync` trait implementations.


### PR DESCRIPTION
Original issue report: https://github.com/kanidm/concread/issues/48

PR that fixed the issue: https://github.com/kanidm/concread/pull/49


Thank you for reviewing this PR :crab: 