### PR TITLE
Add rust-ammonia/ammonia#142

### DIFF
--- a/crates/ammonia/RUSTSEC-0000-0000.md
+++ b/crates/ammonia/RUSTSEC-0000-0000.md
@@ -21,7 +21,7 @@ DOM, which appeared "safe" when examining the DOM tree, but when serialized and 
 could be exploited to inject abitrary markup.
 
 To exploit this, the application using this library must allow a tag that is parsed as raw text in HTML.
-These elements are:
+These [elements] are:
 
 * title
 * textarea

--- a/crates/ammonia/RUSTSEC-0000-0000.md
+++ b/crates/ammonia/RUSTSEC-0000-0000.md
@@ -19,3 +19,21 @@ are not allowed, the underlying HTML parser still treats them differently.
 Running cleanup without accounting for these differing namespaces resulted in an "impossible"
 DOM, which appeared "safe" when examining the DOM tree, but when serialized and deserialized,
 could be exploited to inject abitrary markup.
+
+To exploit this, the application using this library must allow a tag that is parsed as raw text in HTML.
+These elements are:
+
+* title
+* textarea
+* xmp
+* iframe
+* noembed
+* noframes
+* plaintext
+* noscript
+* style
+* script
+
+Applications that do not explicitly allow any of these tags should not be affected, since none are allowed by default.
+
+[elements]: https://github.com/servo/html5ever/blob/57eb334c0ffccc6f88d563419f0fbeef6ff5741c/html5ever/src/tree_builder/rules.rs

--- a/crates/ammonia/RUSTSEC-0000-0000.md
+++ b/crates/ammonia/RUSTSEC-0000-0000.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "ammonia"
+date = "2021-07-08"
+url = "https://github.com/rust-ammonia/ammonia/pull/142"
+categories = ["format-injection"]
+keywords = ["html", "xss"]
+
+[versions]
+patched = [">= 3.1.0", ">= 2.1.3, < 3.0.0"]
+```
+
+# Incorrect handling of embedded SVG and MathML leads to mutation XSS
+
+Affected versions of this crate did not account for namespace-related parsing
+differences between HTML, SVG, and MathML. Even if the `svg` and `math` elements
+are not allowed, the underlying HTML parser still treats them differently.
+Running cleanup without accounting for these differing namespaces resulted in an "impossible"
+DOM, which appeared "safe" when examining the DOM tree, but when serialized and deserialized,
+could be exploited to inject abitrary markup.


### PR DESCRIPTION
XSS vuln in Ammonia.

I don't know how to exploit it without allowing `<iframe>`, which it doesn't allow by default, but that's not an unreasonable thing for someone to do.

rust-ammonia/ammonia#142