### PR TITLE
add advisory for data race in 'reffers'

### DIFF
--- a/crates/reffers/RUSTSEC-0000-0000.md
+++ b/crates/reffers/RUSTSEC-0000-0000.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "reffers"
+date = "2020-12-01"
+url = "https://github.com/diwic/reffers-rs/issues/7"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["concurrency"]
+
+[versions]
+# Versions which include fixes for this vulnerability
+patched = []
+```
+
+# Unsound: can make `ARefss` contain a !Send, !Sync object.
+
+`ARefss<'a, V>` is a type that is assumed to contain objects that are `Send + Sync`.
+
+In the affected versions of this crate,
+`Send`/`Sync` traits are unconditionally implemented for `ARefss<'a, V>`.
+
+By using the `ARefss::map()` API, we can insert a `!Send` or `!Sync` object into `ARefss<'a, V>`. After that, it is possible to create a data race to the inner object of `ARefss<'a, V>`, which can lead to undefined behavior & memory corruption.
+
+The flaw was corrected in commit 6dd7ca0 (https://github.com/diwic/reffers-rs/commit/6dd7ca0d50f2464df708975cdafcfaeeb6d41c66) by adding trait bound `V: Send + Sync` to `ARefss::map()` API.


### PR DESCRIPTION
### reffers: Unsound: can make `ARefss` contain a !Send, !Sync object.

Original issue report: https://github.com/diwic/reffers-rs/issues/7

Commit that fixed the issue: https://github.com/diwic/reffers-rs/commit/6dd7ca0d50f2464df708975cdafcfaeeb6d41c66

Thank you for reviewing this PR :+1: 