### PR TITLE
Report uninitialized memory drop in adtensor

### DIFF
--- a/crates/adtensor/RUSTSEC-0000-0000.md
+++ b/crates/adtensor/RUSTSEC-0000-0000.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "adtensor"
+date = "2021-01-11"
+url = "https://github.com/charles-r-earp/adtensor/issues/4"
+categories = ["memory-corruption"]
+keywords = ["memory-safety"]
+
+[versions]
+patched = []
+```
+
+# FromIterator implementation for Vector/Matrix can drop uninitialized memory
+
+The `FromIterator<T>` methods for `Vector` and `Matrix` rely on the type
+parameter `N` to allocate space in the iterable.
+
+If the passed in `N` type parameter is larger than the number of items returned
+by the iterator, it can lead to uninitialized memory being left in the
+`Vector` or `Matrix` type which gets dropped.


### PR DESCRIPTION
Upstream issue: https://github.com/charles-r-earp/adtensor/issues/4

Open for 3 months without a response from the crate author.