### PR TITLE
fix: update rustsec-2020-0009 with patched version

### DIFF
--- a/crates/flatbuffers/RUSTSEC-2020-0009.md
+++ b/crates/flatbuffers/RUSTSEC-2020-0009.md
@@ -11,7 +11,7 @@ url = "https://github.com/google/flatbuffers/issues/5825"
 "flatbuffers::read_scalar_at" = [">= 0.4.0"]
 
 [versions]
-patched = []
+patched = [">= 2.0.0"]
 unaffected = ["< 0.4.0"]
 ```
 


### PR DESCRIPTION
With the [release of flatbuffers 2.0.0](https://github.com/google/flatbuffers/releases/tag/v2.0.0)
google/flatbuffers#5825 has been fixed and released. This patch updates
the advisory-db to indicate a patched version addressing the issue.