### PR TITLE
xcb: Soundness issue with base::Error

### DIFF
--- a/crates/xcb/RUSTSEC-0000-0000.md
+++ b/crates/xcb/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "xcb"
+date = "2020-12-10"
+url = "https://github.com/rtbo/rust-xcb/issues/93"
+categories = ["memory-corruption"]
+informational = "unsound"
+
+[versions]
+patched = []
+```
+
+# Soundness issue with base::Error
+
+`base::Error` type contains public field named `ptr`.
+With this definition, it is possible to create a `base::Error` with an invalid pointer and trigger memory safety errors
+such as use-after-free or double-free with safe Rust.
+
+The users of `xcb` crate are advised not to manipulate the field.


### PR DESCRIPTION
Original issue report: https://github.com/rtbo/rust-xcb/issues/93