### PR TITLE
Add an advisory on lifetime extension in generic-array

### DIFF
--- a/crates/generic-array/RUSTSEC-0000-0000.md
+++ b/crates/generic-array/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "generic-array"
+date = "2020-04-09"
+url = "https://github.com/fizyk20/generic-array/issues/98"
+categories = ["memory-corruption"]
+keywords = ["soundness"]
+
+[versions]
+patched = [">= 0.14.0"]
+unaffected = ["< 0.8.0"]
+```
+
+# arr! macro erases lifetimes
+
+Affected versions of this crate allowed unsoundly extending
+lifetimes using `arr!` macro. This may result in a variety of
+memory corruption scenarios, most likely use-after-free.


### PR DESCRIPTION
This is an advisory for an old version of `generic-array`, however some crates (notably `headers`) still use those old versions of `generic-array`.