### PR TITLE
Yank advisories for once-again maintained `dirs` / `directories` crates

### DIFF
--- a/crates/directories/RUSTSEC-2020-0054.md
+++ b/crates/directories/RUSTSEC-2020-0054.md
@@ -5,6 +5,7 @@ package = "directories"
 date = "2020-10-16"
 informational = "unmaintained"
 url = "https://github.com/dirs-dev/directories-rs"
+yanked = true
 
 [versions]
 patched = []

--- a/crates/dirs/RUSTSEC-2020-0053.md
+++ b/crates/dirs/RUSTSEC-2020-0053.md
@@ -5,6 +5,7 @@ package = "dirs"
 date = "2020-10-16"
 informational = "unmaintained"
 url = "https://github.com/dirs-dev/dirs-rs"
+yanked = true
 
 [versions]
 patched = []


### PR DESCRIPTION
Both `dirs` and `directories` seem to be actively maintained again, making `RUSTSEC-2020-0053` and `RUSTSEC-2020-0054` obsolete. From the `dirs-next` crate:

> Note: This is a fork of once-abandoned `dirs` crate.

https://crates.io/crates/dirs-next/2.0.0

and the `directories-next` crate:

> Note: This is a fork of once-abandoned `directories` crate.

https://crates.io/crates/directories-next/2.0.0

and new releases of the `dirs`/`directories` crates where the Readmes state that they are actively developed again:

https://crates.io/crates/dirs/3.0.1 / https://crates.io/crates/directories/3.0.1