### PR TITLE
im: TreeFocus lacks bounds on its Send and Sync traits

### DIFF
--- a/crates/im/RUSTSEC-0000-0000.md
+++ b/crates/im/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "im"
+date = "2020-11-09"
+url = "https://github.com/bodil/im-rs/issues/157"
+informational = "unsound"
+
+[versions]
+patched = []
+unaffected = ["< 12.0.0"]
+```
+
+# TreeFocus lacks bounds on its Send and Sync traits
+
+Affected versions of `im` contains `TreeFocus` that unconditionally implements `Send` and `Sync`.
+
+This allows a data race in safe Rust code if `TreeFocus` is extracted from `Focus` type.
+Typical users that only use `Focus` type are not affected.


### PR DESCRIPTION
Original issue report: https://github.com/bodil/im-rs/issues/157

`informational = "unsound"` because typical users are expected to use it
through [Focus](https://docs.rs/im/15.0.0/im/vector/enum.Focus.html)
which has a correct bound.