### PR TITLE
bra: Read on uninitialized buffer

### DIFF
--- a/crates/bra/RUSTSEC-0000-0000.md
+++ b/crates/bra/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "bra"
+date = "2021-01-02"
+url = "https://github.com/Enet4/bra-rs/issues/1"
+categories = ["memory-exposure"]
+
+[versions]
+patched = [">= 0.1.1"]
+```
+
+# reading on uninitialized buffer can cause UB (`impl<R> BufRead for GreedyAccessReader<R>`)
+
+Affected versions of this crate creates an uninitialized buffer and passes it to user-provided `Read` implementation.
+
+This is unsound, because it allows safe Rust code to exhibit an undefined behavior (read from uninitialized memory).
+
+The flaw was corrected in version 0.1.1 by zero-initializing a newly allocated buffer
+before handing it to a user-provided `Read` implementation. 


### PR DESCRIPTION
# bra: reading on uninitialized buffer can cause UB (`impl<R> BufRead for GreedyAccessReader<R>`)

Original issue report: https://github.com/Enet4/bra-rs/issues/1

Thank you for reviewing!