### PR TITLE
acc_reader: API Soundness issue in `fill_buf()` and `read_up_to()`

### DIFF
--- a/crates/acc_reader/RUSTSEC-0000-0000.md
+++ b/crates/acc_reader/RUSTSEC-0000-0000.md
@@ -5,6 +5,7 @@ package = "acc_reader"
 date = "2020-12-27"
 url = "https://github.com/netvl/acc_reader/issues/1"
 categories = ["memory-exposure"]
+informational = "unsound"
 
 [versions]
 patched = []

--- a/crates/acc_reader/RUSTSEC-0000-0000.md
+++ b/crates/acc_reader/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "acc_reader"
+date = "2020-12-27"
+url = "https://github.com/netvl/acc_reader/issues/1"
+categories = ["memory-exposure"]
+
+[versions]
+patched = []
+```
+
+# `Read` on uninitialized buffer in `fill_buf()` and `read_up_to()`
+
+Affected versions of this crate passes an uninitialized buffer to a user-provided `Read` implementation.
+
+Arbitrary `Read` implementations can read from the uninitialized buffer (memory exposure) and also can return incorrect number of bytes written to the buffer.
+Reading from uninitialized memory produces undefined values that can quickly invoke undefined behavior.


### PR DESCRIPTION
Original issue report: https://github.com/netvl/acc_reader/issues/1

As of Jan 2021, there doesn't seem to be an ideal fix that works in stable Rust with no performance overhead. Below are links to relevant discussions & suggestions for the fix.

* [Well-written document regarding the issue](https://paper.dropbox.com/doc/IO-Buffer-Initialization-MvytTgjIOTNpJAS6Mvw38)
* [Rust RFC 2930](https://github.com/rust-lang/rfcs/blob/master/text/2930-read-buf.md#summary)
* [nightly feature `std::io::Initializer`](https://doc.rust-lang.org/std/io/struct.Initializer.html)
* [Discussion in Rust Internals Forum](https://internals.rust-lang.org/t/uninitialized-memory/1652)

Thank you for reviewing this PR :)