### PR TITLE
Add unmaintained crate advisory for `cpuid-bool`

### DIFF
--- a/crates/cpuid-bool/RUSTSEC-0000-0000.md
+++ b/crates/cpuid-bool/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "cpuid-bool"
+date = "2021-05-06"
+informational = "unmaintained"
+url = "https://github.com/RustCrypto/utils/pull/381"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# `cpuid-bool` has been renamed to `cpufeatures`
+
+Please use the `cpufeatures`` crate going forward:
+
+<https://github.com/RustCrypto/utils/tree/master/cpufeatures>
+
+There will be no further releases of `cpuid-bool`.


### PR DESCRIPTION
It has been renamed to `cpufeatures`. See:

https://github.com/RustCrypto/utils/pull/381