### PR TITLE
v9: SyncRef's clone() and debug() allow data races

### DIFF
--- a/crates/v9/RUSTSEC-0000-0000.md
+++ b/crates/v9/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "v9"
+date = "2020-12-18"
+url = "https://github.com/purpleposeidon/v9/issues/1"
+categories = ["memory-corruption", "thread-safety"]
+
+[versions]
+patched = []
+```
+
+# SyncRef's clone() and debug() allow data races
+
+Affected versions of this crate unconditionally implement `Sync` for `SyncRef<T>`.
+This definition allows data races if `&T` is accessible through `&SyncRef`.
+
+`SyncRef<T>` derives `Clone` and `Debug`, and the default implementations of those traits access `&T` by invoking `T::clone()` & `T::fmt()`. It is possible to create data races & undefined behavior by concurrently invoking `SyncRef<T>::clone()` or `SyncRef<T>::fmt()` from multiple threads with `T: !Sync`.


### PR DESCRIPTION
Original issue report: https://github.com/purpleposeidon/v9/issues/1