### PR TITLE
marc: Record::read : Custom `Read` on uninitialized buffer may cause UB

### DIFF
--- a/crates/marc/RUSTSEC-0000-0000.md
+++ b/crates/marc/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "marc"
+date = "2021-01-26"
+url = "https://github.com/blackbeam/rust-marc/issues/7"
+categories = ["memory-exposure"]
+
+[versions]
+patched = [">= 2.0.0"]
+```
+
+# Record::read : Custom `Read` on uninitialized buffer may cause UB
+
+Affected versions of this crate passes an uninitialized buffer to a user-provided `Read` implementation. (`Record::read()`)
+
+Arbitrary `Read` implementations can read from the uninitialized buffer (memory exposure) and also can return incorrect number of bytes written to the buffer.
+Reading from uninitialized memory produces undefined values that can quickly invoke undefined behavior.
+
+This flaw was fixed in commit 6299af0 by zero-initializing the newly allocated memory (via `data.resize(len, 0)`) instead of exposing uninitialized memory (`unsafe { data.set_len(len) }`).


### PR DESCRIPTION
Original issue report: https://github.com/blackbeam/rust-marc/issues/7

Thank you for reviewing :)