### PR TITLE
Report abomonation as unsound

### DIFF
--- a/crates/abomonation/RUSTSEC-0000-0000.md
+++ b/crates/abomonation/RUSTSEC-0000-0000.md
@@ -4,8 +4,8 @@ id = "RUSTSEC-0000-0000"
 package = "abomonation"
 date = "2021-10-17"
 url = "https://github.com/TimelyDataflow/abomonation/issues/23"
-categories = [""]
-keywords = [""]
+categories = []
+keywords = []
 informational = "unsound"
 
 [versions]


### PR DESCRIPTION
I'm a bit unsure where to go with this.

The abomonation crate is unsound in so many ways; though the interface is marked as `unsafe` it doesn't document all its requirements and contains probably-invalid implementations of its own `unsafe Trait`. The authors appear to know that this is all deeply problematic (most of the open issues on the crate are about various soundness problems), but the crate averages ~600 daily downloads on weekdays due to its use in `nalgebra`, whose tests for their abomonation implementations also fail for the same reasons.