### PR TITLE
Add advisory for out-of-bounds write and uninitialized memory exposure in reorder

### DIFF
--- a/crates/reorder/RUSTSEC-0000-0000.md
+++ b/crates/reorder/RUSTSEC-0000-0000.md
@@ -1,0 +1,28 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "reorder"
+date = "2021-02-24"
+url = "https://github.com/tiby312/reorder/issues/1"
+keywords = ["memory-corruption", "out-of-bounds"]
+
+[versions]
+patched = []
+```
+
+# swap_index can write out of bounds and return uninitialized memory
+
+`swap_index` takes an iterator and swaps the items with their corresponding
+indexes. It reserves capacity and sets the length of the vector based on the
+`.len()` method of the iterator.
+
+If the `len()` returned by the iterator is larger than the actual number of
+elements yielded, then `swap_index` creates a vector containing uninitialized
+members. If the `len()` returned by the iterator is smaller than the actual
+number of members yielded, then `swap_index` can write out of bounds past
+its allocated vector.
+
+As noted by the Rust documentation, [`len()`](https://doc.rust-lang.org/std/iter/trait.ExactSizeIterator.html#method.len)
+and `size_hint()` are primarily meant for optimization and incorrect values
+from their implementations should not lead to memory safety violations.
+


### PR DESCRIPTION
Upstream issue: https://github.com/tiby312/reorder/issues/1

Been open now for a little over a month with no response.