### PR TITLE
Add unmaintained crate advisory for `aesni`

### DIFF
--- a/crates/aesni/RUSTSEC-0000-0000.md
+++ b/crates/aesni/RUSTSEC-0000-0000.md
@@ -1,0 +1,31 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "aesni"
+date = "2021-04-29"
+informational = "unmaintained"
+url = "https://github.com/RustCrypto/block-ciphers/pull/200"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# merged into the `aes` crate
+
+The `aesni` crate has been merged into the `aes` crate. The new repository
+location is at:
+
+<https://github.com/RustCrypto/block-ciphers/tree/master/aes>
+
+AES-NI is now autodetected at runtime on `i686`/`x86-64` platforms.
+If AES-NI is not present, the `aes` crate will fallback to a constant-time
+portable software implementation.
+
+To prevent this fallback (and have absence of AES-NI result in an illegal
+instruction crash instead), continue to pass the same RUSTFLAGS which were
+previously required for the `aesni` crate to compile:
+
+```
+RUSTFLAGS=-Ctarget-feature=+aes,+ssse3
+```


### PR DESCRIPTION
The `aesni` crate has been merged into the `aes` crate. See:

https://github.com/RustCrypto/block-ciphers/pull/200