### PR TITLE
Cache<K>: Send/Sync impls needs trait bounds on `K`

### DIFF
--- a/crates/cache/RUSTSEC-0000-0000.md
+++ b/crates/cache/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "cache"
+date = "2020-11-24"
+url = "https://github.com/krl/cache/issues/1"
+categories = ["memory-corruption", "thread-safety"]
+
+[versions]
+patched = []
+```
+
+# Cache<K>: Send/Sync impls needs trait bounds on `K`
+
+Affected versions of this crate unconditionally implement Send/Sync for `Cache<K>`.
+This allows users to insert `K` that is not Send or not Sync.
+
+This allows users to create data races by using non-Send types like `Arc<Cell<T>>` or `Rc<T>` as `K` in `Cache<K>`. It is also possible to create data races by using types like `Cell<T>` or `RefCell<T>` (types that are `Send` but not `Sync`).
+Such data races can lead to memory corruption.


### PR DESCRIPTION
Original issue report: https://github.com/krl/cache/issues/1