### PR TITLE
Update advisory to indicate patched versions of stackvector.

### DIFF
--- a/crates/stackvector/RUSTSEC-2021-0048.md
+++ b/crates/stackvector/RUSTSEC-2021-0048.md
@@ -7,7 +7,7 @@ url = "https://github.com/Alexhuszagh/rust-stackvector/issues/2"
 categories = ["memory-corruption"]
 
 [versions]
-patched = []
+patched = ["1.0.9"]
 ```
 
 # StackVec::extend can write out of bounds when size_hint is incorrect


### PR DESCRIPTION
A memory corruption issue in the `extend` method of https://github.com/Alexhuszagh/rust-stackvector/issues/2 has been patched in this [commit](https://github.com/Alexhuszagh/rust-stackvector/commit/f45657d5a823a67bb3f5cffee65efbb401a44192). All versions prior to this commit have been yanked from [crates.io](https://crates.io/crates/stackvector/versions) out of precaution, so any available versions should be unaffected.