### PR TITLE
Add disappeared advisories

### DIFF
--- a/crates/metrics-util/RUSTSEC-0000-0000.md
+++ b/crates/metrics-util/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "metrics-util"
+date = "2021-04-07"
+url = "https://github.com/metrics-rs/metrics/issues/190"
+categories = ["memory-corruption", "thread-safety"]
+[versions]
+patched = [">= 0.7.0"]
+```
+
+# AtomicBucket<T> unconditionally implements Send/Sync
+
+In the affected versions of the crate, `AtomicBucket<T>` unconditionally implements `Send`/`Sync` traits. Therefore, users can create a data race to the inner
+`T: !Sync` by using the `AtomicBucket::data_with()` API.
+Such data races can potentially cause memory corruption or other undefined behavior.
+
+The flaw was fixed in commit 8e6daab by adding appropriate Send/Sync bounds to the Send/Sync impl of struct `Block<T>` (which is a data type contained inside `AtomicBucket<T>`).

--- a/crates/tectonic_xdv/RUSTSEC-0000-0000.md
+++ b/crates/tectonic_xdv/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tectonic_xdv"
+date = "2021-02-17"
+url = "https://github.com/tectonic-typesetting/tectonic/issues/752"
+categories = ["memory-exposure"]
+informational = "unsound"
+[versions]
+patched = [">= 0.1.12"]
+```
+
+# `Read` on uninitialized buffer may cause UB ('tectonic_xdv' crate)
+
+Affected versions of this crate passes an uninitialized buffer to a user-provided `Read` implementation.
+
+Arbitrary `Read` implementations can read from the uninitialized buffer (memory exposure) and also can return incorrect number of bytes written to the buffer. Reading from uninitialized memory produces undefined values that can quickly invoke undefined behavior.
+
+The problem was fixed in commit `cdff034` by zero-initializing the buffer before passing it to a user-provided `Read` implementation.


### PR DESCRIPTION
#935 and #936 are merged but do not appear to exist on the current main branch.