### PR TITLE
sshkeys: lack of cert verification vuln

### DIFF
--- a/crates/sshkeys/RUSTSEC-0000-0000.md
+++ b/crates/sshkeys/RUSTSEC-0000-0000.md
@@ -1,0 +1,7 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "sshkeys"
+date = "2021-02-08"
+url = "https://github.com/dnaeon/rust-sshkeys/issues/4"
+categories = ["privilege-escalation"]
+keywords = ["ssh"]


### PR DESCRIPTION
sshkeys does not verify certificate signatures, making anyone relying
upon this vulnerable to trivial privilege escalation by presenting a
bogus certificate that lists the proper CA and fake signature.

Note, though the `fix version` field is mandatory, I've left it out b/c there is no fix yet.