### PR TITLE
Add CVE number for RUSTSEC-2020-0091

### DIFF
--- a/crates/arc-swap/RUSTSEC-2020-0091.md
+++ b/crates/arc-swap/RUSTSEC-2020-0091.md
@@ -6,6 +6,7 @@ date = "2020-12-10"
 url = "https://github.com/vorner/arc-swap/issues/45"
 categories = ["memory-corruption"]
 keywords = ["dangling reference"]
+aliases = ["CVE-2020-35711"]
 
 [versions]
 patched = [">= 1.1.0", ">= 0.4.8"]


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2020-35711