### PR TITLE
[patched] Add advisory for out-of-bounds write in bam

### DIFF
--- a/crates/bam/RUSTSEC-0000-0000.md
+++ b/crates/bam/RUSTSEC-0000-0000.md
@@ -1,0 +1,28 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "bam"
+date = "2021-01-07"
+url = "https://gitlab.com/tprodanov/bam/-/issues/4"
+categories = ["memory-corruption"]
+
+[versions]
+patched = [">= 0.1.3"]
+
+[affected]
+functions = { "bam::bgzip::Block::load" = ["< 0.1.3"] }
+```
+
+# Loading a bgzip block can write out of bounds if size overflows.
+
+Affected versions of `bam` set the length of an internal buffer using
+`self.compressed.set_len(block_size - HEADER_SIZE - MIN_EXTRA_SIZE)` and then
+wrote into it. While `block_size` was constrained to a proper maximum, when it
+was too small the subtraction could overflow negatively to a large number past
+the capacity of `self.compressed`.
+
+This can result in memory corruption in the form of writing out of bounds when
+loading a `bgzip` file with a small `block_size`.
+
+Commit `061eee38d4` fixed this issue by checking for the underflow when setting
+the buffer size.


### PR DESCRIPTION
Upstream issue: https://gitlab.com/tprodanov/bam/-/issues/4