### PR TITLE
lazy-init: Missing Send bound for Lazy (khuey/lazy-init#9)

### DIFF
--- a/crates/lazy-init/RUSTSEC-0000-0000.md
+++ b/crates/lazy-init/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "lazy-init"
+date = "2021-01-17"
+informational = "unsound"
+url = "https://github.com/khuey/lazy-init/issues/9"
+
+[versions]
+patched = ["> 0.4.0"]
+```
+
+# Missing Send bound for Lazy
+
+All current versions of this crate allow causing data races in safe code.
+
+The flaw will be fixed in the next release.

--- a/crates/lazy-init/RUSTSEC-0000-0000.md
+++ b/crates/lazy-init/RUSTSEC-0000-0000.md
@@ -3,7 +3,7 @@
 id = "RUSTSEC-0000-0000"
 package = "lazy-init"
 date = "2021-01-17"
-informational = "unsound"
+categories = ["memory-corruption"]
 url = "https://github.com/khuey/lazy-init/issues/9"
 
 [versions]


### PR DESCRIPTION
Add an informational advisory for a long-standing soundness issue that has recently been fixed (https://github.com/khuey/lazy-init/commit/ab2cac8383a499be6700244cd2682f55c120f4a7).