### PR TITLE
[patched] Add advisory for memory safety issue in toodee's insert_row

### DIFF
--- a/crates/toodee/RUSTSEC-0000-0000.md
+++ b/crates/toodee/RUSTSEC-0000-0000.md
@@ -1,0 +1,30 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "toodee"
+date = "2021-02-19"
+url = "https://github.com/antonmarsden/toodee/issues/13"
+categories = ["memory-corruption"]
+keywords = ["memory-safety", "double-free"]
+
+[versions]
+patched = [">= 0.3.0"]
+unaffected = []
+
+[affected]
+functions = { "toodee::TooDee::insert_row" = ["< 0.3.0"] }
+```
+
+# Multiple memory safety issues in insert_row
+
+When inserting rows from an iterator at a particular index, `toodee` would shift
+items over, duplicating their ownership. The space reserved for the new elements
+was based on the `len()` returned by the `ExactSizeIterator`.
+
+This could result in elements in the array being freed twice if the iterator
+panics. Uninitialized or previously freed elements could also be exposed if the
+`len()` didn't match the number of elements.
+
+These issues were fixed in commit `ced70c17` by temporarily setting the length
+of the array smaller while processing it and adding assertions on the number
+of elements returned by the iterator.


### PR DESCRIPTION
Upstream issue: https://github.com/antonmarsden/toodee/issues/13