### PR TITLE
Fixed memory corruption.

### DIFF
--- a/crates/array-tools/RUSTSEC-2020-0132.md
+++ b/crates/array-tools/RUSTSEC-2020-0132.md
@@ -7,7 +7,7 @@ url = "https://github.com/L117/array-tools/issues/2"
 categories = ["memory-corruption"]
 
 [versions]
-patched = []
+patched = [">= 0.3.2"]
 ```
 
 # `FixedCapacityDequeLike::clone()` can cause dropping uninitialized memory


### PR DESCRIPTION
https://github.com/L117/array-tools/commit/709d89f23c5b2e81ed25537446f838c3cdb73b6f (v0.3.2 on crates.io)