### PR TITLE
[patched] Add advisory for use-after-free in rocket

### DIFF
--- a/crates/rocket/RUSTSEC-0000-0000.md
+++ b/crates/rocket/RUSTSEC-0000-0000.md
@@ -1,0 +1,31 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rocket"
+date = "2021-02-09"
+url = "https://github.com/SergioBenitez/Rocket/issues/1534"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["memory-safety", "use-after-free"]
+
+[versions]
+patched = [">= 0.4.7"]
+```
+
+# Use after free possible in `uri::Formatter` on panic
+
+Affected versions of this crate transmuted a `&str` to a `&'static str` before
+pushing it into a `StackVec`, this value was then popped later in the same
+function.
+
+This was assumed to be safe because the reference would be valid while the
+method's stack was active. In between the push and the pop, however, a function
+`f` was called that could invoke a user provided function.
+
+If the user provided panicked, then the assumption used by the function was no
+longer true and the transmute to `&'static` would create an illegal static
+reference to the string that could result in a freed string being used.
+
+This flaw was corrected in commit [e325e2f](https://github.com/SergioBenitez/Rocket/commit/e325e2fce4d9f9f392761e9fb58b418a48cef8bb)
+by using a guard object to ensure that the `&'static str` was dropped inside
+the function.

--- a/crates/rocket/RUSTSEC-0000-0000.md
+++ b/crates/rocket/RUSTSEC-0000-0000.md
@@ -24,7 +24,9 @@ method's stack was active. In between the push and the pop, however, a function
 
 If the user provided panicked, then the assumption used by the function was no
 longer true and the transmute to `&'static` would create an illegal static
-reference to the string that could result in a freed string being used.
+reference to the string. This could result in a freed string being used during
+(such as in a `Drop` implementation) or after (e.g through `catch_unwind`) the
+panic unwinding.
 
 This flaw was corrected in commit [e325e2f](https://github.com/SergioBenitez/Rocket/commit/e325e2fce4d9f9f392761e9fb58b418a48cef8bb)
 by using a guard object to ensure that the `&'static str` was dropped inside


### PR DESCRIPTION
Upstream issue: https://github.com/SergioBenitez/Rocket/issues/1534

Marked as `informational = unsound` because as per the original bug thread, it is rare for users to actually implement a custom `UriDisplay` and it's unlikely for such a method to panic since it just deals with string formatting.