### PR TITLE
multiqueue2: Queues allow non-Send types to be sent to other threads, allowing data races

### DIFF
--- a/crates/multiqueue2/RUSTSEC-0000-0000.md
+++ b/crates/multiqueue2/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "multiqueue2"
+date = "2020-12-19"
+url = "https://github.com/abbychau/multiqueue2/issues/10"
+categories = ["memory-corruption"]
+informational = "unsound"
+
+[versions]
+patched = [">= 0.1.7"]
+```
+
+# Queues allow non-Send types to be sent to other threads, allowing data races
+
+Affected versions of this crate unconditionally implemented `Send` for types used in queue implementations (`InnerSend<RW, T>`, `InnerRecv<RW, T>`, `FutInnerSend<RW, T>`, `FutInnerRecv<RW, T>`).
+
+This allows users to send non-Send types to other threads, which can lead to data race bugs or other undefined behavior.
+
+The flaw was corrected in v0.1.7 by adding `T: Send` bound to to the `Send` impl of four data types explained above.


### PR DESCRIPTION
Original issue report: https://github.com/abbychau/multiqueue2/issues/10