### PR TITLE
array-tools: `FixedCapacityDequeLike::clone()` can cause dropping uninitialized memory

### DIFF
--- a/crates/array-tools/RUSTSEC-0000-0000.md
+++ b/crates/array-tools/RUSTSEC-0000-0000.md
@@ -1,0 +1,15 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "array-tools"
+date = "2020-12-31"
+url = "https://github.com/L117/array-tools/issues/2"
+categories = ["memory-corruption"]
+
+[versions]
+patched = []
+```
+
+# `FixedCapacityDequeLike::clone()` can cause dropping uninitialized memory
+
+Affected versions of this crate don't guard against panics, so that partially uninitialized buffer is dropped when user-provided `T::clone()` panics in `FixedCapacityDequeLike<T, A>::clone()`. This causes memory corruption.


### PR DESCRIPTION
Original issue report: https://github.com/L117/array-tools/issues/2

The author has been inactive on GitHub for more than 3 months,
so it's not likely for us to get a response to the issue soon.

Thank you for reviewing this PR :)