### PR TITLE
bronzedb-protocol: `Read` on uninitialized buffer can cause UB (impl of `ReadKVExt`)

### DIFF
--- a/crates/bronzedb-protocol/RUSTSEC-0000-0000.md
+++ b/crates/bronzedb-protocol/RUSTSEC-0000-0000.md
@@ -5,6 +5,7 @@ package = "bronzedb-protocol"
 date = "2021-01-03"
 url = "https://github.com/Hexilee/BronzeDB/issues/1"
 categories = ["memory-exposure"]
+informational = "unsound"
 
 [versions]
 patched = []

--- a/crates/bronzedb-protocol/RUSTSEC-0000-0000.md
+++ b/crates/bronzedb-protocol/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "bronzedb-protocol"
+date = "2021-01-03"
+url = "https://github.com/Hexilee/BronzeDB/issues/1"
+categories = ["memory-exposure"]
+
+[versions]
+patched = []
+```
+
+# `Read` on uninitialized buffer can cause UB (impl of `ReadKVExt`)
+
+Affected versions of this crate passes an uninitialized buffer to a user-provided `Read` implementation.
+
+Arbitrary `Read` implementations can read from the uninitialized buffer (memory exposure) and also can return incorrect number of bytes written to the buffer.
+Reading from uninitialized memory produces undefined values that can quickly invoke undefined behavior.


### PR DESCRIPTION
Original issue report: https://github.com/Hexilee/BronzeDB/issues/1

As of Jan 2021, there doesn't seem to be an ideal fix that works in stable Rust with no performance overhead. Below are links to relevant discussions & suggestions for the fix.

* [Well-written document regarding the issue](https://paper.dropbox.com/doc/IO-Buffer-Initialization-MvytTgjIOTNpJAS6Mvw38)
* [Rust RFC 2930](https://github.com/rust-lang/rfcs/blob/master/text/2930-read-buf.md#summary)
* [nightly feature `std::io::Initializer`](https://doc.rust-lang.org/std/io/struct.Initializer.html)
* [Discussion in Rust Internals Forum](https://internals.rust-lang.org/t/uninitialized-memory/1652)

Thank you for reviewing this PR :)