### PR TITLE
data race in lexer::ReaderResult<T, E>

### DIFF
--- a/crates/lexer/RUSTSEC-0000-0000.md
+++ b/crates/lexer/RUSTSEC-0000-0000.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "lexer"
+date = "2020-11-10"
+url = "https://gitlab.com/nathanfaucett/rs-lexer/-/issues/2"
+categories = ["memory-corruption"]
+
+[versions]
+patched = []
+```
+
+# ReaderResult should be bounded by Sync
+
+Affected versions of this crate implements `Sync` for `ReaderResult<T, E>` with the trait bound `T: Send, E: Send`.
+
+Since matching on the public enum `ReaderResult<T, E>` provides access to `&T` & `&E`,
+allowing data race to a non-Sync type `T` or `E`.
+This can result in a memory corruption when multiple threads concurrently access `&T` or `&E`.
+
+Suggested fix for the bug is change the trait bounds imposed on `T` & `E` to be `T: Sync, E: Sync`.


### PR DESCRIPTION
# data race in lexer::ReaderResult<T, E>

Original issue report: https://gitlab.com/nathanfaucett/rs-lexer/-/issues/2

Issue report was submitted to main repo for more than 2 months ago, but the author hasn't responded yet.

Thank you for reviewing this PR :crab: 