### PR TITLE
anymap is unmaintained

### DIFF
--- a/crates/anymap/RUSTSEC-0000-0000.md
+++ b/crates/anymap/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "anymap"
+date = "2021-05-07"
+informational = "unmaintained"
+url = "https://github.com/chris-morgan/anymap/issues/37"
+[versions]
+patched = []
+unaffected = []
+```
+
+# anymap is unmaintained.
+
+The `anymap` crate does not appear to be maintained, and the most recent
+published version 0.12.1 includes a soundness bug. This has been
+[fixed](https://github.com/chris-morgan/anymap/pull/32) a few years ago, but
+was never released.


### PR DESCRIPTION
It appears that the `anymap` has been [abandoned](https://github.com/chris-morgan/anymap/issues/37), and the most recent released version contains a soundness bug that has been [fixed upstream](https://github.com/chris-morgan/anymap/pull/32), but never published to crates.io