### PR TITLE
Bump rustsec-admin to v0.3.3

### DIFF
--- a/.github/workflows/assign-ids.yml
+++ b/.github/workflows/assign-ids.yml
@@ -15,12 +15,12 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cargo/bin
-        key: rustsec-admin-v0.3.2
+        key: rustsec-admin-v0.3.3
 
     - name: Install rustsec-admin
       run: |
         if [ ! -f $HOME/.cargo/bin/rustsec-admin ]; then
-            cargo install rustsec-admin --vers 0.3.2
+            cargo install rustsec-admin --vers 0.3.3
         fi
 
     - name: Assign IDs

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,12 +16,12 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cargo/bin
-        key: rustsec-admin-v0.3.2
+        key: rustsec-admin-v0.3.3
 
     - name: Install rustsec-admin
       run: |
         if [ ! -f $HOME/.cargo/bin/rustsec-admin ]; then
-            cargo install rustsec-admin --vers 0.3.2
+            cargo install rustsec-admin --vers 0.3.3
         fi
 
     - name: Lint advisories

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # RustSec Advisory Database
 
 [![Build Status][build-image]][build-link]
-![Maintained: Q4 2020][maintained-image]
+![Maintained: Q1 2021][maintained-image]
 [![Project Chat][chat-image]][chat-link]
 
 The RustSec Advisory Database is a repository of security advisories filed
@@ -111,7 +111,7 @@ All content in this repository is placed in the public domain.
 
 [build-image]: https://github.com/rustsec/advisory-db/workflows/Validate/badge.svg
 [build-link]: https://github.com/rustsec/advisory-db/actions
-[maintained-image]: https://img.shields.io/maintenance/yes/2020.svg
+[maintained-image]: https://img.shields.io/maintenance/yes/2021.svg
 [chat-image]: https://img.shields.io/badge/zulip-join_chat-blue.svg
 [chat-link]: https://rust-lang.zulipchat.com/#narrow/stream/146229-wg-secure-code/
 


### PR DESCRIPTION
Should address the bug we encountered assigning an ID to the first advisory for a given year:

https://github.com/RustSec/advisory-db/runs/1644743652