### PR TITLE
Mark RUSTSEC-2020-0146 as unsound

### DIFF
--- a/crates/generic-array/RUSTSEC-2020-0146.md
+++ b/crates/generic-array/RUSTSEC-2020-0146.md
@@ -5,6 +5,7 @@ package = "generic-array"
 date = "2020-04-09"
 informational = "unsound"
 url = "https://github.com/fizyk20/generic-array/issues/98"
+categories = ["memory-corruption"]
 
 [versions]
 patched = [">= 0.14.0"]

--- a/crates/generic-array/RUSTSEC-2020-0146.md
+++ b/crates/generic-array/RUSTSEC-2020-0146.md
@@ -3,9 +3,8 @@
 id = "RUSTSEC-2020-0146"
 package = "generic-array"
 date = "2020-04-09"
+informational = "unsound"
 url = "https://github.com/fizyk20/generic-array/issues/98"
-categories = ["memory-corruption"]
-keywords = ["soundness"]
 
 [versions]
 patched = [">= 0.14.0"]


### PR DESCRIPTION
I didn't realize this was an option because it wasn't in example advisory.