### PR TITLE
autorand: `impl Random` on arrays can lead to dropping uninitialized memory

### DIFF
--- a/crates/autorand/RUSTSEC-0000-0000.md
+++ b/crates/autorand/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "autorand"
+date = "2020-12-31"
+url = "https://github.com/mersinvald/autorand-rs/issues/5"
+categories = ["memory-corruption"]
+
+[versions]
+patched = [">= 0.2.3"]
+```
+
+# `impl Random` on arrays can lead to dropping uninitialized memory
+
+Affected versions of this crate had a panic safety issue to drop partially uninitialized array of `T` upon panic in a user provided function `T::random()`. Dropping uninitialized `T` can potentially cause memory corruption or undefined behavior.
+
+The flaw was corrected in commit 565d508 by using `MaybeUninit<T>` to avoid possible dropping of uninitialized memory upon panic.


### PR DESCRIPTION
Original issue report: https://github.com/mersinvald/autorand-rs/issues/5