### PR TITLE
signal-simple: SyncChannel<T> can send non-Send types to other threads

### DIFF
--- a/crates/signal-simple/RUSTSEC-0000-0000.md
+++ b/crates/signal-simple/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "signal-simple"
+date = "2020-11-15"
+url = "https://github.com/kitsuneninetails/signal-rust/issues/2"
+categories = ["memory-corruption"]
+
+[versions]
+patched = []
+```
+
+# SyncChannel<T> can move 'T: !Send' to other threads
+
+Affected versions of this crate unconditionally implement Send/Sync for `SyncChannel<T>`.
+`SyncChannel<T>` doesn't provide access to `&T` but merely serves as a channel that consumes and returns owned `T`.
+
+Users can create UB in safe Rust by sending `T: !Send` to other threads with `SyncChannel::send/recv` APIs. Using `T = Arc<Cell<_>` allows to create data races (which can lead to memory corruption), and using `T = MutexGuard<T>` allows to unlock a mutex from a thread that didn't lock the mutex.


### PR DESCRIPTION
Original issue report: https://github.com/kitsuneninetails/signal-rust/issues/2