### PR TITLE
raw-cpuid: Optional `Deserialize` implementations unsound

### DIFF
--- a/crates/raw-cpuid/RUSTSEC-0000-0000.md
+++ b/crates/raw-cpuid/RUSTSEC-0000-0000.md
@@ -1,0 +1,27 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "raw-cpuid"
+date = "2021-01-20"
+url = "https://github.com/gz/rust-cpuid/issues/43"
+categories = ["memory-corruption", "denial-of-service"]
+
+[versions]
+patched = []
+unaffected = ["<= 3.1.0"]
+```
+
+# Optional `Deserialize` implementations lacking validation
+
+When activating the non-default feature `serialize`, most structs implement
+`serde::Deserialize` without sufficient validation. This allows breaking
+invariants in safe code, leading to:
+
+* Undefined behavior in `as_string()` methods (which use
+  `std::str::from_utf8_unchecked()` internally).
+* Panics due to failed assertions.
+
+See https://github.com/gz/rust-cpuid/issues/43.
+
+A fix is not yet available, but most use cases do not require enabling
+the `serialize` feature.


### PR DESCRIPTION
Following up on #614: Thanks. Here's part 2, then.