### PR TITLE
Add advisory for double-free in sys-info

### DIFF
--- a/crates/sys-info/RUSTSEC-0000-0000.md
+++ b/crates/sys-info/RUSTSEC-0000-0000.md
@@ -1,0 +1,27 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "sys-info"
+date = "2020-01-19"
+url = "https://github.com/FillZpp/sys-info-rs/issues/63"
+categories = ["memory-corruption"]
+keywords = ["concurrency", "double free"]
+
+[versions]
+patched = []
+unaffected = []
+
+[affected]
+os = ["linux"]
+functions = { "sys_info::disk_info" = ["<= 0.1.1"] }
+```
+
+# Double free when calling `sys_info::disk_info` from multiple threads
+
+Affected versions of `sys-info` use a static, global, list to store temporary disk information while running. The function that cleans up this list,
+`DFCleanup`, assumes a single threaded environment and will try to free the same memory twice in a multithreaded environment.
+
+This results in consistent double-frees and segfaults when calling `sys_info::disk_info` from multiple threads at once.
+
+## Safer Alternatives:
+ - [`sysinfo`](https://crates.io/crates/sysinfo)


### PR DESCRIPTION
[This issue](https://github.com/FillZpp/sys-info-rs/issues/63) has been open for some time. All published versions of `sys-info` have this issue. The crate also appears unmaintained and has various correctness issues, so a a fixed version is probably unlikely. 