### PR TITLE
Lever 0.1.1 patch

### DIFF
--- a/crates/lever/RUSTSEC-2020-0137.md
+++ b/crates/lever/RUSTSEC-2020-0137.md
@@ -8,7 +8,7 @@ categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
 
 [versions]
-patched = []
+patched = [">= 0.1.1"]
 ```
 
 # AtomicBox<T> lacks bound on its Send and Sync traits allowing data races


### PR DESCRIPTION
Lever 0.1.1 patch fixes [RUSTSEC-2020-0137](https://rustsec.org/advisories/RUSTSEC-2020-0137.html), thanks to [this issue](https://github.com/vertexclique/lever/issues/15) and [this pull request](https://github.com/vertexclique/lever/pull/17).

Thanks for letting us know, and thanks for reviewing, please let me know if there's anything I can do to improve this pull request :)

