### PR TITLE
[patched] Add advisory for double-free in qwutils

### DIFF
--- a/crates/qwutils/RUSTSEC-0000-0000.md
+++ b/crates/qwutils/RUSTSEC-0000-0000.md
@@ -1,0 +1,26 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "qwutils"
+date = "2021-02-03"
+url = "https://github.com/qwertz19281/rust_utils/issues/3"
+categories = ["memory-corruption"]
+keywords = ["memory-safety", "double-free"]
+
+[versions]
+patched = [">= 0.3.1"]
+
+[affected]
+functions = { "qwutils::imp::vec::VecExt::insert_slice_clone" = ["< 0.3.1"] }
+```
+
+# insert_slice_clone can double drop if Clone panics.
+
+Affected versions of this crate used `ptr::copy` when inserting into the middle
+of a `Vec`. When ownership was temporarily duplicated during this copy, it calls
+the clone method of a user provided element.
+
+This issue can result in an element being double-freed if the clone call panics.
+
+Commit `20cb73d` fixed this issue by adding a `set_len(0)` call before
+operating on the vector to avoid dropping the elements during a panic.


### PR DESCRIPTION
Upstream issue: https://github.com/qwertz19281/rust_utils/issues/3