### PR TITLE
Add unmaintained crate advisory for `cosmos_sdk`

### DIFF
--- a/crates/cosmos_sdk/RUSTSEC-0000-0000.md
+++ b/crates/cosmos_sdk/RUSTSEC-0000-0000.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "cosmos_sdk"
+date = "2021-08-25"
+informational = "unmaintained"
+url = "https://github.com/cosmos/cosmos-rust/issues/113"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# Crate has been renamed to `cosmrs`
+
+The `cosmos_sdk` crate, which provides a basic Rust SDK for the Cosmos ecosystem,
+has rebranded to “CosmRS” in the spirit of other projects like CosmJS and CosmWasm.
+
+You can find the new home here:
+
+https://github.com/cosmos/cosmos-rust/tree/main/cosmrs
+
+The new crate name is `cosmrs`:
+
+https://crates.io/crates/cosmrs


### PR DESCRIPTION
It has been renamed to `cosmrs`:

https://github.com/cosmos/cosmos-rust/tree/main/cosmrs