### PR TITLE
Add unmaintained advisory for office crate. Fixes #742

### DIFF
--- a/crates/office/RUSTSEC-0000-0000.md
+++ b/crates/office/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "office"
+date = "2021-02-04"
+url = "https://github.com/RustSec/advisory-db/issues/742#issuecomment-773313783"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# office is unmaintained, use calamine instead
+
+The `office` crate is unmaintained. Use [calamine](https://crates.io/crates/calamine)
+for reading excel files.
+
+Contact the `office` author for ownership of the package name.


### PR DESCRIPTION
As per the author in https://github.com/RustSec/advisory-db/issues/742#issuecomment-773313783

Office is not supported and has been replaced by `calamine`.