### PR TITLE
ms3d: `IoReader::read()`: user-provided `Read` on uninitialized buffer may cause UB

### DIFF
--- a/crates/ms3d/RUSTSEC-0000-0000.md
+++ b/crates/ms3d/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "ms3d"
+date = "2021-01-26"
+url = "https://github.com/andrewhickman/ms3d/issues/1"
+categories = ["memory-exposure"]
+
+[versions]
+patched = [">= 0.1.3"]
+```
+
+# `IoReader::read()`: user-provided `Read` on uninitialized buffer may cause UB
+
+Affected versions of this crate passes an uninitialized buffer to a user-provided `Read` implementation.
+
+Arbitrary `Read` implementations can read from the uninitialized buffer (memory exposure) and also can return incorrect number of bytes written to the buffer.
+Reading from uninitialized memory produces undefined values that can quickly invoke undefined behavior.
+
+The flaw was fixed in commit 599313b by zero-initializing the buffer (via `self.buf.resize(len, 0)`) before passing it to `Read`.


### PR DESCRIPTION
Original issue report: https://github.com/andrewhickman/ms3d/issues/1