### PR TITLE
libsbc: Decoder<R> can carry `R: !Send` to other threads

### DIFF
--- a/crates/libsbc/RUSTSEC-0000-0000.md
+++ b/crates/libsbc/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libsbc"
+date = "2020-11-10"
+url = "https://github.com/mvertescher/libsbc-rs/issues/4"
+categories = ["memory-corruption"]
+informational = "unsound"
+
+[versions]
+patched = [">= 0.1.5"]
+```
+
+# Minor soundness issue with Decoder's Send trait
+
+Affected versions of this crate implements `Send` for `Decoder<R>` for any `R: Read`. This allows to use `R: !Send` in `Decoder<R>` to send a non-Send type to another thread.
+
+This can result in undefined behavior such as memory corruption from data race on `R`, or dropping `R = MutexGuard<_>` from a thread that didn't lock the mutex.
+
+The flaw was corrected in commit a34d6e1 by adding trait bound `R: Send` to the `Send` impl for `Decoder<R>`.

--- a/crates/libsbc/RUSTSEC-0000-0000.md
+++ b/crates/libsbc/RUSTSEC-0000-0000.md
@@ -11,9 +11,9 @@ informational = "unsound"
 patched = [">= 0.1.5"]
 ```
 
-# Minor soundness issue with Decoder's Send trait
+# `Decoder<R>` can carry `R: !Send` to other threads
 
-Affected versions of this crate implements `Send` for `Decoder<R>` for any `R: Read`. This allows to use `R: !Send` in `Decoder<R>` to send a non-Send type to another thread.
+Affected versions of this crate implements `Send` for `Decoder<R>` for any `R: Read`. This allows `Decoder<R>` to contain `R: !Send` and carry (move) it to another thread.
 
 This can result in undefined behavior such as memory corruption from data race on `R`, or dropping `R = MutexGuard<_>` from a thread that didn't lock the mutex.
 


### PR DESCRIPTION
Original issue report: https://github.com/mvertescher/libsbc-rs/issues/4