### PR TITLE
Add advisory for iced-x86 soundness bug

### DIFF
--- a/crates/iced-x86/RUSTSEC-0000-0000.md
+++ b/crates/iced-x86/RUSTSEC-0000-0000.md
@@ -1,3 +1,4 @@
+```toml
 [advisory]
 id = "RUSTSEC-0000-0000"
 
@@ -14,3 +15,14 @@ functions = { "iced_86::Decoder::new" = ["<= 1.10.3"] }
 
 [versions]
 patched = ["> 1.10.3"]
+```
+
+# Soundness issue in `iced-x86` versions <= 1.10.3 
+
+Versions of iced-x86 <= 1.10.3 invoke undefined behavior which may cause soundness
+issues in crates using the `iced_x86::Decoder` struct. The `Decoder::new()` function
+made a call to `slice.get_unchecked(slice.length())` to get the end position of 
+the input buffer. The flaw was fixed with safe logic that does not invoke undefined
+behavior.
+
+More details can be found at <https://github.com/icedland/iced/issues/168>.

--- a/crates/iced-x86/RUSTSEC-0000-0000.md
+++ b/crates/iced-x86/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+
+package = "iced-x86"
+
+date = "2021-05-19"
+
+url = "https://github.com/icedland/iced/issues/168"
+
+keywords = ["soundness"]
+
+[affected]
+functions = { "iced_86::Decoder::new" = ["<= 1.10.3"] }
+
+[versions]
+patched = ["> 1.10.3"]


### PR DESCRIPTION
More information here: https://github.com/icedland/iced/issues/168

[Rendered](https://github.com/landaire/advisory-db/blob/iced-x86-advisory/crates/iced-x86/RUSTSEC-0000-0000.md).