### PR TITLE
eventio: Input<R>' can send non-Send types to other threads

### DIFF
--- a/crates/eventio/RUSTSEC-0000-0000.md
+++ b/crates/eventio/RUSTSEC-0000-0000.md
@@ -7,7 +7,7 @@ url = "https://github.com/petabi/eventio/issues/33"
 categories = ["memory-corruption"]
 
 [versions]
-patched = []
+patched = [">= 0.5.1"]
 ```
 
 # Soundness issue: Input<R> can be misused to create data race to an object
@@ -17,4 +17,4 @@ patched = []
 Affected versions of this crate allows users to send non-Send types to other threads,
 which can lead to undefined behavior such as data race and memory corruption.
 
-The flaw was corrected in the PR(https://github.com/petabi/eventio/pull/34) by adding `R: Send` bound to the `Send` impl of `Input<R>`.
+The flaw was corrected in version 0.5.1 by adding `R: Send` bound to the `Send` impl of `Input<R>`.

--- a/crates/eventio/RUSTSEC-0000-0000.md
+++ b/crates/eventio/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "eventio"
+date = "2020-12-20"
+url = "https://github.com/petabi/eventio/issues/33"
+categories = ["memory-corruption"]
+
+[versions]
+patched = []
+```
+
+# Soundness issue: Input<R> can be misused to create data race to an object
+
+`Input<R>` implements `Send` without requiring `R: Send`.
+
+Affected versions of this crate allows users to send non-Send types to other threads,
+which can lead to undefined behavior such as data race and memory corruption.
+
+The flaw was corrected in the PR(https://github.com/petabi/eventio/pull/34) by adding `R: Send` bound to the `Send` impl of `Input<R>`.


### PR DESCRIPTION
# eventio: Input<R> allows sending non-Send types across thread boundaries

Original issue report: https://github.com/petabi/eventio/issues/33

The issue has been resolved in petabi/eventio#34, and I've currently asked them to publish a new version of `eventio` crate that includes the fix.

Thank you very much for reviewing this PR :+1: 