### PR TITLE
Mirror 'main' branch to 'master'

### DIFF
--- a/.github/workflows/mirror-main-to-master.yml
+++ b/.github/workflows/mirror-main-to-master.yml
@@ -1,0 +1,14 @@
+# Temporary job to support clients which still consume 'master'
+# See: <https://github.com/RustSec/advisory-db/issues/312>
+name: Mirror 'main' branch to 'master'
+
+on:
+  push:
+    branches: master
+
+jobs:
+  publish-web:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: git push origin master:main


### PR DESCRIPTION
The 'master' branch has been renamed to 'main' per https://github.com/RustSec/advisory-db/issues/312

However older clients are still consuming the 'master' branch.

This commit adds a GitHub Actions job which mirrors the 'main' branch to 'master' to continue supporting these older clients.