### PR TITLE
RUSTSEC-2020-0100: Update date field

### DIFF
--- a/crates/sys-info/RUSTSEC-2020-0100.md
+++ b/crates/sys-info/RUSTSEC-2020-0100.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "RUSTSEC-2020-0100"
 package = "sys-info"
-date = "2020-01-19"
+date = "2020-05-31"
 url = "https://github.com/FillZpp/sys-info-rs/issues/63"
 categories = ["memory-corruption"]
 keywords = ["concurrency", "double free"]


### PR DESCRIPTION
Update the date field of RUSTSEC-2020-0100 to the date when the original issue was reported.
The current date 2020-01-19 seems to be a typo of 2021-01-19, the date when the RustSec PR was created.