### PR TITLE
Track std bugs that received CVE numbers

### DIFF
--- a/rust/std/CVE-2015-20001.md
+++ b/rust/std/CVE-2015-20001.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "CVE-2015-20001"
+package = "std"
+categories = ["memory-corruption"]
+date = "2015-05-27"
+url = "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-20001"
+
+[versions]
+patched = [">= 1.2.0"]
+unaffected = ["< 1.0.0"]
+```
+
+# Panic safety violation in BinaryHeap
+
+In the standard library in Rust before 1.2.0, BinaryHeap is not panic-safe. The binary heap is left in an inconsistent state when the comparison of generic elements inside sift_up or sift_down_range panics. This bug leads to a drop of zeroed memory as an arbitrary type, which can result in a memory safety violation.

--- a/rust/std/CVE-2020-36317.md
+++ b/rust/std/CVE-2020-36317.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "CVE-2020-36317"
+package = "std"
+categories = ["memory-corruption"]
+date = "2020-10-28"
+url = "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36317"
+
+[versions]
+patched = [">= 1.49.0"]
+unaffected = ["< 1.26.0"]
+```
+
+# String::retain allows safely creating invalid strings when abusing panic
+
+In the standard library in Rust before 1.49.0, String::retain() function has a panic safety problem. It allows creation of a non-UTF-8 Rust string when the provided closure panics. This bug could result in a memory safety violation when other string APIs assume that UTF-8 encoding is used on the same string.

--- a/rust/std/CVE-2020-36318.md
+++ b/rust/std/CVE-2020-36318.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "CVE-2020-36318"
+package = "std"
+categories = ["memory-corruption"]
+date = "2020-12-07"
+url = "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36318"
+
+[versions]
+patched = [">= 1.49.0"]
+unaffected = ["< 1.48.0"]
+```
+
+# VecDeque::make_contiguous may duplicate the contained elements
+
+In the standard library in Rust before 1.49.0, VecDeque::make_contiguous has a bug that pops the same element more than once under certain condition. This bug could result in a use-after-free or double free.

--- a/rust/std/CVE-2021-28875.md
+++ b/rust/std/CVE-2021-28875.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "CVE-2021-28875"
+package = "std"
+categories = ["memory-corruption"]
+date = "2021-01-10"
+url = "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-28875"
+
+[versions]
+patched = [">= 1.50.0"]
+unaffected = ["< 1.20.0"]
+```
+
+# Logic bug in Read can cause buffer overflow in read_to_end()
+
+In the standard library in Rust before 1.50.0, read_to_end() does not validate the return value from Read in an unsafe context. This bug could lead to a buffer overflow.

--- a/rust/std/CVE-2021-28876.md
+++ b/rust/std/CVE-2021-28876.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "CVE-2021-28876"
+package = "std"
+categories = ["memory-corruption"]
+date = "2021-02-04"
+url = "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-28876"
+
+[versions]
+patched = [">= 1.52.0"]
+unaffected = ["< 1.14.0"]
+```
+
+# Panic safety issue in Zip specialization
+
+In the standard library in Rust before 1.52.0, the Zip implementation has a panic safety issue. It calls __iterator_get_unchecked() more than once for the same index when the underlying iterator panics (in certain conditions). This bug could lead to a memory safety violation due to an unmet safety requirement for the TrustedRandomAccess trait.

--- a/rust/std/CVE-2021-28877.md
+++ b/rust/std/CVE-2021-28877.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "CVE-2021-28877"
+package = "std"
+categories = ["memory-corruption"]
+date = "2021-01-03"
+url = "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-28877"
+
+[versions]
+patched = [">= 1.51.0"]
+unaffected = ["< 1.11.0"]
+```
+
+# TrustedRandomAaccess specialization composes incorrectly for nested iter::Zips
+
+In the standard library in Rust before 1.51.0, the Zip implementation calls __iterator_get_unchecked() for the same index more than once when nested. This bug can lead to a memory safety violation due to an unmet safety requirement for the TrustedRandomAccess trait.

--- a/rust/std/CVE-2021-28878.md
+++ b/rust/std/CVE-2021-28878.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "CVE-2021-28878"
+package = "std"
+categories = ["memory-corruption"]
+date = "2021-02-19"
+url = "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-28878"
+
+[versions]
+patched = [">= 1.52.0"]
+unaffected = ["< 1.14.0"]
+```
+
+# Zip may call __iterator_get_unchecked twice with the same index
+
+In the standard library in Rust before 1.52.0, the Zip implementation calls __iterator_get_unchecked() more than once for the same index (under certain conditions) when next_back() and next() are used together. This bug could lead to a memory safety violation due to an unmet safety requirement for the TrustedRandomAccess trait.

--- a/rust/std/CVE-2021-28879.md
+++ b/rust/std/CVE-2021-28879.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "CVE-2021-28879"
+package = "std"
+categories = ["memory-corruption"]
+date = "2021-02-18"
+url = "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-28879"
+
+[versions]
+patched = [">= 1.52.0"]
+unaffected = ["< 1.14.0"]
+```
+
+# Zip can cause buffer overflow when a consumed Zip iterator is used again
+
+In the standard library in Rust before 1.52.0, the Zip implementation can report an incorrect size due to an integer overflow. This bug can lead to a buffer overflow when a consumed Zip iterator is used again.


### PR DESCRIPTION
The first eight bugs reported as part of #539