### PR TITLE
Report use-after-free issue in diesels sqlite backend

### DIFF
--- a/crates/diesel/RUSTSEC-0000-0000.md
+++ b/crates/diesel/RUSTSEC-0000-0000.md
@@ -15,7 +15,7 @@ patched = [">= 1.4.6"]
 
 # Fix a use-after-free bug in diesels Sqlite backend
 
-We've missused `sqlite3_column_name`. The
+We've misused `sqlite3_column_name`. The
 [SQLite](https://www.sqlite.org/c3ref/column_name.html) documentation
 states that the following:
 

--- a/crates/diesel/RUSTSEC-0000-0000.md
+++ b/crates/diesel/RUSTSEC-0000-0000.md
@@ -1,0 +1,31 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "diesel"
+date = "2021-03-05"
+url = "https://github.com/diesel-rs/diesel/pull/2663"
+categories = ["memory-exposure"]
+keywords = ["use after free"]
+
+[affected]
+functions = { "diesel::SqliteConnection::query_by_name" = ["< 1.4.6"] }
+[versions]
+patched = [">= 1.4.6"]
+```
+
+# Fix a use-after-free bug in diesels Sqlite backend
+
+We've missused `sqlite3_column_name`. The
+[SQLite](https://www.sqlite.org/c3ref/column_name.html) documentation
+states that the following:
+
+> The returned string pointer is valid until either the prepared statement
+> is destroyed by sqlite3_finalize() or until the statement is automatically
+> reprepared by the first call to sqlite3_step() for a particular
+> run or until the next call to sqlite3_column_name()
+> or sqlite3_column_name16() on the same column.
+
+As part of our `query_by_name` infrastructure we've first received all
+field names for the prepared statement and stored them as string slices
+for later use. After that we called `sqlite3_step()` for the first time,
+which invalids the pointer and therefore the stored string slice.

--- a/crates/diesel/RUSTSEC-0000-0000.md
+++ b/crates/diesel/RUSTSEC-0000-0000.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-0000-0000"
 package = "diesel"
 date = "2021-03-05"
 url = "https://github.com/diesel-rs/diesel/pull/2663"
-categories = ["memory-exposure"]
+categories = ["memory-corruption"]
 keywords = ["use after free"]
 
 [affected]


### PR DESCRIPTION
We've discovered a use-after-free issue in diesel's sqlite backend, which can be triggered by real world code. See the corresponding PR (https://github.com/diesel-rs/diesel/pull/2663) for details.