### PR TITLE
Update CVE numbers

### DIFF
--- a/crates/abi_stable/RUSTSEC-2020-0105.md
+++ b/crates/abi_stable/RUSTSEC-2020-0105.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2020-0105"
 package = "abi_stable"
+aliases = ["CVE-2020-36212", "CVE-2020-36213"]
 date = "2020-12-21"
 url = "https://github.com/rodrimati1992/abi_stable_crates/issues/44"
 categories = ["memory-corruption"]

--- a/crates/aovec/RUSTSEC-2020-0099.md
+++ b/crates/aovec/RUSTSEC-2020-0099.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2020-0099"
 package = "aovec"
+aliases = ["CVE-2020-36207"]
 date = "2020-12-10"
 categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]

--- a/crates/async-h1/RUSTSEC-2020-0093.md
+++ b/crates/async-h1/RUSTSEC-2020-0093.md
@@ -2,12 +2,11 @@
 [advisory]
 id = "RUSTSEC-2020-0093"
 package = "async-h1"
-aliases = ["CVE-2020-36202"]
 date = "2020-12-17"
 url = "https://github.com/http-rs/async-h1/releases/tag/v2.3.0"
 categories = []
 keywords = ["smuggling", "http", "reverse proxy", "request smuggling"]
-aliases = ["GHSA-4vr9-8cjf-vf9c"]
+aliases = ["CVE-2020-36202", "GHSA-4vr9-8cjf-vf9c"]
 
 [versions]
 patched = [">= 2.3.0"]

--- a/crates/async-h1/RUSTSEC-2020-0093.md
+++ b/crates/async-h1/RUSTSEC-2020-0093.md
@@ -6,7 +6,7 @@ date = "2020-12-17"
 url = "https://github.com/http-rs/async-h1/releases/tag/v2.3.0"
 categories = []
 keywords = ["smuggling", "http", "reverse proxy", "request smuggling"]
-aliases = ["CVE-2020-36202", "GHSA-4vr9-8cjf-vf9c"]
+aliases = ["CVE-2020-26281", "CVE-2020-36202", "GHSA-4vr9-8cjf-vf9c"]
 
 [versions]
 patched = [">= 2.3.0"]

--- a/crates/async-h1/RUSTSEC-2020-0093.md
+++ b/crates/async-h1/RUSTSEC-2020-0093.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2020-0093"
 package = "async-h1"
+aliases = ["CVE-2020-36202"]
 date = "2020-12-17"
 url = "https://github.com/http-rs/async-h1/releases/tag/v2.3.0"
 categories = []

--- a/crates/atomic-option/RUSTSEC-2020-0113.md
+++ b/crates/atomic-option/RUSTSEC-2020-0113.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2020-0113"
 package = "atomic-option"
+aliases = ["CVE-2020-36219"]
 date = "2020-10-31"
 url = "https://github.com/reem/rust-atomic-option/issues/4"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/autorand/RUSTSEC-2020-0103.md
+++ b/crates/autorand/RUSTSEC-2020-0103.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2020-0103"
 package = "autorand"
+aliases = ["CVE-2020-36210"]
 date = "2020-12-31"
 url = "https://github.com/mersinvald/autorand-rs/issues/5"
 categories = ["memory-corruption"]

--- a/crates/av-data/RUSTSEC-2021-0007.md
+++ b/crates/av-data/RUSTSEC-2021-0007.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0007"
 package = "av-data"
+aliases = ["CVE-2021-25904"]
 date = "2021-01-07"
 url = "https://github.com/rust-av/rust-av/issues/136"
 categories = ["memory-exposure", "privilege-escalation"]

--- a/crates/basic_dsp_matrix/RUSTSEC-2021-0009.md
+++ b/crates/basic_dsp_matrix/RUSTSEC-2021-0009.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0009"
 package = "basic_dsp_matrix"
+aliases = ["CVE-2021-25906"]
 date = "2021-01-10"
 url = "https://github.com/liebharc/basic_dsp/issues/47"
 categories = ["memory-corruption"]

--- a/crates/bra/RUSTSEC-2021-0008.md
+++ b/crates/bra/RUSTSEC-2021-0008.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0008"
 package = "bra"
+aliases = ["CVE-2021-25905"]
 date = "2021-01-02"
 url = "https://github.com/Enet4/bra-rs/issues/1"
 categories = ["memory-exposure"]

--- a/crates/buttplug/RUSTSEC-2020-0112.md
+++ b/crates/buttplug/RUSTSEC-2020-0112.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2020-0112"
 package = "buttplug"
+aliases = ["CVE-2020-36218"]
 date = "2020-12-18"
 url = "https://github.com/buttplugio/buttplug-rs/issues/225"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/cache/RUSTSEC-2021-0006.md
+++ b/crates/cache/RUSTSEC-2021-0006.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0006"
 package = "cache"
+aliases = ["CVE-2021-25903"]
 date = "2021-01-01"
 url = "https://github.com/krl/cache/issues/2"
 informational = "unsound"

--- a/crates/calamine/RUSTSEC-2021-0015.md
+++ b/crates/calamine/RUSTSEC-2021-0015.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0015"
 package = "calamine"
+aliases = ["CVE-2021-26951"]
 date = "2021-01-06"
 url = "https://github.com/tafia/calamine/issues/199"
 categories = ["memory-corruption", "memory-exposure"]

--- a/crates/cdr/RUSTSEC-2021-0012.md
+++ b/crates/cdr/RUSTSEC-2021-0012.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0012"
 package = "cdr"
+aliases = ["CVE-2021-26305"]
 date = "2021-01-02"
 url = "https://github.com/hrektts/cdr-rs/issues/10"
 categories = ["memory-exposure"]

--- a/crates/comrak/RUSTSEC-2021-0026.md
+++ b/crates/comrak/RUSTSEC-2021-0026.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0026"
 package = "comrak"
+aliases = ["CVE-2021-27671"]
 date = "2021-02-21"
 url = "https://github.com/kivikakk/comrak/releases/tag/0.9.1"
 categories = ["format-injection"]

--- a/crates/conquer-once/RUSTSEC-2020-0101.md
+++ b/crates/conquer-once/RUSTSEC-2020-0101.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2020-0101"
 package = "conquer-once"
+aliases = ["CVE-2020-36208"]
 date = "2020-12-22"
 url = "https://github.com/oliver-giersch/conquer-once/issues/3"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/containers/RUSTSEC-2021-0010.md
+++ b/crates/containers/RUSTSEC-2021-0010.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0010"
 package = "containers"
+aliases = ["CVE-2021-25907"]
 date = "2021-01-12"
 url = "https://github.com/strake/containers.rs/issues/2"
 categories = ["memory-corruption"]

--- a/crates/eventio/RUSTSEC-2020-0108.md
+++ b/crates/eventio/RUSTSEC-2020-0108.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2020-0108"
 package = "eventio"
+aliases = ["CVE-2020-36216"]
 date = "2020-12-20"
 url = "https://github.com/petabi/eventio/issues/33"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/fil-ocl/RUSTSEC-2021-0011.md
+++ b/crates/fil-ocl/RUSTSEC-2021-0011.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0011"
 package = "fil-ocl"
+aliases = ["CVE-2021-25908"]
 date = "2021-01-04"
 url = "https://github.com/cogciprocate/ocl/issues/194"
 categories = ["memory-corruption"]

--- a/crates/gfwx/RUSTSEC-2020-0104.md
+++ b/crates/gfwx/RUSTSEC-2020-0104.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2020-0104"
 package = "gfwx"
+aliases = ["CVE-2020-36211"]
 date = "2020-12-08"
 url = "https://github.com/Devolutions/gfwx-rs/issues/7"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/glsl-layout/RUSTSEC-2021-0005.md
+++ b/crates/glsl-layout/RUSTSEC-2021-0005.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0005"
 package = "glsl-layout"
+aliases = ["CVE-2021-25902"]
 date = "2021-01-10"
 url = "https://github.com/rustgd/glsl-layout/pull/10"
 categories = ["memory-corruption"]

--- a/crates/hashconsing/RUSTSEC-2020-0107.md
+++ b/crates/hashconsing/RUSTSEC-2020-0107.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2020-0107"
 package = "hashconsing"
+aliases = ["CVE-2020-36215"]
 date = "2020-11-10"
 url = "https://github.com/AdrienChampion/hashconsing/issues/1"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/im/RUSTSEC-2020-0096.md
+++ b/crates/im/RUSTSEC-2020-0096.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2020-0096"
 package = "im"
+aliases = ["CVE-2020-36204"]
 date = "2020-11-09"
 url = "https://github.com/bodil/im-rs/issues/157"
 categories = ["thread-safety"]

--- a/crates/late-static/RUSTSEC-2020-0102.md
+++ b/crates/late-static/RUSTSEC-2020-0102.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2020-0102"
 package = "late-static"
+aliases = ["CVE-2020-36209"]
 date = "2020-11-10"
 url = "https://github.com/Richard-W/late-static/issues/1"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/lazy-init/RUSTSEC-2021-0004.md
+++ b/crates/lazy-init/RUSTSEC-2021-0004.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0004"
 package = "lazy-init"
+aliases = ["CVE-2021-25901"]
 date = "2021-01-17"
 categories = ["memory-corruption"]
 url = "https://github.com/khuey/lazy-init/issues/9"

--- a/crates/marc/RUSTSEC-2021-0014.md
+++ b/crates/marc/RUSTSEC-2021-0014.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0014"
 package = "marc"
+aliases = ["CVE-2021-26308"]
 date = "2021-01-26"
 url = "https://github.com/blackbeam/rust-marc/issues/7"
 categories = ["memory-exposure"]

--- a/crates/may_queue/RUSTSEC-2020-0111.md
+++ b/crates/may_queue/RUSTSEC-2020-0111.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2020-0111"
 package = "may_queue"
+aliases = ["CVE-2020-36217"]
 date = "2020-11-10"
 url = "https://github.com/Xudong-Huang/may/issues/88"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/ms3d/RUSTSEC-2021-0016.md
+++ b/crates/ms3d/RUSTSEC-2021-0016.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0016"
 package = "ms3d"
+aliases = ["CVE-2021-26952"]
 date = "2021-01-26"
 url = "https://github.com/andrewhickman/ms3d/issues/1"
 categories = ["memory-exposure"]

--- a/crates/multiqueue2/RUSTSEC-2020-0106.md
+++ b/crates/multiqueue2/RUSTSEC-2020-0106.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2020-0106"
 package = "multiqueue2"
+aliases = ["CVE-2020-36214"]
 date = "2020-12-19"
 url = "https://github.com/abbychau/multiqueue2/issues/10"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/nb-connect/RUSTSEC-2021-0021.md
+++ b/crates/nb-connect/RUSTSEC-2021-0021.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0021"
 package = "nb-connect"
+aliases = ["CVE-2021-27376"]
 date = "2021-02-14"
 url = "https://github.com/smol-rs/nb-connect/issues/1"
 keywords = ["memory", "layout", "cast"]

--- a/crates/postscript/RUSTSEC-2021-0017.md
+++ b/crates/postscript/RUSTSEC-2021-0017.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0017"
 package = "postscript"
+aliases = ["CVE-2021-26953"]
 date = "2021-01-30"
 url = "https://github.com/bodoni/postscript/issues/1"
 categories = ["memory-exposure"]

--- a/crates/qwutils/RUSTSEC-2021-0018.md
+++ b/crates/qwutils/RUSTSEC-2021-0018.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0018"
 package = "qwutils"
+aliases = ["CVE-2021-26954"]
 date = "2021-02-03"
 url = "https://github.com/qwertz19281/rust_utils/issues/3"
 categories = ["memory-corruption"]

--- a/crates/rand_core/RUSTSEC-2021-0023.md
+++ b/crates/rand_core/RUSTSEC-2021-0023.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0023"
 package = "rand_core"
+aliases = ["CVE-2021-27378"]
 date = "2021-02-12"
 url = "https://github.com/rust-random/rand/pull/1096"
 categories = ["crypto-failure"]

--- a/crates/raw-cpuid/RUSTSEC-2021-0013.md
+++ b/crates/raw-cpuid/RUSTSEC-2021-0013.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0013"
 package = "raw-cpuid"
+aliases = ["CVE-2021-26306", "CVE-2021-26307"]
 date = "2021-01-20"
 url = "https://github.com/RustSec/advisory-db/pull/614"
 categories = ["memory-corruption", "denial-of-service"]

--- a/crates/reffers/RUSTSEC-2020-0094.md
+++ b/crates/reffers/RUSTSEC-2020-0094.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2020-0094"
 package = "reffers"
+aliases = ["CVE-2020-36203"]
 date = "2020-12-01"
 url = "https://github.com/diwic/reffers-rs/issues/7"
 informational = "unsound"

--- a/crates/rusb/RUSTSEC-2020-0098.md
+++ b/crates/rusb/RUSTSEC-2020-0098.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2020-0098"
 package = "rusb"
+aliases = ["CVE-2020-36206"]
 date = "2020-12-18"
 url = "https://github.com/a1ien/rusb/issues/44"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/smallvec/RUSTSEC-2021-0003.md
+++ b/crates/smallvec/RUSTSEC-2021-0003.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0003"
 package = "smallvec"
+aliases = ["CVE-2021-25900"]
 date = "2021-01-08"
 url = "https://github.com/servo/rust-smallvec/issues/252"
 categories = ["memory-corruption"]

--- a/crates/va-ts/RUSTSEC-2020-0114.md
+++ b/crates/va-ts/RUSTSEC-2020-0114.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2020-0114"
 package = "va-ts"
+aliases = ["CVE-2020-36220"]
 date = "2020-12-22"
 url = "https://github.com/video-audio/va-ts/issues/4"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/xcb/RUSTSEC-2020-0097.md
+++ b/crates/xcb/RUSTSEC-2020-0097.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2020-0097"
 package = "xcb"
+aliases = ["CVE-2020-36205"]
 date = "2020-12-10"
 url = "https://github.com/rtbo/rust-xcb/issues/93"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/xcb/RUSTSEC-2021-0019.md
+++ b/crates/xcb/RUSTSEC-2021-0019.md
@@ -2,6 +2,12 @@
 [advisory]
 id = "RUSTSEC-2021-0019"
 package = "xcb"
+aliases = [
+    "CVE-2021-26955",
+    "CVE-2021-26956",
+    "CVE-2021-26957",
+    "CVE-2021-26958",
+]
 date = "2021-02-04"
 url = "https://github.com/RustSec/advisory-db/issues/653"
 categories = ["memory-corruption", "memory-exposure"]

--- a/crates/yottadb/RUSTSEC-2021-0022.md
+++ b/crates/yottadb/RUSTSEC-2021-0022.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0022"
 package = "yottadb"
+aliases = ["CVE-2021-27377"]
 date = "2021-02-09"
 url = "https://gitlab.com/YottaDB/Lang/YDBRust/-/issues/40"
 categories = ["memory-corruption"]


### PR DESCRIPTION
CVE numbers were looked up at: https://cve.mitre.org/cgi-bin/cvekey.cgi?keyword=rust

These two bugs do not have corresponding RUSTSEC entries, so we might need to add them.
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-21235
* https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-21269