### PR TITLE
data race in `ButtplugFutureStateShared<T>`

### DIFF
--- a/crates/buttplug/RUSTSEC-0000-0000.md
+++ b/crates/buttplug/RUSTSEC-0000-0000.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "buttplug"
+date = "2020-12-18"
+url = "https://github.com/buttplugio/buttplug-rs/issues/225"
+categories = ["memory-corruption"]
+
+[versions]
+# Versions which include fixes for this vulnerability
+patched = [">= 1.0.4"]
+```
+
+# ButtplugFutureStateShared allows data race to (!Send|!Sync) objects
+
+`ButtplugFutureStateShared<T>` implements `Send` & `Sync` regardless of `T`.
+
+If `T: !Send` for `ButtplugFutureStateShared<T>`, it is possible to move non-Send types across thread boundaries (e.g. `T`=`Rc<T>`) and lead to undefined behavior.
+If `T: !Sync` for `ButtplugFutureStateShared<T>`, it is possible to cause data race to `T` (e.g. `T`=`Arc<Cell<_>>`) and lead to undefined behavior.
+
+The flaw was corrected in version 1.0.4 by removing manual implementations of `Send`/`Sync` for `ButtplugFutureStateShared<T>` to let rustc generate auto trait implementations with correct trait bounds on `T`.


### PR DESCRIPTION
# buttplug: ButtplugFutureStateShared allows data race to (!Send|!Sync) objects

Original issue report: https://github.com/buttplugio/buttplug-rs/issues/225

Thank you for reviewing this PR :+1: 