### PR TITLE
Add GHSA mentions to `aliases` field

### DIFF
--- a/crates/cranelift-codegen/RUSTSEC-2021-0067.md
+++ b/crates/cranelift-codegen/RUSTSEC-2021-0067.md
@@ -6,7 +6,7 @@ date = "2021-05-21"
 url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-hpqh-2wqx-7qp5"
 categories = ["code-execution", "memory-corruption", "memory-exposure"]
 keywords = ["miscompile", "sandbox", "wasm"]
-aliases = ["CVE-2021-32629"]
+aliases = ["CVE-2021-32629", "GHSA-hpqh-2wqx-7qp5"]
 
 [versions]
 patched = [">= 0.73.1"]

--- a/crates/hyper/RUSTSEC-2021-0020.md
+++ b/crates/hyper/RUSTSEC-2021-0020.md
@@ -6,7 +6,7 @@ date = "2021-02-05"
 url = "https://github.com/hyperium/hyper/security/advisories/GHSA-6hfq-h8hq-87mf"
 categories = ["format-injection"]
 keywords = ["http", "request-smuggling"]
-aliases = ["CVE-2021-21299"]
+aliases = ["CVE-2021-21299", "GHSA-6hfq-h8hq-87mf"]
 
 [versions]
 patched = [">= 0.14.3", "0.13.10", "0.12.36"]

--- a/crates/libpulse-binding/RUSTSEC-2018-0020.md
+++ b/crates/libpulse-binding/RUSTSEC-2018-0020.md
@@ -5,6 +5,7 @@ package = "libpulse-binding"
 date = "2018-12-22"
 url = "https://github.com/jnqnfe/pulse-binding-rust/security/advisories/GHSA-f56g-chqp-22m9"
 categories = ["memory-corruption"]
+aliases = ["GHSA-f56g-chqp-22m9"]
 
 [versions]
 patched = [">= 2.5.0"]

--- a/crates/libpulse-binding/RUSTSEC-2018-0021.md
+++ b/crates/libpulse-binding/RUSTSEC-2018-0021.md
@@ -5,6 +5,7 @@ package = "libpulse-binding"
 date = "2018-06-15"
 url = "https://github.com/jnqnfe/pulse-binding-rust/security/advisories/GHSA-ghpq-vjxw-ch5w"
 categories = ["memory-corruption"]
+aliases = ["GHSA-ghpq-vjxw-ch5w"]
 
 [versions]
 patched = [">= 1.2.1"]


### PR DESCRIPTION
Some advisories mentioned GHSA in links, but didn't specify an alias. This PR fixes that.

This is becoming more important with OSV enabling interop between databases.