### PR TITLE
evm-core: fix crate name

### DIFF
--- a/crates/evm-core/RUSTSEC-2021-0066.md
+++ b/crates/evm-core/RUSTSEC-2021-0066.md
@@ -1,7 +1,7 @@
 ```toml
 [advisory]
 id = "RUSTSEC-2021-0066"
-package = "evm"
+package = "evm-core"
 date = "2021-05-11"
 url = "https://github.com/rust-blockchain/evm"
 categories = ["denial-of-service"]
@@ -13,7 +13,7 @@ patched = [">= 0.26.1", "0.25.1", "0.24.1", "0.23.1", "0.21.1"]
 # Denial of service on EVM execution due to memory over-allocation
 
 Prior to the patch, when executing specific EVM opcodes related
-to memory operations that use `evm_core::Memory::copy_large`, the `evm`
+to memory operations that use `evm_core::Memory::copy_large`, the
 crate can over-allocate memory when it is not needed, making it
 possible for an attacker to perform denial-of-service attack.
 


### PR DESCRIPTION
While `evm` is usually what is directly imported by the library users, the security advisory only requires bumping version of `evm-core`, but not any other `evm`-related crates.