### PR TITLE
Report slice-deque as unmaintained

### DIFF
--- a/crates/slice-deque/RUSTSEC-0000-0000.md
+++ b/crates/slice-deque/RUSTSEC-0000-0000.md
@@ -1,0 +1,15 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "slice-deque"
+date = "2020-02-10"
+url = "https://github.com/gnzlbg/slice_deque/issues/94"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# slice-deque is unmaintained
+
+The author of the `slice-deque` crate is unresponsive and is not receiving security patches.


### PR DESCRIPTION
A panic safety issue has been pointed out in gnzlbg/slice_deque#90 four months ago, a fix was offered in gnzlbg/slice_deque#91 three months ago but has still not been merged, the crate has last received a new commit two years ago and the maintainer seems inactive.

Tracked at gnzlbg/slice_deque#94