### PR TITLE
heapless: use-after-free when cloning partially consumed Iterator

### DIFF
--- a/crates/heapless/RUSTSEC-0000-0000.md
+++ b/crates/heapless/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "heapless"
+date = "2010-11-02"
+url = "https://github.com/japaric/heapless/issues/181"
+categories = ["memory-corruption", "memory-exposure"]
+keywords = ["use-after-free"]
+informational = "unsound"
+
+[affected.functions]
+"heapless::vec::IntoIter::clone" = ["<= 0.6"]
+
+[versions]
+patched = []
+```
+
+# Use-after-free when cloning a partially consumed `Vec` iterator
+
+The `IntoIter` `Clone` implementation clones the whole underlying `Vec`.
+If the iterator is partially consumed the consumed items will be copied, thus creating a use-after-free access.
+
+A proof of concept is available in the original bug report.


### PR DESCRIPTION
Original issue: https://github.com/japaric/heapless/issues/181

There is a proof-of-concept in the original bug report.
The issue is not yet fixed.