### PR TITLE
Update RUSTSEC-2020-0043.md

### DIFF
--- a/crates/ws/RUSTSEC-2020-0043.md
+++ b/crates/ws/RUSTSEC-2020-0043.md
@@ -18,4 +18,4 @@ Affected versions of this crate did not properly check and cap the growth of the
 
 This allows a remote attacker to take down the process by growing the buffer of their (single) connection until the process runs out of memory it can allocate and is killed.
 
-The flaw was corrected in the [`parity-ws` fork](https://crates.io/crates/parity-ws) (>0.10.0) by [disconnecting a client when the buffer runs full](https://github.com/housleyjk/ws-rs/pull/328).
+The flaw was corrected in the [`parity-ws` fork](https://crates.io/crates/parity-ws) (>=0.10.0) by [disconnecting a client when the buffer runs full](https://github.com/housleyjk/ws-rs/pull/328).


### PR DESCRIPTION
Version of `parity-ws` containing fix changed to read `>=0.10.0', not '>0.10.0' (0.10.0 is the latest as of this writing and contains the fix).