### PR TITLE
calamine: access unclaimed/uninitialized memory

### DIFF
--- a/crates/calamine/RUSTSEC-0000-0000.md
+++ b/crates/calamine/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "calamine"
+date = "2021-01-06"
+url = "https://github.com/tafia/calamine/issues/199"
+categories = ["memory-corruption", "memory-exposure"]
+
+[versions]
+patched = []
+```
+
+# `Sectors::get` accesses unclaimed/uninitialized memory
+
+Affected versions of this crate arbitrarily calls `Vec::set_len` to increase length of a vector without claiming more memory for the vector. Affected versions of this crate
+also calls user-provided `Read` on the uninitialized memory of the vector that was
+extended with `Vec::set_len`.
+
+This can overwrite active entities in adjacent heap memory and seems to be a major security issue. Also, calling user-provided `Read` on uninitialized memory is defined as UB in Rust.


### PR DESCRIPTION
# calamine: `Sectors::get` accesses unclaimed/uninitialized memory

Original issue report: https://github.com/tafia/calamine/issues/199

Thank you for reviewing this issue :+1: