### PR TITLE
Add advisory for uninitialized memory exposure in messagepack-rs

### DIFF
--- a/crates/messagepack-rs/RUSTSEC-0000-0000.md
+++ b/crates/messagepack-rs/RUSTSEC-0000-0000.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "messagepack-rs"
+date = "2021-01-26"
+url = "https://github.com/otake84/messagepack-rs/issues/2"
+categories = ["memory-exposure"]
+
+[versions]
+patched = []
+```
+
+# Deserialization functions pass uninitialized memory to user-provided Read
+
+Affected versions of this crate passed an uninitialized buffer to a
+user-provided `Read` instance in:
+
+* `deserialize_binary`
+* `deserialize_string`
+* `deserialize_extension_others`
+* `deserialize_string_primitive`
+
+This can result in safe `Read` implementations reading from the uninitialized
+buffer leading to undefined behavior.
+


### PR DESCRIPTION
Upstream issue: https://github.com/otake84/messagepack-rs/issues/2

Open for 2 months with no response from the author.