### PR TITLE
columnar: Reading on uninitialized buffer may cause UB

### DIFF
--- a/crates/columnar/RUSTSEC-0000-0000.md
+++ b/crates/columnar/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "columnar"
+date = "2021-01-07"
+url = "https://github.com/frankmcsherry/columnar/issues/6"
+categories = ["memory-exposure"]
+
+[versions]
+patched = []
+```
+
+# columnar: `Read` on uninitialized buffer may cause UB (ColumnarReadExt::read_typed_vec())
+
+Affected versions of this crate passes an uninitialized buffer to a user-provided `Read` implementation (`ColumnarReadExt::read_typed_vec()`).
+
+Arbitrary `Read` implementations can read from the uninitialized buffer (memory exposure) and also can return incorrect number of bytes written to the buffer.
+Reading from uninitialized memory produces undefined values that can quickly invoke undefined behavior.

--- a/crates/columnar/RUSTSEC-0000-0000.md
+++ b/crates/columnar/RUSTSEC-0000-0000.md
@@ -5,6 +5,7 @@ package = "columnar"
 date = "2021-01-07"
 url = "https://github.com/frankmcsherry/columnar/issues/6"
 categories = ["memory-exposure"]
+informational = "unsound"
 
 [versions]
 patched = []


### PR DESCRIPTION
Original issue report: https://github.com/frankmcsherry/columnar/issues/6

As of Jan 2021, there doesn't seem to be an ideal fix that works in stable Rust with no performance overhead. Below are links to relevant discussions & suggestions for the fix.

* [Well-written document regarding the issue](https://paper.dropbox.com/doc/IO-Buffer-Initialization-MvytTgjIOTNpJAS6Mvw38)
* [Rust RFC 2930](https://github.com/rust-lang/rfcs/blob/master/text/2930-read-buf.md#summary)
* [nightly feature `std::io::Initializer`](https://doc.rust-lang.org/std/io/struct.Initializer.html)
* [Discussion in Rust Internals Forum](https://internals.rust-lang.org/t/uninitialized-memory/1652)

Thank you for reviewing this PR :)