### PR TITLE
slock: Slock<T> allows sending non-Send types across thread boundaries

### DIFF
--- a/crates/slock/RUSTSEC-0000-0000.md
+++ b/crates/slock/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "slock"
+date = "2020-11-17"
+url = "https://github.com/BrokenLamp/slock-rs/issues/2"
+categories = ["memory-corruption"]
+
+[versions]
+patched = []
+```
+
+# Slock<T> allows sending non-Send types across thread boundaries
+
+`Slock<T>` unconditionally implements `Send`/`Sync`.
+
+Affected versions of this crate allows sending non-Send types to other threads,
+which can lead to data races and memory corruption due to the data race.


### PR DESCRIPTION
Original issue report: https://github.com/BrokenLamp/slock-rs/issues/2