### PR TITLE
RUSTSEC-2020-0017.md (use-after-free in internment) is fixed

### DIFF
--- a/crates/internment/RUSTSEC-2020-0017.md
+++ b/crates/internment/RUSTSEC-2020-0017.md
@@ -11,7 +11,7 @@ url = "https://github.com/droundy/internment/issues/11"
 "internment::ArcIntern::drop" = [">= 0.3.12"]
 
 [versions]
-patched = []
+patched = [">= 0.4.0"]
 unaffected = ["< 0.3.12"]
 ```
 
@@ -20,5 +20,8 @@ unaffected = ["< 0.3.12"]
 `ArcIntern::drop` has a race condition where it can release memory
 which is about to get another user. The new user will get a reference
 to freed memory.
+
+This was fixed by serializing access to an interned object while it
+is being deallocated.
 
 Versions prior to 0.3.12 used stronger locking which avoided the problem.


### PR DESCRIPTION
The vulnerability in this report was fixed in internment 0.4.0.  For details, see https://github.com/droundy/internment/issues/11#issuecomment-758862385.

This advisory was originally created in https://github.com/RustSec/advisory-db/pull/306.