### PR TITLE
async-coap: ArcGuard's Send and Sync should have bounds on RC

### DIFF
--- a/crates/async-coap/RUSTSEC-0000-0000.md
+++ b/crates/async-coap/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "async-coap"
+date = "2020-12-08"
+url = "https://github.com/google/rust-async-coap/issues/33"
+categories = ["memory-corruption"]
+
+[versions]
+patched = []
+```
+
+# ArcGuard's Send and Sync should have bounds on RC
+
+Affected versions of this crate implement Send/Sync for `ArcGuard<RC, T>` with no trait bounds on `RC`. This allows users to send `RC: !Send` to other threads and also allows users to concurrently access `Rc: !Sync` from multiple threads.
+
+This can result in memory corruption from data race or other undefined behavior caused by sending `T: !Send` to other threads (e.g. dropping `MutexGuard<T>` in another thread that didn't lock its mutex).


### PR DESCRIPTION
Original issue report: https://github.com/google/rust-async-coap/issues/33