### PR TITLE
algorithmica: 'merge_sort::merge()' crashes with double-free for `T: Drop`

### DIFF
--- a/crates/algorithmica/RUSTSEC-0000-0000.md
+++ b/crates/algorithmica/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "algorithmica"
+date = "2021-03-07"
+url = "https://github.com/AbrarNitk/algorithmica/issues/1"
+categories = ["memory-corruption"]
+
+[versions]
+patched = []
+```
+
+# 'merge_sort::merge()' crashes with double-free for `T: Drop`
+
+In the affected versions of this crate, `merge_sort::merge()` wildly duplicates and drops ownership of `T` without guarding against double-free. Due to such implementation,
+simply invoking `merge_sort::merge()` on `Vec<T: Drop>` can cause **double free** bugs.


### PR DESCRIPTION
Original issue report: https://github.com/AbrarNitk/algorithmica/issues/1

Thank you for reviewing this PR :)