### PR TITLE
Update patched version of zeroize_derive.

### DIFF
--- a/crates/zeroize_derive/RUSTSEC-2021-0115.md
+++ b/crates/zeroize_derive/RUSTSEC-2021-0115.md
@@ -6,7 +6,7 @@ date = "2021-09-24"
 url = "https://github.com/iqlusioninc/crates/issues/876"
 
 [versions]
-patched = [">= 1.2.0"]
+patched = [">= 1.1.1"]
 ```
 
 # `#[zeroize(drop)]` doesn't implement `Drop` for `enum`s


### PR DESCRIPTION
zeroize_derive backported the patch to the `1.1` branch and released version `1.1.1` (see https://github.com/iqlusioninc/crates/pull/881), so `1.1.1` should count as patched.