### PR TITLE
beef: beef::Cow lacks a Sync bound on its Send trait allowing for data races

### DIFF
--- a/crates/beef/RUSTSEC-0000-0000.md
+++ b/crates/beef/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "beef"
+date = "2020-10-28"
+url = "https://github.com/maciejhirsz/beef/issues/37"
+categories = ["memory-corruption"]
+
+[versions]
+patched = [">= 0.5.0"]
+```
+
+# beef::Cow lacks a Sync bound on its Send trait allowing for data races
+
+Affected versions of this crate did not have a `T: Sync` bound in the `Send` impl for `Cow<'_, T, U>`. This allows users to create data races by making `Cow` contain types that are (Send && !Sync) like `Cell<_>` or `RefCell<_>`.
+
+Such data races can lead to memory corruption.
+
+The flaw was corrected in commit d1c7658 by adding trait bounds `T: Sync` and `T::Owned: Send` to the `Send` impl for `Cow<'_, T, U>`.

--- a/crates/beef/RUSTSEC-0000-0000.md
+++ b/crates/beef/RUSTSEC-0000-0000.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-0000-0000"
 package = "beef"
 date = "2020-10-28"
 url = "https://github.com/maciejhirsz/beef/issues/37"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 
 [versions]
 patched = [">= 0.5.0"]


### PR DESCRIPTION
Original issue report: https://github.com/maciejhirsz/beef/issues/37