### PR TITLE
Update vec-const advisory

### DIFF
--- a/crates/vec-const/RUSTSEC-2021-0082.md
+++ b/crates/vec-const/RUSTSEC-2021-0082.md
@@ -9,9 +9,11 @@ keywords = ["memory-safety"]
 informational = "unsound"
 
 [versions]
-patched = []
+patched = [">= 2.0.0"]
 ```
 
 # vec-const attempts to construct a Vec from a pointer to a const slice
 
-This crate claims to construct a const `Vec` with nonzero length and capacity, but that cannot be done because such a `Vec` requires a pointer from an allocator.
+Affected versions of this crate claimed to construct a const `Vec` with nonzero length and capacity, but that cannot be done because such a `Vec` requires a pointer from an allocator.
+
+The implementation was later changed to just construct a `std::borrow::Cow`.


### PR DESCRIPTION
Just over a month ago, the maintainer released new versions with a fix. This crate is almost entirely unused, but this change makes a warning more actionable :partying_face: 