### PR TITLE
Add thread-safety category to relevant bugs

### DIFF
--- a/crates/abox/RUSTSEC-2020-0121.md
+++ b/crates/abox/RUSTSEC-2020-0121.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0121"
 package = "abox"
 date = "2020-11-10"
 url = "https://github.com/SonicFrog/abox/issues/1"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 
 [versions]
 patched = [">= 0.4.1"]

--- a/crates/aovec/RUSTSEC-2020-0099.md
+++ b/crates/aovec/RUSTSEC-2020-0099.md
@@ -3,7 +3,7 @@
 id = "RUSTSEC-2020-0099"
 package = "aovec"
 date = "2020-12-10"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
 
 [versions]

--- a/crates/arr/RUSTSEC-2020-0034.md
+++ b/crates/arr/RUSTSEC-2020-0034.md
@@ -5,6 +5,7 @@ package = "arr"
 aliases = ["CVE-2020-35886", "CVE-2020-35887", "CVE-2020-35888"]
 date = "2020-08-25"
 url = "https://github.com/sjep/array/issues/1"
+categories = ["memory-corruption", "thread-safety"]
 
 [versions]
 patched = []

--- a/crates/async-coap/RUSTSEC-2020-0124.md
+++ b/crates/async-coap/RUSTSEC-2020-0124.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0124"
 package = "async-coap"
 date = "2020-12-08"
 url = "https://github.com/google/rust-async-coap/issues/33"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 
 [versions]
 patched = []

--- a/crates/atom/RUSTSEC-2020-0044.md
+++ b/crates/atom/RUSTSEC-2020-0044.md
@@ -6,6 +6,7 @@ aliases = ["CVE-2020-35897"]
 date = "2020-09-21"
 informational = "unsound"
 url = "https://github.com/slide-rs/atom/issues/13"
+categories = ["thread-safety"]
 
 [versions]
 patched = [">= 0.3.6"]

--- a/crates/atomic-option/RUSTSEC-2020-0113.md
+++ b/crates/atomic-option/RUSTSEC-2020-0113.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0113"
 package = "atomic-option"
 date = "2020-10-31"
 url = "https://github.com/reem/rust-atomic-option/issues/4"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 
 [versions]
 patched = []

--- a/crates/bunch/RUSTSEC-2020-0130.md
+++ b/crates/bunch/RUSTSEC-2020-0130.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0130"
 package = "bunch"
 date = "2020-11-12"
 url = "https://github.com/krl/bunch/issues/1"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 
 [versions]
 patched = []

--- a/crates/buttplug/RUSTSEC-2020-0112.md
+++ b/crates/buttplug/RUSTSEC-2020-0112.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0112"
 package = "buttplug"
 date = "2020-12-18"
 url = "https://github.com/buttplugio/buttplug-rs/issues/225"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 
 [versions]
 # Versions which include fixes for this vulnerability

--- a/crates/concread/RUSTSEC-2020-0092.md
+++ b/crates/concread/RUSTSEC-2020-0092.md
@@ -5,6 +5,7 @@ package = "concread"
 aliases = ["CVE-2020-35928"]
 date = "2020-11-13"
 url = "https://github.com/kanidm/concread/issues/48"
+categories = ["thread-safety"]
 informational = "unsound"
 
 [versions]

--- a/crates/conquer-once/RUSTSEC-2020-0101.md
+++ b/crates/conquer-once/RUSTSEC-2020-0101.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0101"
 package = "conquer-once"
 date = "2020-12-22"
 url = "https://github.com/oliver-giersch/conquer-once/issues/3"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
 
 [versions]

--- a/crates/conqueue/RUSTSEC-2020-0117.md
+++ b/crates/conqueue/RUSTSEC-2020-0117.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0117"
 package = "conqueue"
 date = "2020-11-24"
 url = "https://github.com/longshorej/conqueue/issues/9"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 
 [versions]
 patched = [">= 0.4.0"]

--- a/crates/dces/RUSTSEC-2020-0139.md
+++ b/crates/dces/RUSTSEC-2020-0139.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0139"
 package = "dces"
 date = "2020-12-09"
 url = "https://gitlab.redox-os.org/redox-os/dces-rust/-/issues/8"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
 
 [versions]

--- a/crates/eventio/RUSTSEC-2020-0108.md
+++ b/crates/eventio/RUSTSEC-2020-0108.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0108"
 package = "eventio"
 date = "2020-12-20"
 url = "https://github.com/petabi/eventio/issues/33"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 
 [versions]
 patched = [">= 0.5.1"]

--- a/crates/futures-intrusive/RUSTSEC-2020-0072.md
+++ b/crates/futures-intrusive/RUSTSEC-2020-0072.md
@@ -5,7 +5,7 @@ package = "futures-intrusive"
 aliases = ["CVE-2020-35915"]
 date = "2020-10-31"
 url = "https://github.com/Matthias247/futures-intrusive/issues/53"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
 informational = "unsound"
 

--- a/crates/futures-util/RUSTSEC-2020-0059.md
+++ b/crates/futures-util/RUSTSEC-2020-0059.md
@@ -5,7 +5,7 @@ package = "futures-util"
 aliases = ["CVE-2020-35905"]
 date = "2020-10-22"
 url = "https://github.com/rust-lang/futures-rs/issues/2239"
-categories = ["memory-corruption"]
+categories = ["thread-safety"]
 keywords = ["concurrency", "memory-corruption", "memory-management"]
 
 [affected]

--- a/crates/futures-util/RUSTSEC-2020-0062.md
+++ b/crates/futures-util/RUSTSEC-2020-0062.md
@@ -5,7 +5,7 @@ package = "futures-util"
 aliases = ["CVE-2020-35908"]
 date = "2020-01-24"
 url = "https://github.com/rust-lang/futures-rs/issues/2050"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency", "memory-corruption", "memory-management"]
 
 [affected]
@@ -18,7 +18,7 @@ unaffected = ["< 0.3.0"]
 
 # Improper `Sync` implementation on `FuturesUnordered` in futures-utils can cause data corruption
 Affected versions of the crate had an unsound `Sync` implementation on the `FuturesUnordered` structure, which used a `Cell` for
-interior mutablity without any code to handle synchronized access to the underlying task list's length and head safely.
+interior mutability without any code to handle synchronized access to the underlying task list's length and head safely.
 
 This could of lead to data corruption since two threads modifying the list at once could see incorrect values due to the lack
 of access synchronization.

--- a/crates/gfwx/RUSTSEC-2020-0104.md
+++ b/crates/gfwx/RUSTSEC-2020-0104.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0104"
 package = "gfwx"
 date = "2020-12-08"
 url = "https://github.com/Devolutions/gfwx-rs/issues/7"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 
 [versions]
 patched = [">= 0.3.0"]

--- a/crates/hashconsing/RUSTSEC-2020-0107.md
+++ b/crates/hashconsing/RUSTSEC-2020-0107.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0107"
 package = "hashconsing"
 date = "2020-11-10"
 url = "https://github.com/AdrienChampion/hashconsing/issues/1"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
 [versions]
 patched = [">= 1.1.0"]

--- a/crates/im/RUSTSEC-2020-0096.md
+++ b/crates/im/RUSTSEC-2020-0096.md
@@ -4,6 +4,7 @@ id = "RUSTSEC-2020-0096"
 package = "im"
 date = "2020-11-09"
 url = "https://github.com/bodil/im-rs/issues/157"
+categories = ["thread-safety"]
 informational = "unsound"
 
 [versions]

--- a/crates/late-static/RUSTSEC-2020-0102.md
+++ b/crates/late-static/RUSTSEC-2020-0102.md
@@ -4,13 +4,13 @@ id = "RUSTSEC-2020-0102"
 package = "late-static"
 date = "2020-11-10"
 url = "https://github.com/Richard-W/late-static/issues/1"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 
 [versions]
 patched = [">= 0.4.0"]
 ```
 
-# LateStatic
+# LateStatic has incorrect Sync bound
 
 Affected versions of this crate implemented `Sync` for `LateStatic` with `T: Send`, so that it is possible to create a data race to a type `T: Send + !Sync` (e.g. `Cell<T>`).
 

--- a/crates/lever/RUSTSEC-2020-0137.md
+++ b/crates/lever/RUSTSEC-2020-0137.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0137"
 package = "lever"
 date = "2020-11-10"
 url = "https://github.com/vertexclique/lever/issues/15"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
 
 [versions]

--- a/crates/lexer/RUSTSEC-2020-0138.md
+++ b/crates/lexer/RUSTSEC-2020-0138.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0138"
 package = "lexer"
 date = "2020-11-10"
 url = "https://gitlab.com/nathanfaucett/rs-lexer/-/issues/2"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 
 [versions]
 patched = []

--- a/crates/libsbc/RUSTSEC-2020-0120.md
+++ b/crates/libsbc/RUSTSEC-2020-0120.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0120"
 package = "libsbc"
 date = "2020-11-10"
 url = "https://github.com/mvertescher/libsbc-rs/issues/4"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 informational = "unsound"
 
 [versions]

--- a/crates/lock_api/RUSTSEC-2020-0070.md
+++ b/crates/lock_api/RUSTSEC-2020-0070.md
@@ -11,7 +11,7 @@ aliases = [
 ]
 date = "2020-11-08"
 url = "https://github.com/Amanieu/parking_lot/pull/262"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
 informational = "unsound"
 

--- a/crates/magnetic/RUSTSEC-2020-0088.md
+++ b/crates/magnetic/RUSTSEC-2020-0088.md
@@ -5,6 +5,7 @@ package = "magnetic"
 aliases = ["CVE-2020-35925"]
 date = "2020-11-29"
 url = "https://github.com/johnshaw/magnetic/issues/9"
+categories = ["thread-safety"]
 
 [versions]
 patched = [">= 2.0.1"]

--- a/crates/may_queue/RUSTSEC-2020-0111.md
+++ b/crates/may_queue/RUSTSEC-2020-0111.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0111"
 package = "may_queue"
 date = "2020-11-10"
 url = "https://github.com/Xudong-Huang/may/issues/88"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
 
 [versions]

--- a/crates/model/RUSTSEC-2020-0140.md
+++ b/crates/model/RUSTSEC-2020-0140.md
@@ -4,6 +4,7 @@ id = "RUSTSEC-2020-0140"
 package = "model"
 date = "2020-11-10"
 url = "https://github.com/spacejam/model/issues/3"
+categories = ["thread-safety"]
 informational = "unsound"
 
 [versions]

--- a/crates/multiqueue2/RUSTSEC-2020-0106.md
+++ b/crates/multiqueue2/RUSTSEC-2020-0106.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0106"
 package = "multiqueue2"
 date = "2020-12-19"
 url = "https://github.com/abbychau/multiqueue2/issues/10"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 informational = "unsound"
 
 [versions]

--- a/crates/parc/RUSTSEC-2020-0134.md
+++ b/crates/parc/RUSTSEC-2020-0134.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0134"
 package = "parc"
 date = "2020-11-14"
 url = "https://github.com/hyyking/rustracts/pull/6"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 
 [versions]
 patched = []

--- a/crates/rcu_cell/RUSTSEC-2020-0131.md
+++ b/crates/rcu_cell/RUSTSEC-2020-0131.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0131"
 package = "rcu_cell"
 date = "2020-11-14"
 url = "https://github.com/Xudong-Huang/rcu_cell/issues/3"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 
 [versions]
 patched = []

--- a/crates/reffers/RUSTSEC-2020-0094.md
+++ b/crates/reffers/RUSTSEC-2020-0094.md
@@ -5,7 +5,7 @@ package = "reffers"
 date = "2020-12-01"
 url = "https://github.com/diwic/reffers-rs/issues/7"
 informational = "unsound"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
 
 [versions]

--- a/crates/rusb/RUSTSEC-2020-0098.md
+++ b/crates/rusb/RUSTSEC-2020-0098.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0098"
 package = "rusb"
 date = "2020-12-18"
 url = "https://github.com/a1ien/rusb/issues/44"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
 informational = "unsound"
 

--- a/crates/ruspiro-singleton/RUSTSEC-2020-0115.md
+++ b/crates/ruspiro-singleton/RUSTSEC-2020-0115.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0115"
 package = "ruspiro-singleton"
 date = "2020-11-16"
 url = "https://github.com/RusPiRo/ruspiro-singleton/issues/10"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
 
 [versions]

--- a/crates/scottqueue/RUSTSEC-2020-0133.md
+++ b/crates/scottqueue/RUSTSEC-2020-0133.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0133"
 package = "scottqueue"
 date = "2020-11-15"
 url = "https://github.com/rossdylan/rust-scottqueue/issues/1"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 
 [versions]
 patched = []

--- a/crates/signal-simple/RUSTSEC-2020-0126.md
+++ b/crates/signal-simple/RUSTSEC-2020-0126.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0126"
 package = "signal-simple"
 date = "2020-11-15"
 url = "https://github.com/kitsuneninetails/signal-rust/issues/2"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 
 [versions]
 patched = []

--- a/crates/slock/RUSTSEC-2020-0135.md
+++ b/crates/slock/RUSTSEC-2020-0135.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0135"
 package = "slock"
 date = "2020-11-17"
 url = "https://github.com/BrokenLamp/slock-rs/issues/2"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 
 [versions]
 patched = []

--- a/crates/thex/RUSTSEC-2020-0090.md
+++ b/crates/thex/RUSTSEC-2020-0090.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0090"
 package = "thex"
 aliases = ["CVE-2020-35927"]
 date = "2020-12-08"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
 
 [versions]

--- a/crates/ticketed_lock/RUSTSEC-2020-0119.md
+++ b/crates/ticketed_lock/RUSTSEC-2020-0119.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0119"
 package = "ticketed_lock"
 date = "2020-11-17"
 url = "https://github.com/kvark/ticketed_lock/issues/7"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 
 [versions]
 patched = [">= 0.3.0"]

--- a/crates/tiny_future/RUSTSEC-2020-0118.md
+++ b/crates/tiny_future/RUSTSEC-2020-0118.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0118"
 package = "tiny_future"
 date = "2020-12-08"
 url = "https://github.com/KizzyCode/tiny_future/issues/1"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
 
 [versions]

--- a/crates/toolshed/RUSTSEC-2020-0136.md
+++ b/crates/toolshed/RUSTSEC-2020-0136.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0136"
 package = "toolshed"
 date = "2020-11-15"
 url = "https://github.com/ratel-rust/toolshed/issues/12"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
 
 [versions]

--- a/crates/try-mutex/RUSTSEC-2020-0087.md
+++ b/crates/try-mutex/RUSTSEC-2020-0087.md
@@ -5,6 +5,7 @@ package = "try-mutex"
 aliases = ["CVE-2020-35924"]
 date = "2020-11-17"
 url = "https://github.com/mpdn/try-mutex/issues/2"
+categories = ["thread-safety"]
 
 [versions]
 patched = [">= 0.3.0"]

--- a/crates/unicycle/RUSTSEC-2020-0116.md
+++ b/crates/unicycle/RUSTSEC-2020-0116.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0116"
 package = "unicycle"
 date = "2020-11-15"
 url = "https://github.com/udoprog/unicycle/issues/8"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 
 [versions]
 patched = [">= 0.7.1"]

--- a/crates/va-ts/RUSTSEC-2020-0114.md
+++ b/crates/va-ts/RUSTSEC-2020-0114.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0114"
 package = "va-ts"
 date = "2020-12-22"
 url = "https://github.com/video-audio/va-ts/issues/4"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 
 [versions]
 patched = [">= 0.0.4"]

--- a/crates/xcb/RUSTSEC-2020-0097.md
+++ b/crates/xcb/RUSTSEC-2020-0097.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2020-0097"
 package = "xcb"
 date = "2020-12-10"
 url = "https://github.com/rtbo/rust-xcb/issues/93"
-categories = ["memory-corruption"]
+categories = ["memory-corruption", "thread-safety"]
 informational = "unsound"
 
 [versions]


### PR DESCRIPTION
Besides updating the categories, this PR contains the following fixes:
* Add a proper title to `LateStatic` report (the title was just "LateStatic")
* Fix a typo in `futures-util` report: mutablity -> mutability