### PR TITLE
ticketed_lock: ReadTicket and WriteTicket should only be sendable when T is Send

### DIFF
--- a/crates/ticketed_lock/RUSTSEC-0000-0000.md
+++ b/crates/ticketed_lock/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "ticketed_lock"
+date = "2020-11-17"
+url = "https://github.com/kvark/ticketed_lock/issues/7"
+categories = ["memory-corruption"]
+
+[versions]
+patched = [">= 0.3.0"]
+```
+
+# ReadTicket and WriteTicket should only be sendable when T is Send
+
+Affected versions of this crate unconditionally implemented `Send` for `ReadTicket<T>` & `WriteTicket<T>`.
+This allows to send non-Send `T` to other threads.
+
+This can allows creating data races by cloning types with internal mutability and sending them to other threads (as `T` of `ReadTicket<T>`/`WriteTicket<T>`). Such data races can cause memory corruption or other undefined behavior.
+
+The flaw was corrected in commit a986a93 by adding `T: Send` bounds to `Send` impls of `ReadTicket<T>`/`WriteTicket<T>`.


### PR DESCRIPTION
Original issue report: https://github.com/kvark/ticketed_lock/issues/7