### PR TITLE
multiqueue: Queues allow non-Send types to be sent to other threads, allowing data races

### DIFF
--- a/crates/multiqueue/RUSTSEC-0000-0000.md
+++ b/crates/multiqueue/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "multiqueue"
+date = "2020-12-25"
+url = "https://github.com/schets/multiqueue/issues/31"
+categories = ["memory-corruption", "thread-safety"]
+
+[versions]
+patched = []
+```
+
+# Queues allow non-Send types to be sent to other threads, allowing data races
+
+Affected versions of this crate unconditionally implemented `Send` for types used in queue implementations (`InnerSend<RW, T>`, `InnerRecv<RW, T>`, `FutInnerSend<RW, T>`, `FutInnerRecv<RW, T>`).
+
+This allows users to send non-Send types to other threads, which can lead to data race bugs or other undefined behavior.


### PR DESCRIPTION
Original issue report: https://github.com/schets/multiqueue/issues/31