### PR TITLE
`LockWeak<T>` allows to create data race to `T`

### DIFF
--- a/crates/parc/RUSTSEC-0000-0000.md
+++ b/crates/parc/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "parc"
+date = "2020-11-14"
+url = "https://github.com/hyyking/rustracts/pull/6"
+categories = ["memory-corruption"]
+
+[versions]
+patched = []
+```
+
+# `LockWeak<T>` allows to create data race to `T`.
+
+In the affected versions of this crate, `LockWeak<T>` unconditionally implemented `Send` with no trait bounds on `T`. `LockWeak<T>` doesn't own `T` and only provides `&T`.
+
+This allows concurrent access to a non-Sync `T`, which can cause undefined behavior like data races.


### PR DESCRIPTION
Original PR report: https://github.com/hyyking/rustracts/pull/6

The crate author hasn't responded for 3 months.

Thank you for reviewing this PR :)