### PR TITLE
kekbit: ShmWriter allows sending non-Send type across threads

### DIFF
--- a/crates/kekbit/RUSTSEC-0000-0000.md
+++ b/crates/kekbit/RUSTSEC-0000-0000.md
@@ -1,0 +1,15 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "kekbit"
+date = "2020-12-18"
+url = "https://github.com/motoras/kekbit/issues/34"
+categories = ["memory-corruption", "thread-safety"]
+
+[versions]
+patched = []
+```
+
+# ShmWriter allows sending non-Send type across threads
+
+Affected versions of this crate implement `Send` for `ShmWriter<H>` without requiring `H: Send`. This allows users to send `H: !Send` to other threads, which can potentially lead to data races and undefined behavior.


### PR DESCRIPTION
Original issue report: https://github.com/motoras/kekbit/issues/34

The crate author hasn't been active on github for 6 months.