### PR TITLE
Add advisory for double-free in insert_many

### DIFF
--- a/crates/insert_many/RUSTSEC-0000-0000.md
+++ b/crates/insert_many/RUSTSEC-0000-0000.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "insert_many"
+date = "2021-01-26"
+url = "https://github.com/rphmeier/insert_many/issues/1"
+categories = ["memory-corruption"]
+keywords = ["memory-safety", "double-free"]
+
+[versions]
+patched = []
+```
+
+# insert_many can drop elements twice on panic
+
+Affected versions of `insert_many` used `ptr::copy` to move over items in a
+vector to make space before inserting, duplicating their ownership. It then
+iterated over a provided `Iterator` to insert the new items.
+
+If the iterator's `.next()` method panics then the vector would drop the same
+elements twice.


### PR DESCRIPTION
Upstream issue: https://github.com/rphmeier/insert_many/issues/1

It's been open for 2 months now with no response from the author.