### PR TITLE
Make ranges in RUSTSEC-2018-0007.md  non-overlapping

### DIFF
--- a/crates/trust-dns-proto/RUSTSEC-2018-0007.md
+++ b/crates/trust-dns-proto/RUSTSEC-2018-0007.md
@@ -7,7 +7,7 @@ date = "2018-10-09"
 keywords = ["stack-overflow", "crash"]
 
 [versions]
-patched = [">= 0.4.3", ">= 0.5.0-alpha.3"]
+patched = ["^0.4.3", ">= 0.5.0-alpha.3"]
 ```
 
 # Stack overflow when parsing malicious DNS packet


### PR DESCRIPTION
OSV requires all ranges to be non-overlapping. This changes the range definition in RUSTSEC-2018-0007 to avoid overlap and enable that use case.

This should have no effect on the code currently in production.