### PR TITLE
basic_dsp_matrix: panic safety issue in `impl TransformContent<S, D> for [S; (2|3|4)]`

### DIFF
--- a/crates/basic_dsp_matrix/RUSTSEC-0000-0000.md
+++ b/crates/basic_dsp_matrix/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "basic_dsp_matrix"
+date = "2021-01-10"
+url = "https://github.com/liebharc/basic_dsp/issues/47"
+categories = ["memory-corruption"]
+
+[versions]
+patched = [">= 0.9.2"]
+```
+
+# panic safety issue in `impl TransformContent<S, D> for [S; (2|3|4)]`
+
+Affected versions of this crate did not guard against double drop while temporarily duplicating objects' ownership using `ptr::read()`. Upon panic in a user-provided function `conversion`, objects that are copied by `ptr::read()` are dropped twice, leading to memory corruption.
+
+The flaw was corrected in v0.9.2 by using `ManuallyDrop<T>` to enclose objects that are to be temporarily duplicated.


### PR DESCRIPTION
Original issue report: https://github.com/liebharc/basic_dsp/issues/47