### PR TITLE
[patched] Add advisory for uninitialized exposure in uu_od

### DIFF
--- a/crates/uu_od/RUSTSEC-0000-0000.md
+++ b/crates/uu_od/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "uu_od"
+date = "2021-02-17"
+url = "https://github.com/uutils/coreutils/issues/1729"
+categories = ["memory-exposure"]
+
+[versions]
+patched = [">= 0.0.4"]
+```
+
+# PartialReader passes uninitialized memory to user-provided Read
+
+Affected versions of this crate passed an uniniitalized buffer to a
+user-provided `Read` instance in `PartialReader::read`.
+
+This can result in safe `Read` implementations reading from the uninitialized
+buffer leading to undefined behavior.
+
+The flaw was fixed in commit [`39d62c6`](https://github.com/uutils/coreutils/commit/39d62c6c1f809022c903180471c10fde6ecd12d1)
+by zero-initializing the passed buffer.


### PR DESCRIPTION
Upstream issue: https://github.com/uutils/coreutils/issues/1729