### PR TITLE
Add `withdrawn` field

### DIFF
--- a/crates/directories/RUSTSEC-2020-0054.md
+++ b/crates/directories/RUSTSEC-2020-0054.md
@@ -6,6 +6,7 @@ date = "2020-10-16"
 informational = "unmaintained"
 url = "https://github.com/dirs-dev/directories-rs"
 yanked = true
+withdrawn = "2021-04-19"
 
 [versions]
 patched = []

--- a/crates/dirs/RUSTSEC-2020-0053.md
+++ b/crates/dirs/RUSTSEC-2020-0053.md
@@ -6,6 +6,7 @@ date = "2020-10-16"
 informational = "unmaintained"
 url = "https://github.com/dirs-dev/dirs-rs"
 yanked = true
+withdrawn = "2021-04-19"
 
 [versions]
 patched = []

--- a/crates/libpulse-binding/RUSTSEC-2020-0055.md
+++ b/crates/libpulse-binding/RUSTSEC-2020-0055.md
@@ -5,6 +5,7 @@ package = "libpulse-binding"
 date = "2020-10-21"
 url = "https://rustsec.org/advisories/RUSTSEC-2018-0020.html"
 yanked = true
+withdrawn = "2020-10-22"
 
 [versions]
 patched = []

--- a/crates/spin/RUSTSEC-2019-0031.md
+++ b/crates/spin/RUSTSEC-2019-0031.md
@@ -6,6 +6,7 @@ date = "2019-11-21"
 informational = "unmaintained"
 url = "https://github.com/mvdnes/spin-rs/commit/7516c80"
 yanked = true
+withdrawn = "2020-10-08"
 
 [versions]
 patched = []


### PR DESCRIPTION
`cargo audit` works normally and does not require any changes., but this makes the current linter barf because of unknown field `withdrawn`.

I have linter with validation for these fields in the `osv` branch. We could publish that as a pre-release, that would also require a pre-release of `rustsec` crate.

Another approach is to extract just the linter changes (they _seem_ to be self-contained) and publish a new release. That should work in theory, but I haven't tested that.

Only @tarcieri currently has the permissions to publish `rustsec-admin`; adding as a reviewer.
