### PR TITLE
bite: Read on uninitialized memory

### DIFF
--- a/crates/bite/RUSTSEC-0000-0000.md
+++ b/crates/bite/RUSTSEC-0000-0000.md
@@ -5,6 +5,7 @@ package = "bite"
 date = "2020-12-31"
 url = "https://github.com/hinaria/bite/issues/1"
 categories = ["memory-exposure"]
+informational = "unsound"
 
 [versions]
 patched = []

--- a/crates/bite/RUSTSEC-0000-0000.md
+++ b/crates/bite/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "bite"
+date = "2020-12-31"
+url = "https://github.com/hinaria/bite/issues/1"
+categories = ["memory-exposure"]
+
+[versions]
+patched = []
+```
+
+# `read` on uninitialized buffer may cause UB (bite::read::BiteReadExpandedExt::read_framed_max)
+
+Affected versions of this crate calls a user provided `Read` implementation on an uninitialized buffer.
+
+`Read` on uninitialized buffer is defined as undefined behavior in Rust.


### PR DESCRIPTION
# bite: `read` on uninitialized buffer may cause UB (bite::read::BiteReadExpandedExt::read_framed_max)

Original issue report: https://github.com/hinaria/bite/issues/1

The author of the crate is unlikely to respond to the issue, since the author has been inactive on GitHub since late 2019..

Thank you for reviewing! :rocket: 