### PR TITLE
unconditional Sync impl of `AtomicOption<T>` allows UB

### DIFF
--- a/crates/atomic-option/RUSTSEC-0000-0000.md
+++ b/crates/atomic-option/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "atomic-option"
+date = "2020-10-31"
+url = "https://github.com/reem/rust-atomic-option/issues/4"
+categories = ["memory-corruption"]
+
+[versions]
+patched = []
+```
+
+# AtomicOption should have Send + Sync bound on its type argument.
+
+In the affected versions of this crate,
+`AtomicOption<T>` unconditionally implements `Sync`.
+
+This allows programmers to move non-Sync types across thread boundaries (e.g. `Rc<T>`, `Arc<Cell<T>>`), which can lead to data races and undefined behavior. 
+It is also possible to send non-Send types like `std::sync::MutexGuard` to other threads, which can lead to undefined behavior.


### PR DESCRIPTION
# atomic-option: AtomicOption should have Send + Sync bound on its type argument.

Original issue report: https://github.com/reem/rust-atomic-option/issues/4

The crate is popular on crates.io. (>=106,332 downloads).
The author hasn't responded to the issue report which was submitted more than 10 weeks ago.

Thank you for reviewing :crab: 