### PR TITLE
va-ts: `Demuxer` can carry non-Send types across thread boundaries

### DIFF
--- a/crates/va-ts/RUSTSEC-0000-0000.md
+++ b/crates/va-ts/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "va-ts"
+date = "2020-12-22"
+url = "https://github.com/video-audio/va-ts/issues/4"
+categories = ["memory-corruption"]
+
+[versions]
+patched = [">= 0.0.4"]
+```
+
+# `Demuxer` can carry non-Send types across thread boundaries
+
+In the affected versions of this crate, `Demuxer<T>` unconditionally implemented `Send` with no trait bounds on `T`.
+
+This allows sending a non-Send type `T` across thread boundaries, which can cause undefined behavior like unlocking a mutex from a thread that didn't lock the mutex, or memory corruption from data race.
+
+The flaw was corrected in commit 0562cbf by adding a `T: Send` bound to the `Send` impl for `Demuxer<T>`.


### PR DESCRIPTION
Original issue report: https://github.com/video-audio/va-ts/issues/4