### PR TITLE
Report various rust-xcb issues to RustSec

### DIFF
--- a/crates/xcb/RUSTSEC-0000-0000.md
+++ b/crates/xcb/RUSTSEC-0000-0000.md
@@ -1,0 +1,70 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "xcb"
+date = "2021-02-04"
+categories = ["memory-corruption", "memory-exposure"]
+
+[versions]
+patched = []
+```
+
+# Multiple soundness issues and unmaintained
+
+## Calls `std::str::from_utf8_unchecked()` without any checks
+
+The function `xcb::xproto::GetAtomNameReply::name()` calls
+`std::str::from_utf8_unchecked()` on the raw bytes that were received from the
+X11 server without any validity checks. The X11 server only prevents interior
+null bytes, but otherwise allows any X11 client to create an atom for arbitrary
+bytes.
+
+This issue is tracked here: https://github.com/rtbo/rust-xcb/issues/96
+
+## `xcb::xproto::GetPropertyReply::value()` allows arbitrary return types
+
+The function `xcb::xproto::GetPropertyReply::value()` returns a slice of type
+`T` where `T` is an unconstrained type parameter. The raw bytes received from
+the X11 server are interpreted as the requested type.
+
+The users of the `xcb` crate are advised to only call this function with the
+intended types. These are `u8`, `u16`, and `u32`.
+
+This issue is tracked here: https://github.com/rtbo/rust-xcb/issues/95
+
+## Out of bounds read in `xcb::xproto::change_property()`
+
+`xcb::xproto::change_property` has (among others) the arguments `format: u8` and
+`data: &[T]`. The intended use is one of the following cases:
+- `format = 8` and `T = u8`
+- `format = 16` and `T = u16`
+- `format = 32` and `T = u32`
+However, this constraint is not enforced. For example, it is possible to call
+the function with `format = 32` and `T = u8`. In this case, a read beyond the
+end of the `data` slice is performed and the bytes are sent to the X11 server.
+
+The users of the `xcb` crate are advised to only call this function with one of
+the intended argument combinations.
+
+This issue is tracked here: https://github.com/rtbo/rust-xcb/issues/94
+
+## 'Safe' wrapper around `std::mem::transmute()`
+
+The function `xcb::base::cast_event()` takes a reference to a
+`xcb::base::GenericEvent` and returns a reference to an arbitrary type, as
+requested by the caller (or found via type interference). The function is
+implemented as a direct call to `std::mem::transmute()`. Since the return type
+is not constrained, this allows transmution to an incorrect type or a type that
+is larger than the X11 event that was passed in.
+
+X11 events are mostly always 32 bytes large and this function works as intended.
+
+Users are advised to only cast to the event structs provided by the `xcb` crate
+(and hope for the best).
+
+This issue is tracked here: https://github.com/rtbo/rust-xcb/issues/78
+
+## xcb is unmaintained
+
+The `xcb` crate is no longer maintained by its current owner and a replacement
+is sought.

--- a/crates/xcb/RUSTSEC-0000-0000.md
+++ b/crates/xcb/RUSTSEC-0000-0000.md
@@ -9,7 +9,7 @@ categories = ["memory-corruption", "memory-exposure"]
 patched = []
 ```
 
-# Multiple soundness issues and unmaintained
+# Multiple soundness issues
 
 ## Calls `std::str::from_utf8_unchecked()` without any checks
 
@@ -63,8 +63,3 @@ Users are advised to only cast to the event structs provided by the `xcb` crate
 (and hope for the best).
 
 This issue is tracked here: https://github.com/rtbo/rust-xcb/issues/78
-
-## xcb is unmaintained
-
-The `xcb` crate is no longer maintained by its current owner and a replacement
-is sought.


### PR DESCRIPTION
Closes: https://github.com/RustSec/advisory-db/issues/653

---

As requested by @Shnatsel, here is my attempt at an advisory. I tried to follow what #575 does, but elaborate all the various issues in sub-headings. I did not include `informational = "unsound"` (#575 has this), because this is also `informational = "unmaintained"` and this `informational` entry seems to be undocumented (I only found its use in various advisories), so I am not sure what to do. My best idea: If wanted/necessary, I can split this into two PRs, one for the maintenance status and one for the other issues.

---

I'm also nervous about "there is a code generator that turns XML into lots and lots of `unsafe` code, most of that in functions that are supposed to be safe", but that's likely not worth an advisory. At least this makes it a lot harder to review the code in this crate since I first have to find the actual code in `target/`. Just saying.

(I suppose `cargo geiger` would warn users about this, at least)

---

I take this chance to say "Thank you!" to @Shnatsel. I saw your nick name already a couple of times and my first association to "Shnatsel" is "lots of work for Rust security", like fuzzing, advisory, code review infrastructure etc. If someone else had pinged me and asked for a PR, I am not sure what I would have done, but this is my chance to help you helping Rust. Thanks for all your work.