### PR TITLE
Update RUSTEC-2020-0071

### DIFF
--- a/crates/time/RUSTSEC-2020-0071.md
+++ b/crates/time/RUSTSEC-2020-0071.md
@@ -24,6 +24,8 @@ os = [
     "freebsd",
 ]
 [affected.functions]
+"time::at" = ["^0.1"]
+"time::at_utc" = ["^0.1"]
 "time::UtcOffset::local_offset_at" = ["< 0.2.23"]
 "time::UtcOffset::try_local_offset_at" = ["< 0.2.23"]
 "time::UtcOffset::current_local_offset" = ["< 0.2.23"]
@@ -33,16 +35,16 @@ os = [
 
 [versions]
 patched = [">= 0.2.23"]
-unaffected = ["< 0.2.7"]
+unaffected = ["=0.2.0", "=0.2.1", "=0.2.2", "=0.2.3", "=0.2.4", "=0.2.5", "=0.2.6"]
 ```
 
 # Potential segfault in the time crate
 
-## Impact
+### Impact
 
-Unix-like operating systems may segfault due to dereferencing a dangling pointer in specific circumstances. This requires the user to set any environment variable in a different thread than the affected functions.
+Unix-like operating systems may segfault due to dereferencing a dangling pointer in specific circumstances. This requires an environment variable to be set in a different thread than the affected functions. This may occur without the user's knowledge, notably in a third-party library.
 
-The affected functions are:
+The affected functions from time 0.2.7 through 0.2.22 are:
 
 - `time::UtcOffset::local_offset_at`
 - `time::UtcOffset::try_local_offset_at`
@@ -51,18 +53,25 @@ The affected functions are:
 - `time::OffsetDateTime::now_local`
 - `time::OffsetDateTime::try_now_local`
 
-Non-Unix targets are unaffected. This includes Windows and wasm.
+The affected functions in time 0.1 (all versions) are:
 
-## Patches
+- `at`
+- `at_utc`
+
+Non-Unix targets (including Windows and wasm) are unaffected.
+
+### Patches
 
 Pending a proper fix, the internal method that determines the local offset has been modified to always return `None` on the affected operating systems. This has the effect of returning an `Err` on the `try_*` methods and `UTC` on the non-`try_*` methods.
 
-Users and library authors with time in their dependency tree should perform `cargo update`, which will pull in a the updated, unaffected code.
+Users and library authors with time in their dependency tree should perform `cargo update`, which will pull in the updated, unaffected code.
 
-## Workarounds
+Users of time 0.1 do not have a patch and should upgrade to an unaffected version: time 0.2.23 or greater or the 0.3. series.
+
+### Workarounds
 
 No workarounds are known.
 
-## References
+### References
 
-#293
+time-rs/time#293


### PR DESCRIPTION
This includes the affected functions in time 0.1 and rewords a few
things for clarity.