### PR TITLE
aes* crates: add crate names to advisory titles

### DIFF
--- a/crates/aes-ctr/RUSTSEC-2021-0061.md
+++ b/crates/aes-ctr/RUSTSEC-2021-0061.md
@@ -11,10 +11,9 @@ patched = []
 unaffected = []
 ```
 
-# merged into the `aes` crate
+# `aes-ctr` has been merged into the `aes` crate
 
-The `aes-ctr` crate has been merged into the `aes` crate. The new repository
-location is at:
+Please use the `aes` crate going forward. The new repository location is at:
 
 <https://github.com/RustCrypto/block-ciphers/tree/master/aes>
 

--- a/crates/aes-soft/RUSTSEC-2021-0060.md
+++ b/crates/aes-soft/RUSTSEC-2021-0060.md
@@ -11,10 +11,9 @@ patched = []
 unaffected = []
 ```
 
-# merged into the `aes` crate
+# `aes-soft` has been merged into the `aes` crate
 
-The `aes-soft` crate has been merged into the `aes` crate. The new repository
-location is at:
+Please use the `aes` crate going forward. The new repository location is at:
 
 <https://github.com/RustCrypto/block-ciphers/tree/master/aes>
 

--- a/crates/aesni/RUSTSEC-2021-0059.md
+++ b/crates/aesni/RUSTSEC-2021-0059.md
@@ -11,10 +11,9 @@ patched = []
 unaffected = []
 ```
 
-# merged into the `aes` crate
+# `aesni` has been merged into the `aes` crate
 
-The `aesni` crate has been merged into the `aes` crate. The new repository
-location is at:
+Please use the `aes` crate going forward. The new repository location is at:
 
 <https://github.com/RustCrypto/block-ciphers/tree/master/aes>
 


### PR DESCRIPTION
The previous titles accidentally omitted the crate names, making them confusing during reporting.