### PR TITLE
Add unmaintained advisory for stderr crate

### DIFF
--- a/crates/stderr/RUSTSEC-0000-0000.md
+++ b/crates/stderr/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "stderr"
+date = "2020-12-22"
+url = "https://github.com/biluohc/stderr/issues/5"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# stderr is unmaintained; use eprintln instead
+
+The `stderr` crate is no longer maintained by its current owner. 
+
+The author recommends using the `eprintln` macro from the standard library as a
+replacement.


### PR DESCRIPTION
As per the author in https://github.com/biluohc/stderr/issues/5#issuecomment-749377183

They recommend not to use the crate anymore but can't yank it just yet due to some internal dependencies.