### PR TITLE
add patched version for calamine

### DIFF
--- a/crates/calamine/RUSTSEC-2021-0015.md
+++ b/crates/calamine/RUSTSEC-2021-0015.md
@@ -7,7 +7,7 @@ url = "https://github.com/tafia/calamine/issues/199"
 categories = ["memory-corruption", "memory-exposure"]
 
 [versions]
-patched = []
+patched = [">= 0.17.0"]
 ```
 
 # `Sectors::get` accesses unclaimed/uninitialized memory


### PR DESCRIPTION
RUSTSEC-2021-0015 has been patched in v0.17.0.