### PR TITLE
RUSTSEC-2021-0020 is fixed in hyper 0.12.36 too

### DIFF
--- a/crates/hyper/RUSTSEC-2021-0020.md
+++ b/crates/hyper/RUSTSEC-2021-0020.md
@@ -9,7 +9,7 @@ keywords = ["http", "request-smuggling"]
 aliases = ["CVE-2021-21299"]
 
 [versions]
-patched = [">= 0.14.3", "0.13.10"]
+patched = [">= 0.14.3", "0.13.10", "0.12.36"]
 unaffected = ["< 0.12.0"]
 ```
 


### PR DESCRIPTION
The fix was backported to 0.12.x in https://github.com/hyperium/hyper/pull/2436 and released in 0.12.36.

Changelog: https://github.com/hyperium/hyper/blob/0.12.x/CHANGELOG.md#v01236-2021-02-17, _http1: fix server misinterpretting multiple Transfer-Encoding headers_ line