### PR TITLE
evm: security advisory related to memory over-allocation

### DIFF
--- a/crates/evm/RUSTSEC-0000-0000.md
+++ b/crates/evm/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "evm"
+date = "2021-05-11"
+url = "https://github.com/rust-blockchain/evm"
+categories = ["denial-of-service"]
+
+[versions]
+patched = [">= 0.26.1", "0.25.1", "0.24.1", "0.23.1", "0.21.1"]
+```
+
+# Denial of service on EVM execution due to memory over-allocation
+
+Prior to the patch, when executing specific EVM opcodes related
+to memory operations that use `evm_core::Memory::copy_large`, the `evm`
+crate can over-allocate memory when it is not needed, making it
+possible for an attacker to perform denial-of-service attack.
+
+The flaw was corrected in commit `19ade85`.


### PR DESCRIPTION
Related commit: https://github.com/rust-blockchain/evm/commit/19ade858c430ab13eb562764a870ac9f8506f8dd

Fix is available for `>= 0.26.1` and also `0.25.1`, `0.24.1`, `0.23.1`, `0.21.1`.