### PR TITLE
libp2p-deflate: Undefined data exposed in DeflateOutput's AsyncRead implementation

### DIFF
--- a/crates/libp2p-deflate/RUSTSEC-0000-0000.md
+++ b/crates/libp2p-deflate/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libp2p-deflate"
+date = "2020-01-24"
+url = "https://github.com/libp2p/rust-libp2p/issues/1932"
+categories = ["memory-exposure"]
+
+[versions]
+patched = [">= 0.27.1"]
+```
+
+# Undefined data exposed in DeflateOutput's AsyncRead implementation
+
+Affected versions of this crate passes an uninitialized buffer to a user-provided trait function `AsyncRead::poll_read()`.
+
+Arbitrary `AsyncRead::poll_read()` implementations can read from the uninitialized buffer (memory exposure) and also can return incorrect number of bytes written to the buffer.
+Reading from uninitialized memory produces undefined values that can quickly invoke undefined behavior.
+
+The flaw was fixed in commit 5ba266a by ensuring the newly allocated part of the buffer is zero-initialized before passing it to a user-provided `AsyncRead::poll_read()`.

--- a/crates/libp2p-deflate/RUSTSEC-0000-0000.md
+++ b/crates/libp2p-deflate/RUSTSEC-0000-0000.md
@@ -10,7 +10,7 @@ categories = ["memory-exposure"]
 patched = [">= 0.27.1"]
 ```
 
-# Undefined data exposed in DeflateOutput's AsyncRead implementation
+# Contents of uninitialized memory exposed in DeflateOutput's AsyncRead implementation
 
 Affected versions of this crate passes an uninitialized buffer to a user-provided trait function `AsyncRead::poll_read()`.
 


### PR DESCRIPTION
Original issue report: https://github.com/libp2p/rust-libp2p/issues/1932