### PR TITLE
Add link to site

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 [![Project Chat][chat-image]][chat-link]
 
 The RustSec Advisory Database is a repository of security advisories filed
-against Rust crates published via https://crates.io
+against Rust crates published via https://crates.io. A human-readable version
+of the advisory database can be found at https://rustsec.org/advisories/.
 
 The following tools consume this advisory database and can be used for auditing
 and reporting (send PRs to add yours):


### PR DESCRIPTION
When I was l looking for the rustsec.org recently with keywords like "rust advisory database", I found the repository but had some trouble finding the site (perhaps to my defaulting to use DuckDuckGo). A link here makes sense, I think?