### PR TITLE
Revert "Hotfix #957 until we figure out what to do with it"

### DIFF
--- a/crates/prost-types/RUSTSEC-2021-0073.md
+++ b/crates/prost-types/RUSTSEC-2021-0073.md
@@ -9,6 +9,9 @@ keywords = ["denial-of-service"]
 
 [versions]
 patched = [">= 0.8.0"]
+
+[affected]
+functions = { "prost_types::Timestamp::Into<SystemTime>" = ["<= 0.7.0"] }
 ```
 
 # Conversion from `prost_types::Timestamp` to `SystemTime` can cause an overflow and panic 


### PR DESCRIPTION
Reverts RustSec/advisory-db#958

Unfixes #957

We've decided we don't support versions of `cargo-audit` that are that old, and it's not worth sacrificing the extra metadata to accommodate them.