### PR TITLE
tectonic_xdv: `Read` on uninitialized buffer may cause UB ('tectonic_xdv' crate)

### DIFF
--- a/crates/tectonic_xdv/RUSTSEC-0000-0000.md
+++ b/crates/tectonic_xdv/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tectonic_xdv"
+date = "2021-02-17"
+url = "https://github.com/tectonic-typesetting/tectonic/issues/752"
+categories = ["memory-exposure"]
+informational = "unsound"
+
+[versions]
+patched = [">= 0.1.12"]
+```
+
+# `Read` on uninitialized buffer may cause UB ('tectonic_xdv' crate)
+
+Affected versions of this crate passes an uninitialized buffer to a user-provided `Read` implementation.
+
+Arbitrary `Read` implementations can read from the uninitialized buffer (memory exposure) and also can return incorrect number of bytes written to the buffer. Reading from uninitialized memory produces undefined values that can quickly invoke undefined behavior.
+
+The problem was fixed in commit `cdff034` by zero-initializing the buffer before passing it to a user-provided `Read` implementation.


### PR DESCRIPTION
Original issue report: https://github.com/tectonic-typesetting/tectonic/issues/752