### PR TITLE
cdr: Reading uninitialized memory can cause UB (`Deserializer::read_vec`)

### DIFF
--- a/crates/cdr/RUSTSEC-0000-0000.md
+++ b/crates/cdr/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "cdr"
+date = "2021-01-02"
+url = "https://github.com/hrektts/cdr-rs/issues/10"
+categories = ["memory-exposure"]
+
+[versions]
+patched = [">= 0.2.4"]
+```
+
+# Reading uninitialized memory can cause UB (`Deserializer::read_vec`)
+
+`Deserializer::read_vec()` created an uninitialized buffer and passes it to a user-provided `Read` implementation (`Deserializer.reader.read_exact()`).
+
+Passing an uninitialized buffer to an arbitrary `Read` implementation is currently defined as undefined behavior in Rust. Official documentation for the `Read` trait explains the following: "It is your responsibility to make sure that buf is initialized before calling read. Calling read with an uninitialized buf (of the kind one obtains via MaybeUninit<T>) is not safe, and can lead to undefined behavior."
+
+The flaw was corrected in commit ce310f7 by zero-initializing the newly allocated buffer before handing it to `Deserializer.reader.read_exact()`.


### PR DESCRIPTION
Original issue report: https://github.com/hrektts/cdr-rs/issues/10