### PR TITLE
Promote nix::unistd::getgrouplist to vulnerability

### DIFF
--- a/crates/nix/RUSTSEC-2021-0119.md
+++ b/crates/nix/RUSTSEC-2021-0119.md
@@ -6,7 +6,6 @@ date = "2021-09-27"
 url = "https://github.com/nix-rust/nix/issues/1541"
 categories = ["memory-corruption"]
 keywords = ["nss"]
-informational = "unsound"
 
 [versions]
 patched = ["^0.20.2", "^0.21.2", "^0.22.2", ">= 0.23.0",]


### PR DESCRIPTION
because https://github.com/rustsec/advisory-db/pull/1060#issuecomment-938257192 presented credible attack vectors