### PR TITLE
Remove range overlaps, fix some range specifications

### DIFF
--- a/crates/arc-swap/RUSTSEC-2020-0091.md
+++ b/crates/arc-swap/RUSTSEC-2020-0091.md
@@ -9,7 +9,7 @@ keywords = ["dangling reference"]
 aliases = ["CVE-2020-35711"]
 
 [versions]
-patched = [">= 1.1.0", ">= 0.4.8"]
+patched = [">= 0.4.8, < 1.0.0-0", ">= 1.1.0"]
 unaffected = ["< 0.4.2"]
 
 [affected]

--- a/crates/claxon/RUSTSEC-2018-0004.md
+++ b/crates/claxon/RUSTSEC-2018-0004.md
@@ -8,7 +8,7 @@ keywords = ["uninitialized-memory"]
 url = "https://github.com/ruuda/claxon/commit/8f28ec275e412dd3af4f3cda460605512faf332c"
 
 [versions]
-patched = ["=0.3.2", ">= 0.4.1"]
+patched = ["^0.3.2", ">= 0.4.1"]
 ```
 
 # Malicious input could cause uninitialized memory to be exposed

--- a/crates/cranelift-codegen/RUSTSEC-2021-0067.md
+++ b/crates/cranelift-codegen/RUSTSEC-2021-0067.md
@@ -9,7 +9,7 @@ keywords = ["miscompile", "sandbox", "wasm"]
 aliases = ["CVE-2021-32629"]
 
 [versions]
-patched = [">= 0.73.1", ">= 0.74"]
+patched = [">= 0.73.1"]
 
 [affected]
 arch = ["x86"]

--- a/crates/miow/RUSTSEC-2020-0080.md
+++ b/crates/miow/RUSTSEC-2020-0080.md
@@ -9,7 +9,7 @@ keywords = ["memory", "layout", "cast"]
 informational = "unsound"
 
 [versions]
-patched = [">= 0.2.2", ">= 0.3.6"]
+patched = ["^ 0.2.2", ">= 0.3.6"]
 ```
 
 # `miow` invalidly assumes the memory layout of std::net::SocketAddr

--- a/crates/rand_core/RUSTSEC-2019-0035.md
+++ b/crates/rand_core/RUSTSEC-2019-0035.md
@@ -12,7 +12,7 @@ url = "https://github.com/rust-random/rand/blob/master/rand_core/CHANGELOG.md#05
 "rand_core::BlockRng::next_u64" = ["< 0.4.2"]
 
 [versions]
-patched = [">= 0.3.1", ">= 0.4.2"]
+patched = ["^ 0.3.1", ">= 0.4.2"]
 ```
 
 # Unaligned memory access

--- a/crates/trust-dns-proto/RUSTSEC-2018-0007.md
+++ b/crates/trust-dns-proto/RUSTSEC-2018-0007.md
@@ -7,7 +7,7 @@ date = "2018-10-09"
 keywords = ["stack-overflow", "crash"]
 
 [versions]
-patched = ["^0.4.3", ">= 0.5.0-alpha.3"]
+patched = [">= 0.4.3"]
 ```
 
 # Stack overflow when parsing malicious DNS packet


### PR DESCRIPTION
This removes overlaps in version range specifications. Sometimes the change is cosmetic, but in several cases it fixes specifications that were previously defined incorrectly - e.g.:

-patched = [">= 0.3.1", ">= 0.4.2"]
+patched = ["^ 0.3.1", ">= 0.4.2"]

