### PR TITLE
sshkeys: lack of cert verification vuln

### DIFF
--- a/crates/sshkeys/RUSTSEC-0000-0000.md
+++ b/crates/sshkeys/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "sshkeys"
+date = "2021-02-08"
+url = "https://github.com/dnaeon/rust-sshkeys/issues/4"
+categories = ["privilege-escalation"]
+keywords = ["ssh"]
+
+[versions]
+patched = []
+```
+
+# sshkeys does not verify certificate signature
+
+sshkeys will parse an SSH certificate into its fields without verifying the signature on the
+certificate.  This can lead developers to think the certificate is valid and decide to trust
+it for authentication or authorization purposes.  However, it would be trivial to present a
+complete bogus certificate with a fake signature and get authenticated by such a system.  It
+is advisable to not use this crate until signature verification is added.


### PR DESCRIPTION
sshkeys does not verify certificate signatures, making anyone relying
upon this vulnerable to trivial privilege escalation by presenting a
bogus certificate that lists the proper CA and fake signature.

The mandatory field to specify fix version is omitted because no fix exists.