### PR TITLE
av-data: read from arbitrary address in safe API

### DIFF
--- a/crates/av-data/RUSTSEC-0000-0000.md
+++ b/crates/av-data/RUSTSEC-0000-0000.md
@@ -7,7 +7,7 @@ url = "https://github.com/rust-av/rust-av/issues/136"
 categories = ["memory-exposure", "privilege-escalation"]
 
 [versions]
-patched = []
+patched = [">= 0.3.0"]
 ```
 
 # `Frame::copy_from_raw_parts` can lead to segfault without `unsafe`

--- a/crates/av-data/RUSTSEC-0000-0000.md
+++ b/crates/av-data/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "av-data"
+date = "2021-01-07"
+url = "https://github.com/rust-av/rust-av/issues/136"
+categories = ["memory-exposure", "privilege-escalation"]
+
+[versions]
+patched = []
+```
+
+# `Frame::copy_from_raw_parts` can lead to segfault without `unsafe`
+
+`fn Frame::copy_from_raw_parts()` is a safe API that can take a
+raw pointer and dereference it. It is possible to read arbitrary memory address
+with an arbitrarily fed pointer. This allows the safe API to access & read
+arbitrary address in memory. Feeding an invalid memory address pointer to
+the API may also cause the program to segfault.
+
+The flaw was corrected in https://github.com/rust-av/rust-av/pull/137,
+by removing the API `fn Frame::copy_from_raw_parts()`.
+


### PR DESCRIPTION
# av-data: `Frame::copy_from_raw_parts` can lead to segfault without `unsafe`

Original issue report: https://github.com/rust-av/rust-av/issues/136

Thank you for reviewing :crab: 