### PR TITLE
syncpool: Send bound needed on T (for Send impl of `Bucket2`)

### DIFF
--- a/crates/syncpool/RUSTSEC-0000-0000.md
+++ b/crates/syncpool/RUSTSEC-0000-0000.md
@@ -7,7 +7,7 @@ url = "https://github.com/Chopinsky/byte_buffer/issues/2"
 categories = ["memory-corruption"]
 
 [versions]
-patched = []
+patched = [">= 0.1.6"]
 ```
 
 # Send bound needed on T (for Send impl of `Bucket2`)

--- a/crates/syncpool/RUSTSEC-0000-0000.md
+++ b/crates/syncpool/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "syncpool"
+date = "2020-11-29"
+url = "https://github.com/Chopinsky/byte_buffer/issues/2"
+categories = ["memory-corruption"]
+
+[versions]
+patched = []
+```
+
+# Send bound needed on T (for Send impl of `Bucket2`)
+
+Affected versions of this crate unconditionally implements `Send` for `Bucket2`. This allows sending non-Send types to other threads.
+
+This can lead to data races when non Send types like `Cell<T>` or `Rc<T>` are contained inside `Bucket2` and sent across thread boundaries. The data races can potentially lead to memory corruption (as demonstrated in the PoC from the original report issue).
+
+The flaw was corrected in commit 15b2828 by adding a `T: Send` bound to the `Send` impl of `Bucket2<T>`.


### PR DESCRIPTION
Original issue report: https://github.com/Chopinsky/byte_buffer/issues/2

The issue has been resolved in the master branch of the repo,
but a new release hasn't yet been published to crates.io.
I left a comment (to the original issue report) asking to publish a new release to crates.io.

Thank you for reviewing :)