### PR TITLE
ID assignment action: guard against race conditions 

### DIFF
--- a/.duplicate-id-guard
+++ b/.duplicate-id-guard
@@ -1,0 +1,3 @@
+This file causes merge conflicts if two ID assignment jobs run concurrently.
+This prevents duplicate ID assignment due to a race between those jobs.
+90b4c5be517867a32fc05e59aac80a51dff30a8961ac5261357d06dfb1b892fd  -

--- a/.github/workflows/assign-ids.yml
+++ b/.github/workflows/assign-ids.yml
@@ -29,6 +29,12 @@ jobs:
         message=$(rustsec-admin assign-id --github-actions-output)
         echo "::set-output name=commit_message::${message}"
 
+    - name: Create duplicate ID assignment guard
+      run: |
+        echo "This file causes merge conflicts if two ID assignment jobs run concurrently." > .duplicate-id-guard
+        echo "This prevents duplicate ID assignment due to a race between those jobs." >> .duplicate-id-guard
+        ls -R . | sha256sum >> .duplicate-id-guard
+
     - name: Lint advisories
       run: rustsec-admin lint
 


### PR DESCRIPTION
Guard against race conditions resulting in duplicate ID assignment by writing a hash of the directory structure (not file contents) into a file. If two ID assignment jobs run concurrently, the file will create a merge conflict.

This is completely untested, since I don't know how to trigger a test run of a Github action.