### PR TITLE
binjs_io: 'Read' on uninitialized memory may cause UB

### DIFF
--- a/crates/binjs_io/RUSTSEC-0000-0000.md
+++ b/crates/binjs_io/RUSTSEC-0000-0000.md
@@ -5,6 +5,7 @@ package = "binjs_io"
 date = "2021-01-03"
 url = "https://github.com/binast/binjs-ref/issues/460"
 categories = ["memory-exposure"]
+informational = "unsound"
 
 [versions]
 patched = []

--- a/crates/binjs_io/RUSTSEC-0000-0000.md
+++ b/crates/binjs_io/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "binjs_io"
+date = "2021-01-03"
+url = "https://github.com/binast/binjs-ref/issues/460"
+categories = ["memory-exposure"]
+
+[versions]
+patched = []
+```
+
+# 'Read' on uninitialized memory may cause UB
+
+Affected versions of this crate passes an uninitialized buffer to a user-provided `Read` implementation. The crate currently contains 4 occurrences of such cases.
+
+Arbitrary `Read` implementations can read from the uninitialized buffer (memory exposure) and also can return incorrect number of bytes written to the buffer.
+Reading from uninitialized memory produces undefined values that can quickly invoke undefined behavior.


### PR DESCRIPTION
Original issue report: https://github.com/binast/binjs-ref/issues/460

As of Jan 2021, there doesn't seem to be an ideal fix that works in stable Rust with no performance overhead. Below are links to relevant discussions & suggestions for the fix.

* [Well-written document regarding the issue](https://paper.dropbox.com/doc/IO-Buffer-Initialization-MvytTgjIOTNpJAS6Mvw38)
* [Rust RFC 2930](https://github.com/rust-lang/rfcs/blob/master/text/2930-read-buf.md#summary)
* [nightly feature `std::io::Initializer`](https://doc.rust-lang.org/std/io/struct.Initializer.html)
* [Discussion in Rust Internals Forum](https://internals.rust-lang.org/t/uninitialized-memory/1652)

Thank you for reviewing this PR :)