### PR TITLE
gfwx: ImageChunkMut needs bounds on its Send and Sync traits

### DIFF
--- a/crates/gfwx/RUSTSEC-0000-0000.md
+++ b/crates/gfwx/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "gfwx"
+date = "2020-12-08"
+url = "https://github.com/Devolutions/gfwx-rs/issues/7"
+categories = ["memory-corruption"]
+
+[versions]
+patched = [">= 0.3.0"]
+```
+
+# ImageChunkMut needs bounds on its Send and Sync traits
+
+In the affected versions of this crate, `ImageChunkMut<'_, T>` unconditionally implements `Send` and `Sync`, allowing to create data races.
+
+This can result in a memory corruption or undefined behavior when non thread-safe types are moved and referenced across thread boundaries.
+
+The flaw was corrected in commit e7fb2f5 by adding `T: Send` bound to the `Send` impl and adding `T: Sync` bound to the `Sync` impl.


### PR DESCRIPTION
Original issue report: https://github.com/Devolutions/gfwx-rs/issues/7