### PR TITLE
scottqueue: Queue<T> should have a Send bound on its Send/Sync traits

### DIFF
--- a/crates/scottqueue/RUSTSEC-0000-0000.md
+++ b/crates/scottqueue/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "scottqueue"
+date = "2020-11-15"
+url = "https://github.com/rossdylan/rust-scottqueue/issues/1"
+categories = ["memory-corruption"]
+
+[versions]
+patched = []
+```
+
+# Queue<T> should have a Send bound on its Send/Sync traits
+
+Affected versions of this crate unconditionally implements `Send`/`Sync` for `Queue<T>`.
+
+This allows (1) creating data races to a `T: !Sync` and (2) sending `T: !Send` to other threads, resulting in memory corruption or other undefined behavior.


### PR DESCRIPTION
Original issue report: https://github.com/rossdylan/rust-scottqueue/issues/1

Crate author hasn't responded for 2 months, and hasn't been active on GitHub for 6+ months.

Thank you for reviewing this PR :)