### PR TITLE
glsl-layout: double drop upon panic in 'fn map_array'

### DIFF
--- a/crates/glsl-layout/RUSTSEC-0000-0000.md
+++ b/crates/glsl-layout/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "glsl-layout"
+date = "2021-01-10"
+url = "https://github.com/rustgd/glsl-layout/pull/10"
+categories = ["memory-corruption"]
+
+[versions]
+patched = [">= 0.4.0"]
+```
+
+# Double drop upon panic in 'fn map_array()'
+
+Affected versions of this crate did not guard against panic within the user-provided function `f` (2nd parameter of `fn map_array`), and thus panic within `f` 
+causes double drop of a single object.
+
+The flaw was corrected in the 0.4.0 release by wrapping the object vulnerable
+to a double drop within `ManuallyDrop<T>`.


### PR DESCRIPTION
# glsl-layout: double drop upon panic in 'fn map_array'

link to PR (explanation of bug && fix): https://github.com/rustgd/glsl-layout/pull/10

Thank you for reviewing this PR! :crab: 