### PR TITLE
RUSTSEC-2021-0089 has been patched in raw-cpuid 9.1.1

### DIFF
--- a/crates/raw-cpuid/RUSTSEC-2021-0089.md
+++ b/crates/raw-cpuid/RUSTSEC-2021-0089.md
@@ -7,7 +7,7 @@ url = "https://github.com/gz/rust-cpuid/issues/43"
 categories = ["memory-corruption", "denial-of-service"]
 
 [versions]
-patched = []
+patched = [">= 9.1.1"]
 unaffected = ["<= 3.1.0"]
 ```
 
@@ -22,6 +22,3 @@ invariants in safe code, leading to:
 * Panics due to failed assertions.
 
 See https://github.com/gz/rust-cpuid/issues/43.
-
-A fix is not yet available, but most use cases do not require enabling
-the `serialize` feature.


### PR DESCRIPTION
Reviewed and confirmed https://github.com/rustsec/advisory-db/pull/671#issuecomment-903206917.