### PR TITLE
 Update rustsec-admin version to use new website generator

### DIFF
--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -14,12 +14,12 @@ jobs:
       - uses: actions/cache@v1
         with:
           path: ~/.cargo/bin
-          key: rustsec-admin-v0.3.4
+          key: rustsec-admin-v0.4.0
       - run: |
           if [ ! -f $HOME/.cargo/bin/rustsec-admin ]; then
-           cargo install rustsec-admin --vers 0.3.4
+           cargo install rustsec-admin --vers 0.4.0
           fi
-          rustsec-admin web
+          rustsec-admin web .
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .


### PR DESCRIPTION
This should hopefully finish simplifying the website rendering pipeline and fix some of the escaping issues.

**Don't merge this until [rustsec-admin](https://github.com/RustSec/rustsec-admin) has received a version bump and release.**

-----

Since this alters the output of the static file generation, the `gh-pages` branch either needs to be reset, either with a full history reset (will require a force push):

1. `git branch -d gh-pages` _(Delete the branch)_
2. `git checkout --orphan gh-pages` _(Create a new orphan/empty branch)_
3. `git rm -rf .` 

Or if we want to maintain the existing history of the branch, just:

1. `git rm -rf .` 

After which we need to add a `.nojekyll` file so github doesn't try to build the website with jekyll anymore.

1. `touch .nojekyll`
2. `git add .nojekyll`
3. `git commit -m "Add nojekyll file for new website generator"`