### PR TITLE
Publish Web: fix rustsec-admin install

### DIFF
--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -5,7 +5,7 @@ on:
     branches: master
 
 jobs:
-  publish:
+  publish-web:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -15,7 +15,10 @@ jobs:
         with:
           path: ~/.cargo/bin
           key: rustsec-admin-v0.3.3
-      - run: cargo install rustsec-admin --vers 0.3.3
+      - run: |
+        if [ ! -f $HOME/.cargo/bin/rustsec-admin ]; then
+         cargo install rustsec-admin --vers 0.3.3
+        fi
       - run: rustsec-admin web
       - uses: peter-evans/create-pull-request@v3
         with:


### PR DESCRIPTION
We do still need to check if `rustsec-admin` is installed, as an error is returned if it's already installed.