### PR TITLE
Add advisory on nb-connect SocketAddr casting

### DIFF
--- a/crates/nb-connect/RUSTSEC-0000-0000.md
+++ b/crates/nb-connect/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "nb-connect"
+date = "2021-02-14"
+url = "https://github.com/smol-rs/nb-connect/issues/1"
+keywords = ["memory", "layout", "cast"]
+informational = "unsound"
+
+[versions]
+patched = [">= 1.0.3"]
+```
+
+# `nb-connect` invalidly assumes the memory layout of std::net::SocketAddr
+
+The [`nb-connect`](https://crates.io/crates/nb-connect) crate has assumed `std::net::SocketAddrV4`
+and `std::net::SocketAddrV6` have the same memory layout as the system C representation
+`sockaddr`. It has simply casted the pointers to convert the socket addresses to the
+system representation. The standard library does not say anything about the memory
+layout, and this will cause invalid memory access if the standard library
+changes the implementation. No warnings or errors will be emitted once the
+change happens.


### PR DESCRIPTION
The equivalent of #503, #505, #509 and #507. But for the `nb-connect` crate. Before the 1.0.3 release `nb-connect` invalidly assumed the memory layout of a standard library type. Something that is not part of the stable API of `std`.

https://github.com/smol-rs/nb-connect/issues/1