### PR TITLE
[patched] Report uninitialized memory exposure in truetype

### DIFF
--- a/crates/truetype/RUSTSEC-0000-0000.md
+++ b/crates/truetype/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "truetype"
+date = "2021-02-17"
+url = "https://github.com/bodoni/truetype/issues/11"
+categories = ["memory-exposure"]
+
+[versions]
+patched = [">= 0.30.1"]
+```
+
+# Tape::take_bytes exposes uninitialized memory to a user-provided Read
+
+Affected versions of this crate passed an unininitialized buffer to a
+user-provided `Read` instance in `Tape::take_bytes`.
+
+This can result in safe `Read` implementations reading from the uninitialized
+buffer leading to undefined behavior.
+
+The flaw was corrected in commit `1f2dc7f37dd` by removing the unsafe block
+and zero-initializing the buffer.


### PR DESCRIPTION
Upstream issue: https://github.com/bodoni/truetype/issues/11