### PR TITLE
ash: Reading on uninitialized memory may cause UB ( `util::read_spv()` )

### DIFF
--- a/crates/ash/RUSTSEC-0000-0000.md
+++ b/crates/ash/RUSTSEC-0000-0000.md
@@ -5,6 +5,7 @@ package = "ash"
 date = "2021-01-07"
 url = "https://github.com/MaikKlein/ash/issues/354"
 categories = ["memory-exposure"]
+informational = "unsound"
 
 [versions]
 patched = []

--- a/crates/ash/RUSTSEC-0000-0000.md
+++ b/crates/ash/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "ash"
+date = "2021-01-07"
+url = "https://github.com/MaikKlein/ash/issues/354"
+categories = ["memory-exposure"]
+
+[versions]
+patched = []
+```
+
+# Reading on uninitialized memory may cause UB ( `util::read_spv()` )
+
+Affected versions of this crate passes an uninitialized buffer to a user-provided `Read` implementation.
+
+Arbitrary `Read` implementations can read from the uninitialized buffer (memory exposure) and also can return incorrect number of bytes written to the buffer.
+Reading from uninitialized memory produces undefined values that can quickly invoke undefined behavior.


### PR DESCRIPTION
Original issue report: https://github.com/MaikKlein/ash/issues/354

As of Jan 2021, there doesn't seem to be an ideal fix that works in stable Rust with no performance overhead. Below are links to relevant discussions & suggestions for the fix.

* [Well-written document regarding the issue](https://paper.dropbox.com/doc/IO-Buffer-Initialization-MvytTgjIOTNpJAS6Mvw38)
* [Rust RFC 2930](https://github.com/rust-lang/rfcs/blob/master/text/2930-read-buf.md#summary)
* [nightly feature `std::io::Initializer`](https://doc.rust-lang.org/std/io/struct.Initializer.html)
* [Discussion in Rust Internals Forum](https://internals.rust-lang.org/t/uninitialized-memory/1652)

Thank you for reviewing this PR :)