### PR TITLE
add missing cve info to advisories

### DIFF
--- a/crates/abox/RUSTSEC-2020-0121.md
+++ b/crates/abox/RUSTSEC-2020-0121.md
@@ -5,6 +5,7 @@ package = "abox"
 date = "2020-11-10"
 url = "https://github.com/SonicFrog/abox/issues/1"
 categories = ["memory-corruption", "thread-safety"]
+aliases = ["CVE-2020-36441"]
 
 [versions]
 patched = [">= 0.4.1"]

--- a/crates/alg_ds/RUSTSEC-2020-0033.md
+++ b/crates/alg_ds/RUSTSEC-2020-0033.md
@@ -4,6 +4,7 @@ id = "RUSTSEC-2020-0033"
 package = "alg_ds"
 date = "2020-08-25"
 url = "https://gitlab.com/dvshapkin/alg-ds/-/issues/1"
+aliases = ["CVE-2020-36432"]
 
 [versions]
 patched = []

--- a/crates/appendix/RUSTSEC-2020-0149.md
+++ b/crates/appendix/RUSTSEC-2020-0149.md
@@ -5,6 +5,7 @@ package = "appendix"
 date = "2020-11-15"
 url = "https://github.com/krl/appendix/issues/6"
 categories = ["memory-corruption", "thread-safety"]
+aliases = ["CVE-2020-36469"]
 
 [versions]
 patched = []

--- a/crates/array-tools/RUSTSEC-2020-0132.md
+++ b/crates/array-tools/RUSTSEC-2020-0132.md
@@ -5,6 +5,7 @@ package = "array-tools"
 date = "2020-12-31"
 url = "https://github.com/L117/array-tools/issues/2"
 categories = ["memory-corruption"]
+aliases = ["CVE-2020-36452"]
 
 [versions]
 patched = [">= 0.3.2"]

--- a/crates/async-coap/RUSTSEC-2020-0124.md
+++ b/crates/async-coap/RUSTSEC-2020-0124.md
@@ -5,6 +5,7 @@ package = "async-coap"
 date = "2020-12-08"
 url = "https://github.com/google/rust-async-coap/issues/33"
 categories = ["memory-corruption", "thread-safety"]
+aliases = ["CVE-2020-36444"]
 
 [versions]
 patched = []

--- a/crates/beef/RUSTSEC-2020-0122.md
+++ b/crates/beef/RUSTSEC-2020-0122.md
@@ -5,6 +5,7 @@ package = "beef"
 date = "2020-10-28"
 url = "https://github.com/maciejhirsz/beef/issues/37"
 categories = ["memory-corruption", "thread-safety"]
+aliases = ["CVE-2020-36442"]
 
 [versions]
 patched = [">= 0.5.0"]

--- a/crates/bunch/RUSTSEC-2020-0130.md
+++ b/crates/bunch/RUSTSEC-2020-0130.md
@@ -5,6 +5,7 @@ package = "bunch"
 date = "2020-11-12"
 url = "https://github.com/krl/bunch/issues/1"
 categories = ["memory-corruption", "thread-safety"]
+aliases = ["CVE-2020-36450"]
 
 [versions]
 patched = []

--- a/crates/cache/RUSTSEC-2020-0128.md
+++ b/crates/cache/RUSTSEC-2020-0128.md
@@ -5,6 +5,7 @@ package = "cache"
 date = "2020-11-24"
 url = "https://github.com/krl/cache/issues/1"
 categories = ["memory-corruption", "thread-safety"]
+aliases = ["CVE-2020-36448"]
 
 [versions]
 patched = []

--- a/crates/cgc/RUSTSEC-2020-0148.md
+++ b/crates/cgc/RUSTSEC-2020-0148.md
@@ -6,6 +6,7 @@ date = "2020-12-10"
 url = "https://github.com/playXE/cgc/issues/5"
 categories = ["memory-corruption"]
 keywords = ["memory-safety", "aliasing", "concurrency"]
+aliases = ["CVE-2020-36466", "CVE-2020-36467", "CVE-2020-36468"]
 
 [versions]
 patched = []

--- a/crates/chunky/RUSTSEC-2020-0035.md
+++ b/crates/chunky/RUSTSEC-2020-0035.md
@@ -5,6 +5,7 @@ package = "chunky"
 date = "2020-08-25"
 informational = "unsound"
 url = "https://github.com/aeplay/chunky/issues/2"
+aliases = ["CVE-2020-36433"]
 
 [versions]
 patched = []

--- a/crates/conqueue/RUSTSEC-2020-0117.md
+++ b/crates/conqueue/RUSTSEC-2020-0117.md
@@ -5,6 +5,7 @@ package = "conqueue"
 date = "2020-11-24"
 url = "https://github.com/longshorej/conqueue/issues/9"
 categories = ["memory-corruption", "thread-safety"]
+aliases = ["CVE-2020-36437"]
 
 [versions]
 patched = [">= 0.4.0"]

--- a/crates/convec/RUSTSEC-2020-0125.md
+++ b/crates/convec/RUSTSEC-2020-0125.md
@@ -5,6 +5,7 @@ package = "convec"
 date = "2020-11-24"
 url = "https://github.com/krl/convec/issues/2"
 categories = ["memory-corruption", "thread-safety"]
+aliases = ["CVE-2020-36445"]
 
 [versions]
 patched = []

--- a/crates/dces/RUSTSEC-2020-0139.md
+++ b/crates/dces/RUSTSEC-2020-0139.md
@@ -6,6 +6,7 @@ date = "2020-12-09"
 url = "https://gitlab.redox-os.org/redox-os/dces-rust/-/issues/8"
 categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
+aliases = ["CVE-2020-36459"]
 
 [versions]
 patched = []

--- a/crates/disrustor/RUSTSEC-2020-0150.md
+++ b/crates/disrustor/RUSTSEC-2020-0150.md
@@ -5,6 +5,7 @@ package = "disrustor"
 date = "2020-12-17"
 url = "https://github.com/sklose/disrustor/issues/1"
 categories = ["memory-corruption", "thread-safety"]
+aliases = ["CVE-2020-36470"]
 
 [versions]
 patched = []

--- a/crates/failure/RUSTSEC-2020-0036.md
+++ b/crates/failure/RUSTSEC-2020-0036.md
@@ -5,6 +5,7 @@ package = "failure"
 date = "2020-05-02"
 informational = "unmaintained"
 url = "https://github.com/rust-lang-nursery/failure/pull/347"
+aliases = ["CVE-2020-25575"]
 
 [versions]
 patched = []

--- a/crates/generator/RUSTSEC-2019-0020.md
+++ b/crates/generator/RUSTSEC-2019-0020.md
@@ -5,6 +5,7 @@ package = "generator"
 date = "2019-09-06"
 keywords = ["memory-corruption"]
 url = "https://github.com/Xudong-Huang/generator-rs/issues/9"
+aliases = ["CVE-2019-16144"]
 
 [versions]
 patched = [">= 0.6.18"]

--- a/crates/generic-array/RUSTSEC-2020-0146.md
+++ b/crates/generic-array/RUSTSEC-2020-0146.md
@@ -6,6 +6,7 @@ date = "2020-04-09"
 url = "https://github.com/fizyk20/generic-array/issues/98"
 categories = ["memory-corruption"]
 keywords = ["soundness"]
+aliases = ["CVE-2020-36465"]
 
 [versions]
 patched = [

--- a/crates/heapless/RUSTSEC-2020-0145.md
+++ b/crates/heapless/RUSTSEC-2020-0145.md
@@ -7,6 +7,7 @@ url = "https://github.com/japaric/heapless/issues/181"
 categories = ["memory-corruption", "memory-exposure"]
 keywords = ["use-after-free"]
 informational = "unsound"
+aliases = ["CVE-2020-36464"]
 
 [affected.functions]
 "heapless::vec::IntoIter::clone" = ["<= 0.6"]

--- a/crates/kekbit/RUSTSEC-2020-0129.md
+++ b/crates/kekbit/RUSTSEC-2020-0129.md
@@ -5,6 +5,7 @@ package = "kekbit"
 date = "2020-12-18"
 url = "https://github.com/motoras/kekbit/issues/34"
 categories = ["memory-corruption", "thread-safety"]
+aliases = ["CVE-2020-36449"]
 
 [versions]
 patched = [">= 0.3.4"]

--- a/crates/lever/RUSTSEC-2020-0137.md
+++ b/crates/lever/RUSTSEC-2020-0137.md
@@ -6,6 +6,7 @@ date = "2020-11-10"
 url = "https://github.com/vertexclique/lever/issues/15"
 categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
+aliases = ["CVE-2020-36457"]
 
 [versions]
 patched = [">= 0.1.1"]

--- a/crates/lexer/RUSTSEC-2020-0138.md
+++ b/crates/lexer/RUSTSEC-2020-0138.md
@@ -5,6 +5,7 @@ package = "lexer"
 date = "2020-11-10"
 url = "https://gitlab.com/nathanfaucett/rs-lexer/-/issues/2"
 categories = ["memory-corruption", "thread-safety"]
+aliases = ["CVE-2020-36458"]
 
 [versions]
 patched = []

--- a/crates/libp2p-deflate/RUSTSEC-2020-0123.md
+++ b/crates/libp2p-deflate/RUSTSEC-2020-0123.md
@@ -5,6 +5,7 @@ package = "libp2p-deflate"
 date = "2020-01-24"
 url = "https://github.com/libp2p/rust-libp2p/issues/1932"
 categories = ["memory-exposure"]
+aliases = ["CVE-2020-36443"]
 
 [versions]
 patched = [">= 0.27.1"]

--- a/crates/libpulse-binding/RUSTSEC-2018-0020.md
+++ b/crates/libpulse-binding/RUSTSEC-2018-0020.md
@@ -5,7 +5,7 @@ package = "libpulse-binding"
 date = "2018-12-22"
 url = "https://github.com/advisories/GHSA-6gvc-4jvj-pwq4"
 categories = ["memory-corruption"]
-aliases = ["GHSA-6gvc-4jvj-pwq4"]
+aliases = ["GHSA-6gvc-4jvj-pwq4", "CVE-2018-25001"]
 
 [versions]
 patched = [">= 2.5.0"]

--- a/crates/libsbc/RUSTSEC-2020-0120.md
+++ b/crates/libsbc/RUSTSEC-2020-0120.md
@@ -6,6 +6,7 @@ date = "2020-11-10"
 url = "https://github.com/mvertescher/libsbc-rs/issues/4"
 categories = ["memory-corruption", "thread-safety"]
 informational = "unsound"
+aliases = ["CVE-2020-36440"]
 
 [versions]
 patched = [">= 0.1.5"]

--- a/crates/max7301/RUSTSEC-2020-0152.md
+++ b/crates/max7301/RUSTSEC-2020-0152.md
@@ -6,6 +6,7 @@ date = "2020-12-18"
 url = "https://github.com/edarc/max7301/issues/1"
 categories = ["memory-corruption"]
 keywords = ["concurrency"]
+aliases = ["CVE-2020-36472"]
 
 [versions]
 patched = [">= 0.2.0"]

--- a/crates/model/RUSTSEC-2020-0140.md
+++ b/crates/model/RUSTSEC-2020-0140.md
@@ -6,6 +6,7 @@ date = "2020-11-10"
 url = "https://github.com/spacejam/model/issues/3"
 categories = ["thread-safety"]
 informational = "unsound"
+aliases = ["CVE-2020-36460"]
 
 [versions]
 patched = []

--- a/crates/multiqueue/RUSTSEC-2020-0143.md
+++ b/crates/multiqueue/RUSTSEC-2020-0143.md
@@ -5,6 +5,7 @@ package = "multiqueue"
 date = "2020-12-25"
 url = "https://github.com/schets/multiqueue/issues/31"
 categories = ["memory-corruption", "thread-safety"]
+aliases = ["CVE-2020-36463"]
 
 [versions]
 patched = []

--- a/crates/net2/RUSTSEC-2020-0078.md
+++ b/crates/net2/RUSTSEC-2020-0078.md
@@ -6,6 +6,7 @@ date = "2020-11-07"
 url = "https://github.com/deprecrated/net2-rs/issues/105"
 keywords = ["memory", "layout", "cast"]
 informational = "unsound"
+aliases = ["CVE-2020-35919"]
 
 [versions]
 patched = [">= 0.2.36"]

--- a/crates/noise_search/RUSTSEC-2020-0141.md
+++ b/crates/noise_search/RUSTSEC-2020-0141.md
@@ -5,6 +5,7 @@ package = "noise_search"
 date = "2020-12-10"
 url = "https://github.com/pipedown/noise/issues/72"
 categories = ["memory-corruption", "thread-safety"]
+aliases = ["CVE-2020-36461"]
 
 [versions]
 patched = []

--- a/crates/parc/RUSTSEC-2020-0134.md
+++ b/crates/parc/RUSTSEC-2020-0134.md
@@ -5,6 +5,7 @@ package = "parc"
 date = "2020-11-14"
 url = "https://github.com/hyyking/rustracts/pull/6"
 categories = ["memory-corruption", "thread-safety"]
+aliases = ["CVE-2020-36454"]
 
 [versions]
 patched = []

--- a/crates/rcu_cell/RUSTSEC-2020-0131.md
+++ b/crates/rcu_cell/RUSTSEC-2020-0131.md
@@ -5,6 +5,7 @@ package = "rcu_cell"
 date = "2020-11-14"
 url = "https://github.com/Xudong-Huang/rcu_cell/issues/3"
 categories = ["memory-corruption", "thread-safety"]
+aliases = ["CVE-2020-36451"]
 
 [versions]
 patched = []

--- a/crates/rkyv/RUSTSEC-2021-0054.md
+++ b/crates/rkyv/RUSTSEC-2021-0054.md
@@ -6,6 +6,7 @@ date = "2021-04-28"
 url = "https://github.com/djkoloski/rkyv/issues/113"
 categories = ["memory-exposure"]
 keywords = ["uninitialized", "memory", "information", "leak"]
+aliases = ["CVE-2021-31919"]
 
 [versions]
 patched = [">= 0.6.0"]

--- a/crates/ruspiro-singleton/RUSTSEC-2020-0115.md
+++ b/crates/ruspiro-singleton/RUSTSEC-2020-0115.md
@@ -6,6 +6,7 @@ date = "2020-11-16"
 url = "https://github.com/RusPiRo/ruspiro-singleton/issues/10"
 categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
+aliases = ["CVE-2020-36435"]
 
 [versions]
 patched = [">= 0.4.1"]

--- a/crates/signal-simple/RUSTSEC-2020-0126.md
+++ b/crates/signal-simple/RUSTSEC-2020-0126.md
@@ -5,6 +5,7 @@ package = "signal-simple"
 date = "2020-11-15"
 url = "https://github.com/kitsuneninetails/signal-rust/issues/2"
 categories = ["memory-corruption", "thread-safety"]
+aliases = ["CVE-2020-36446"]
 
 [versions]
 patched = []

--- a/crates/slock/RUSTSEC-2020-0135.md
+++ b/crates/slock/RUSTSEC-2020-0135.md
@@ -5,6 +5,7 @@ package = "slock"
 date = "2020-11-17"
 url = "https://github.com/BrokenLamp/slock-rs/issues/2"
 categories = ["memory-corruption", "thread-safety"]
+aliases = ["CVE-2020-36455"]
 
 [versions]
 patched = []

--- a/crates/sys-info/RUSTSEC-2020-0100.md
+++ b/crates/sys-info/RUSTSEC-2020-0100.md
@@ -6,6 +6,7 @@ date = "2020-05-31"
 url = "https://github.com/FillZpp/sys-info-rs/issues/63"
 categories = ["memory-corruption"]
 keywords = ["concurrency", "double free"]
+aliases = ["CVE-2020-36434"]
 
 [versions]
 patched = [">= 0.8.0"]

--- a/crates/ticketed_lock/RUSTSEC-2020-0119.md
+++ b/crates/ticketed_lock/RUSTSEC-2020-0119.md
@@ -5,6 +5,7 @@ package = "ticketed_lock"
 date = "2020-11-17"
 url = "https://github.com/kvark/ticketed_lock/issues/7"
 categories = ["memory-corruption", "thread-safety"]
+aliases = ["CVE-2020-36439"]
 
 [versions]
 patched = [">= 0.3.0"]

--- a/crates/tiny_future/RUSTSEC-2020-0118.md
+++ b/crates/tiny_future/RUSTSEC-2020-0118.md
@@ -6,6 +6,7 @@ date = "2020-12-08"
 url = "https://github.com/KizzyCode/tiny_future/issues/1"
 categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
+aliases = ["CVE-2020-36438"]
 
 [versions]
 patched = [">= 0.4.0"]

--- a/crates/toolshed/RUSTSEC-2020-0136.md
+++ b/crates/toolshed/RUSTSEC-2020-0136.md
@@ -6,6 +6,7 @@ date = "2020-11-15"
 url = "https://github.com/ratel-rust/toolshed/issues/12"
 categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
+aliases = ["CVE-2020-36456"]
 
 [versions]
 patched = []

--- a/crates/unicycle/RUSTSEC-2020-0116.md
+++ b/crates/unicycle/RUSTSEC-2020-0116.md
@@ -5,6 +5,7 @@ package = "unicycle"
 date = "2020-11-15"
 url = "https://github.com/udoprog/unicycle/issues/8"
 categories = ["memory-corruption", "thread-safety"]
+aliases = ["CVE-2020-36436"]
 
 [versions]
 patched = [">= 0.7.1"]

--- a/crates/v9/RUSTSEC-2020-0127.md
+++ b/crates/v9/RUSTSEC-2020-0127.md
@@ -5,6 +5,7 @@ package = "v9"
 date = "2020-12-18"
 url = "https://github.com/purpleposeidon/v9/issues/1"
 categories = ["memory-corruption", "thread-safety"]
+aliases = ["CVE-2020-36447"]
 
 [versions]
 patched = []


### PR DESCRIPTION
looks like RUSTSEC-2020-0036 might be a special case, someone got a cve for that the crate is unmaintained.

This was based on a bit of automation effort, this data is based on all cve's that refeferences the rustsec database, and where there isn't a link back. But I have looked at all of the cve pages manually and it looks correct to me.