### PR TITLE
Fix CVE alias CVE-2020-35920

### DIFF
--- a/crates/net2/RUSTSEC-2020-0078.md
+++ b/crates/net2/RUSTSEC-2020-0078.md
@@ -2,7 +2,6 @@
 [advisory]
 id = "RUSTSEC-2020-0078"
 package = "net2"
-aliases = ["CVE-2020-35920"]
 date = "2020-11-07"
 url = "https://github.com/deprecrated/net2-rs/issues/105"
 keywords = ["memory", "layout", "cast"]

--- a/crates/socket2/RUSTSEC-2020-0079.md
+++ b/crates/socket2/RUSTSEC-2020-0079.md
@@ -6,6 +6,7 @@ date = "2020-11-06"
 url = "https://github.com/rust-lang/socket2-rs/issues/119"
 keywords = ["memory", "layout", "cast"]
 informational = "unsound"
+aliases = ["CVE-2020-35920"]
 
 [versions]
 patched = [">= 0.3.16"]


### PR DESCRIPTION
It was linked to the wrong advisory. Thanks to @OS-WS for pointing it out [here](https://github.com/rustsec/advisory-db/commit/7fb26418880c22999ee69be313d713b8b579e5ff#commitcomment-55284597).