### PR TITLE
conqueue: QueueSender's Send trait and Sync trait should have bounds

### DIFF
--- a/crates/conqueue/RUSTSEC-0000-0000.md
+++ b/crates/conqueue/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "conqueue"
+date = "2020-11-24"
+url = "https://github.com/longshorej/conqueue/issues/9"
+categories = ["memory-corruption"]
+
+[versions]
+patched = [">= 0.4.0"]
+```
+
+# QueueSender<T>/QueueReceiver<T>: Send/Sync impls need `T: Send`
+
+Affected versions of this crate unconditionally implemented `Send`/`Sync` for `QueueSender<T>`,
+allowing to send non-Send `T` to other threads by invoking `(&QueueSender<T>).send()`.
+
+This fails to prevent users from creating data races by sending types like `Rc<T>` or `Arc<Cell<T>>` to other threads, which can lead to memory corruption.
+
+The flaw was corrected in commit 1e462c3 by imposing `T: Send` to both `Send`/`Sync` impls for `QueueSender<T>`/`QueueReceiver<T>`.


### PR DESCRIPTION
Original issue report: https://github.com/longshorej/conqueue/issues/9