### PR TITLE
Add unmaintained crate advisory for `aes-soft`

### DIFF
--- a/crates/aes-soft/RUSTSEC-0000-0000.md
+++ b/crates/aes-soft/RUSTSEC-0000-0000.md
@@ -1,0 +1,27 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "aes-soft"
+date = "2021-04-29"
+informational = "unmaintained"
+url = "https://github.com/RustCrypto/block-ciphers/pull/200"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# merged into the `aes` crate
+
+The `aes-soft` crate has been merged into the `aes` crate. The new repository
+location is at:
+
+<https://github.com/RustCrypto/block-ciphers/tree/master/aes>
+
+AES-NI is now autodetected at runtime on `i686`/`x86-64` platforms.
+If AES-NI is not present, the `aes` crate will fallback to a constant-time
+portable software implementation.
+
+To force the use of a constant-time portable implementation on these platforms,
+even if AES-NI is available, use the new `force-soft` feature of the `aes`
+crate to disable autodetection.


### PR DESCRIPTION
The `aes-soft` crate has been merged into the `aes` crate. See:

https://github.com/RustCrypto/block-ciphers/pull/200