### PR TITLE
Add advisory for soundness issue in rusb

### DIFF
--- a/crates/rusb/RUSTSEC-0000-0000.md
+++ b/crates/rusb/RUSTSEC-0000-0000.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rusb"
+date = "2020-12-18"
+url = "https://github.com/a1ien/rusb/issues/44"
+categories = ["memory-corruption"]
+keywords = ["concurrency"]
+informational = "unsound"
+
+[versions]
+patched = [">= 0.7.0"]
+unaffected = []
+```
+
+# UsbContext trait did not require implementers to be Send and Sync.
+
+Affected versions of `rusb` did not require `UsbContext` to implement `Send`
+and `Sync`. However, through `Device` and `DeviceHandle` it is possible to use
+`UsbContext`s across threads.
+
+This issue allows non-thread safe `UsbContext` types to be used concurrently
+leading to data races and memory corruption.
+
+The issue was fixed by adding `Send` and `Sync` bounds to `UsbContext`.


### PR DESCRIPTION
Upstream issue: https://github.com/a1ien/rusb/issues/44

Marked `informational = unsound` because it's unlikely that users of the library would be implementing `UsbContext` themselves.