### PR TITLE
Mark patched tiny-http version for 2020-0031

### DIFF
--- a/crates/tiny_http/RUSTSEC-2020-0031.md
+++ b/crates/tiny_http/RUSTSEC-2020-0031.md
@@ -8,7 +8,7 @@ keywords = ["http", "request-smuggling"]
 url = "https://github.com/tiny-http/tiny-http/issues/173"
 
 [versions]
-patched = [">= 0.8.0"]
+patched = [">= 0.8.0", ">= 0.6.3, < 0.7.0"]
 ```
 
 # HTTP Request smuggling through malformed Transfer Encoding headers

--- a/crates/tiny_http/RUSTSEC-2020-0031.md
+++ b/crates/tiny_http/RUSTSEC-2020-0031.md
@@ -8,7 +8,7 @@ keywords = ["http", "request-smuggling"]
 url = "https://github.com/tiny-http/tiny-http/issues/173"
 
 [versions]
-patched = [">= 0.8.0", ">= 0.6.3, < 0.7.0"]
+patched = [">= 0.8.0", "^0.6.3"]
 ```
 
 # HTTP Request smuggling through malformed Transfer Encoding headers


### PR DESCRIPTION
A backport of the fix for 2020-0031 has been applied to the 0.6.x branch, starting at 0.6.3, subsequent 0.6 versions are no longer vulnerable.

I wasn't quite sure how to express "0.6.x versions are no longer vulnerable where x >= 3", I hope this is correct!
