### PR TITLE
Fix RUSTSEC-2021-0048 which doesn't declare an operand

### DIFF
--- a/crates/stackvector/RUSTSEC-2021-0048.md
+++ b/crates/stackvector/RUSTSEC-2021-0048.md
@@ -8,7 +8,7 @@ url = "https://github.com/Alexhuszagh/rust-stackvector/issues/2"
 categories = ["memory-corruption"]
 
 [versions]
-patched = ["1.0.9"]
+patched = [">= 1.0.9"]
 ```
 
 # StackVec::extend can write out of bounds when size_hint is incorrect


### PR DESCRIPTION
The advisory as declared currently would consider 2.0.0 and later to be vulnerable.