### PR TITLE
OSV export: fix handling of advisories without an ID

### DIFF
--- a/.github/workflows/export-osv.yml
+++ b/.github/workflows/export-osv.yml
@@ -21,6 +21,8 @@ jobs:
           fi
           mkdir -p crates
           rustsec-admin osv crates
+          # FIXME: hack to avoid committing advisories without an ID
+          rm crates/RUSTSEC-0000-0000.json
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .

--- a/.github/workflows/export-osv.yml
+++ b/.github/workflows/export-osv.yml
@@ -22,7 +22,7 @@ jobs:
           mkdir -p crates
           rustsec-admin osv crates
           # FIXME: hack to avoid committing advisories without an ID
-          rm crates/RUSTSEC-0000-0000.json
+          rm -f crates/RUSTSEC-0000-0000.json
           git config user.name github-actions
           git config user.email github-actions@github.com
           git add .


### PR DESCRIPTION
Kinda gross, but this is the fastest fix I could think of