### PR TITLE
noise_search: `MvccRwLock` allows data races & aliasing violations

### DIFF
--- a/crates/noise_search/RUSTSEC-0000-0000.md
+++ b/crates/noise_search/RUSTSEC-0000-0000.md
@@ -13,6 +13,6 @@ patched = []
 # MvccRwLock allows data races & aliasing violations
 
 Affected versions of this crate unconditionally implement Send/Sync for `MvccRwLock`.
-This can lead to data races when non Send types like `Cell<T>` or `Rc<T>` are contained inside `MvccRwLock` and sent across thread boundaries. The data races can potentially lead to memory corruption (as demonstrated in the PoC from the original report issue).
+This can lead to data races when types that are either `!Send` or `!Sync` (e.g. `Rc<T>`, `Arc<Cell<_>>`) are contained inside `MvccRwLock` and sent across thread boundaries. The data races can potentially lead to memory corruption (as demonstrated in the PoC from the original report issue).
 
 Also, safe APIs of `MvccRwLock` allow aliasing violations by allowing `&T` and `LockResult<MutexGuard<Box<T>>>` to co-exist in conflicting lifetime regions. The APIs of `MvccRwLock` should either be marked as `unsafe` or `MbccRwLock` should be changed to private or pub(crate).

--- a/crates/noise_search/RUSTSEC-0000-0000.md
+++ b/crates/noise_search/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "noise_search"
+date = "2020-12-10"
+url = "https://github.com/pipedown/noise/issues/72"
+categories = ["memory-corruption", "thread-safety"]
+
+[versions]
+patched = []
+```
+
+# MvccRwLock allows data races & aliasing violations
+
+Affected versions of this crate unconditionally implement Send/Sync for `MvccRwLock`.
+This can lead to data races when non Send types like `Cell<T>` or `Rc<T>` are contained inside `MvccRwLock` and sent across thread boundaries. The data races can potentially lead to memory corruption (as demonstrated in the PoC from the original report issue).
+
+Also, safe APIs of `MvccRwLock` allow aliasing violations by allowing `&T` and `LockResult<MutexGuard<Box<T>>>` to co-exist in conflicting lifetime regions. The APIs of `MvccRwLock` should either be marked as `unsafe` or `MbccRwLock` should be changed to private or pub(crate).


### PR DESCRIPTION
Original issue report: https://github.com/pipedown/noise/issues/72