### PR TITLE
Add advisory URL to RUSTSEC-2021-0019

### DIFF
--- a/crates/xcb/RUSTSEC-2021-0019.md
+++ b/crates/xcb/RUSTSEC-2021-0019.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0019"
 package = "xcb"
 date = "2021-02-04"
+url = "https://github.com/RustSec/advisory-db/issues/653"
 categories = ["memory-corruption", "memory-exposure"]
 
 [versions]


### PR DESCRIPTION

Advisories without URLs are slightly disadvantageous to automated consumers of the JSON output of `cargo audit --json` as any reference to the advisory created automatically has no context for reviewers to learn more.

Since there currently is no URL reference for the recently added RUSTSEC-2021-0019 advisory against `xcb`, I added the rustsec.org one since it is the most complete, compared to the [original issue](https://github.com/RustSec/advisory-db/issues/653).
