### PR TITLE
Add fix for RUSTSEC-2021-0080

### DIFF
--- a/crates/tar/RUSTSEC-2021-0080.md
+++ b/crates/tar/RUSTSEC-2021-0080.md
@@ -7,7 +7,7 @@ url = "https://github.com/alexcrichton/tar-rs/issues/238"
 
 [versions]
 # none, 0day
-patched = []
+patched = [">= 0.4.36"]
 
 [affected]
 functions = { "tar::Archive::unpack" = ["< 1.2.3"] }
@@ -54,4 +54,6 @@ fn main() -> Result<()> {
 }
 ```
 
-This issue was discovered and reported by Martin Michaelis (@mgjm).
+This has been fixed in https://github.com/alexcrichton/tar-rs/pull/259 and is
+published as `tar` 0.4.36. Thanks to Martin Michaelis (@mgjm) for discovering
+and reporting this, and Nikhil Benesch (@benesch) for the fix!


### PR DESCRIPTION
See [issue #238](https://github.com/alexcrichton/tar-rs/issues/238) and [PR #259](https://github.com/alexcrichton/tar-rs/pull/259)