### PR TITLE
ash: RUSTSEC-2021-0090 has been patched in 0.33.1

### DIFF
--- a/crates/ash/RUSTSEC-2021-0090.md
+++ b/crates/ash/RUSTSEC-2021-0090.md
@@ -8,7 +8,7 @@ categories = ["memory-exposure"]
 informational = "unsound"
 
 [versions]
-patched = []
+patched = [">= 0.33.1"]
 ```
 
 # Reading on uninitialized memory may cause UB ( `util::read_spv()` )


### PR DESCRIPTION
https://github.com/MaikKlein/ash/issues/354 was fixed in https://github.com/MaikKlein/ash/pull/470.