### PR TITLE
Add advisory for interfaces2

### DIFF
--- a/crates/interfaces2/RUSTSEC-0000-0000.md
+++ b/crates/interfaces2/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "interfaces2"
+date = "2021-01-04"
+informational = "unmaintained"
+url = "https://github.com/aep/interfaces-rs"
+
+[versions]
+patched = []
+```
+
+# interfaces2 is unmaintained, use interfaces instead
+
+The `interfaces2` crate is not maintained any more;
+use [`interfaces`](https://crates.io/crates/interfaces) instead.


### PR DESCRIPTION
interfaces2 is not maintained now, and I took over the maintenance of the original interfaces crate.

https://github.com/aep/interfaces-rs