### PR TITLE
Add unmaintained crate advisory for `aes-ctr`

### DIFF
--- a/crates/aes-ctr/RUSTSEC-0000-0000.md
+++ b/crates/aes-ctr/RUSTSEC-0000-0000.md
@@ -1,0 +1,26 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "aes-ctr"
+date = "2021-04-29"
+informational = "unmaintained"
+url = "https://github.com/RustCrypto/block-ciphers/pull/200"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# merged into the `aes` crate
+
+The `aes-ctr` crate has been merged into the `aes` crate. The new repository
+location is at:
+
+<https://github.com/RustCrypto/block-ciphers/tree/master/aes>
+
+The `aes` crate now has an optional `ctr` feature which autodetects SIMD
+features on `i686`/`x86-64` targets and uses them if available, or otherwise
+falls back to the implementation in the `ctr` crate.
+
+If you would prefer not to have this autodetection performed, use the `aes`
+crate directly with the `ctr` crate.


### PR DESCRIPTION
The `aes-ctr` crate has been merged into the `aes` crate. See:

https://github.com/RustCrypto/block-ciphers/pull/200