### PR TITLE
Add advisory for out-of-bounds read in rdiff

### DIFF
--- a/crates/rdiff/RUSTSEC-0000-0000.md
+++ b/crates/rdiff/RUSTSEC-0000-0000.md
@@ -5,6 +5,7 @@ package = "rdiff"
 date = "2021-02-03"
 url = "https://github.com/dyule/rdiff/issues/3"
 categories = ["memory-exposure"]
+informational = "unsound"
 
 [versions]
 patched = []

--- a/crates/rdiff/RUSTSEC-0000-0000.md
+++ b/crates/rdiff/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rdiff"
+date = "2021-02-03"
+url = "https://github.com/dyule/rdiff/issues/3"
+categories = ["memory-exposure"]
+
+[versions]
+patched = []
+```
+
+# Window can read out of bounds if Read instance returns more bytes than buffer size
+
+`rdiff` performs a diff of two provided strings or files. As part of its reading
+code it uses the return value of a `Read` instance to set the length of
+its internal character vector.
+
+If the `Read` implementation claims that it has read more bytes than the length
+of the provided buffer, the length of the vector will be set to longer than its
+capacity. This causes `rdiff` APIs to return uninitialized memory in its API
+methods.


### PR DESCRIPTION
Upstream issue: https://github.com/dyule/rdiff/issues/3

Open for around two months now with no response.