### PR TITLE
endian_trait: panic in user-provided `Endian` impl triggers double drop of T

### DIFF
--- a/crates/endian_trait/RUSTSEC-0000-0000.md
+++ b/crates/endian_trait/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "endian_trait"
+date = "2021-01-04"
+url = "https://gitlab.com/myrrlyn/endian_trait/-/issues/1"
+categories = ["memory-corruption"]
+
+[versions]
+patched = []
+```
+
+# panic in user-provided `Endian` impl triggers double drop of T
+
+Affected versions of the crate does not guard against panic from user-provided impl of `Endian` trait, which is a safe trait that users can implement.
+If a user-provided implementation of the `Endian` trait panics, double-drop is triggered due to the duplicated ownership of `T` created by `ptr::read()`.
+
+Double-drop (or double free) can cause memory corruption in the heap.


### PR DESCRIPTION
Original issue report: https://gitlab.com/myrrlyn/endian_trait/-/issues/1