### PR TITLE
Add unmaintained advisory for rulinalg crate

### DIFF
--- a/crates/rulinalg/RUSTSEC-0000-0000.md
+++ b/crates/rulinalg/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rulinalg"
+date = "2020-02-11"
+url = "https://github.com/AtheMathmo/rulinalg/issues/201#issuecomment-584749313"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# rulinalg is unmaintained, use nalgebra instead
+
+The `rulinalg` crate is no longer maintained, use [nalgebra](https://crates.io/crates/nalgebra)
+instead.


### PR DESCRIPTION
As per the author in https://github.com/AtheMathmo/rulinalg/issues/201#issuecomment-584749313 and this note in the README: https://github.com/AtheMathmo/rulinalg/commit/0ea49678d2dfa0e0a0df9cd26f49f6330aef80c4

They recommend `nalgebra` as an alternative.