### PR TITLE
Update RUSTSEC-2021-0080 [affected] version

### DIFF
--- a/crates/tar/RUSTSEC-2021-0080.md
+++ b/crates/tar/RUSTSEC-2021-0080.md
@@ -10,7 +10,7 @@ url = "https://github.com/alexcrichton/tar-rs/issues/238"
 patched = [">= 0.4.36"]
 
 [affected]
-functions = { "tar::Archive::unpack" = ["< 1.2.3"] }
+functions = { "tar::Archive::unpack" = ["< 0.4.36"] }
 ```
 
 # Links in archive can create arbitrary directories


### PR DESCRIPTION
This replaces a place holder with the actual fixed version.