### PR TITLE
Revert "Mark RUSTSEC-2020-0146 as unsound (#788)"

### DIFF
--- a/crates/generic-array/RUSTSEC-2020-0146.md
+++ b/crates/generic-array/RUSTSEC-2020-0146.md
@@ -3,9 +3,9 @@
 id = "RUSTSEC-2020-0146"
 package = "generic-array"
 date = "2020-04-09"
-informational = "unsound"
 url = "https://github.com/fizyk20/generic-array/issues/98"
 categories = ["memory-corruption"]
+keywords = ["soundness"]
 
 [versions]
 patched = [


### PR DESCRIPTION
Allows use-after-free, and looks easy enough to trigger.