### PR TITLE
Report vec-const as unsound

### DIFF
--- a/crates/vec-const/RUSTSEC-0000-0000.md
+++ b/crates/vec-const/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "vec-const"
+date = "2021-08-14"
+url = "https://github.com/Eolu/vec-const/issues/1#issuecomment-898908241"
+categories = ["memory-corruption"]
+keywords = ["memory-safety"]
+
+[versions]
+patched = []
+```
+
+# vec-const attempts to construct a Vec from a pointer to a const slice
+
+This crate claims to construct a const `Vec` with nonzero length and capacity, but that cannot be done because such a `Vec` requires a pointer from an allocator.

--- a/crates/vec-const/RUSTSEC-0000-0000.md
+++ b/crates/vec-const/RUSTSEC-0000-0000.md
@@ -6,6 +6,7 @@ date = "2021-08-14"
 url = "https://github.com/Eolu/vec-const/issues/1#issuecomment-898908241"
 categories = ["memory-corruption"]
 keywords = ["memory-safety"]
+informational = "unsound"
 
 [versions]
 patched = []


### PR DESCRIPTION
It looks like most of the reports are for higher-profile crates, but someone on Reddit already mistook `vec-const` for something they should consider using.

I've added a URL to a simple example that demonstrates one aspect of the unsoundness of this crate. Is anything else needed in that area?