### PR TITLE
Add advisory for potential memory corruption in derive-com-impl

### DIFF
--- a/crates/derive-com-impl/RUSTSEC-0000-0000.md
+++ b/crates/derive-com-impl/RUSTSEC-0000-0000.md
@@ -6,15 +6,8 @@ date = "2021-01-20"
 url = "https://github.com/Connicpu/com-impl/issues/1"
 categories = ["memory-corruption"]
 keywords = ["com", "queryinterface", "addref"]
-#aliases = ["CVE-YYYY-NNNN"]
-#cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
-
-[versions]
-patched = []
 
 [affected]
-#arch = ["x86"]
-os = ["windows"]
 functions = { "derive-com-impl::derive_com_impl" = ["<= 0.1.1"] }
 
 [versions]
@@ -35,30 +28,8 @@ will cause WMI to drop reference to the interface, and can lead to invalid refer
 
 This is documented in <https://docs.microsoft.com/en-us/windows/win32/learnwin32/managing-the-lifetime-of-an-object#reference-counting>
 
-Suggested fix is to add a call to `IUnknown::AddRef` in `derive-com-impl/src/derive.rs`:
+There is no simple workaround, as you can't know how many time QueryInterface will be called.
+The only way to quick fix this is to use the macro expanded version of the code and modify 
+the QueryInterface method to add the AddRef call yourself.
 
-```rust
-#[inline(never)]
-unsafe extern "system" fn __com_impl__IUnknown__QueryInterface(
-	this: *mut winapi::um::unknwnbase::IUnknown,
-	riid: *const winapi::shared::guiddef::IID,
-	ppv: *mut *mut winapi::ctypes::c_void,
-) -> winapi::shared::winerror::HRESULT {
-	if ppv.is_null() {
-		return winapi::shared::winerror::E_POINTER;
-	}
-	if #( #is_equal_iid )||* {
-		// ADD CALL TO ADDREF TO FIX  //
-		let that = &*(this as *const Self);
-		that.#refcount.add_ref();
-		// END FIX //
-		*ppv = this as *mut winapi::ctypes::c_void;
-		winapi::shared::winerror::S_OK
-	} else {
-		*ppv = std::ptr::null_mut();
-		winapi::shared::winerror::E_NOINTERFACE
-	}
-}
-```
-
-It was corrected in commit `9803f31fbd1717d482d848f041044d061fca6da7`.
+The issue was corrected in commit `9803f31fbd1717d482d848f041044d061fca6da7`.

--- a/crates/derive-com-impl/RUSTSEC-0000-0000.md
+++ b/crates/derive-com-impl/RUSTSEC-0000-0000.md
@@ -8,7 +8,7 @@ categories = ["memory-corruption"]
 keywords = ["com", "queryinterface", "addref"]
 
 [affected]
-functions = { "derive-com-impl::derive_com_impl" = ["<= 0.1.1"] }
+functions = { "derive_com_impl::derive_com_impl" = ["<= 0.1.1"] }
 
 [versions]
 patched = [">= 0.1.2"]

--- a/crates/derive-com-impl/RUSTSEC-0000-0000.md
+++ b/crates/derive-com-impl/RUSTSEC-0000-0000.md
@@ -1,0 +1,64 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "derive-com-impl"
+date = "2021-01-20"
+url = "https://github.com/Connicpu/com-impl/issues/1"
+categories = ["memory-corruption"]
+keywords = ["com", "queryinterface", "addref"]
+#aliases = ["CVE-YYYY-NNNN"]
+#cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+
+[versions]
+patched = []
+
+[affected]
+#arch = ["x86"]
+os = ["windows"]
+functions = { "derive-com-impl::derive_com_impl" = ["<= 0.1.1"] }
+
+[versions]
+patched = [">= 0.1.2"]
+```
+
+# QueryInterface should call AddRef before returning pointer
+
+Affected version of this crate, which is a required dependency in com-impl, 
+provides a faulty implementation of the `IUnknown::QueryInterface` method.
+
+`QueryInterface` implementation must call `IUnknown::AddRef` before returning the pointer,
+as describe in this documentation:
+<https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iunknown-queryinterface(refiid_void)>
+
+As it is not incrementing the refcount as expected, the following calls to `IUnknown::Release` method 
+will cause WMI to drop reference to the interface, and can lead to invalid reference.
+
+This is documented in <https://docs.microsoft.com/en-us/windows/win32/learnwin32/managing-the-lifetime-of-an-object#reference-counting>
+
+Suggested fix is to add a call to `IUnknown::AddRef` in `derive-com-impl/src/derive.rs`:
+
+```rust
+#[inline(never)]
+unsafe extern "system" fn __com_impl__IUnknown__QueryInterface(
+	this: *mut winapi::um::unknwnbase::IUnknown,
+	riid: *const winapi::shared::guiddef::IID,
+	ppv: *mut *mut winapi::ctypes::c_void,
+) -> winapi::shared::winerror::HRESULT {
+	if ppv.is_null() {
+		return winapi::shared::winerror::E_POINTER;
+	}
+	if #( #is_equal_iid )||* {
+		// ADD CALL TO ADDREF TO FIX  //
+		let that = &*(this as *const Self);
+		that.#refcount.add_ref();
+		// END FIX //
+		*ppv = this as *mut winapi::ctypes::c_void;
+		winapi::shared::winerror::S_OK
+	} else {
+		*ppv = std::ptr::null_mut();
+		winapi::shared::winerror::E_NOINTERFACE
+	}
+}
+```
+
+It was corrected in commit `9803f31fbd1717d482d848f041044d061fca6da7`.


### PR DESCRIPTION
# Missing call to AddRef in QueryInterface in IUnknown implementation

`com-impl` crate relies on `derive-com-impl` to provide a default implementation for AddRef, Release and QueryInterface methods of IUnkown

To respect COM conventions, QueryInterface must call AddRef before returning a pointer to the underlying class. This leads to too many Release, and when the refcount drops to 0, WMI free the memory, which can lead to undefined behaviour.

