### PR TITLE
abox: AtomicBox<T> implements Send/Sync for any `T: Sized`

### DIFF
--- a/crates/abox/RUSTSEC-0000-0000.md
+++ b/crates/abox/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "abox"
+date = "2020-11-10"
+url = "https://github.com/SonicFrog/abox/issues/1"
+categories = ["memory-corruption"]
+
+[versions]
+patched = [">= 0.4.1"]
+```
+
+# AtomicBox<T> implements Send/Sync for any `T: Sized`
+
+Affected versions of this crate implements `Send`/`Sync` for `AtomicBox<T>` without requiring `T: Send`/`T: Sync`. This allows to create data races to `T: !Sync` and send `T: !Send` to another thread.
+
+Such behavior breaks the compile-time thread safety guarantees of Rust, and allows users to incur undefined behavior using safe Rust (e.g. memory corruption from data race).
+
+The flaw was corrected in commit 34c2b9e by adding trait bound `T: Send` to `Send` impl for `AtomicBox<T>` and trait bound `T: Sync` to `Sync` impl for `AtomicBox<T>`.


### PR DESCRIPTION
Original issue report: https://github.com/SonicFrog/abox/issues/1