### PR TITLE
Add `chrono` advisory for chrono#499 (localtime_r)

### DIFF
--- a/crates/chrono/RUSTSEC-0000-0000.md
+++ b/crates/chrono/RUSTSEC-0000-0000.md
@@ -1,0 +1,27 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "chrono"
+date = "2020-11-10"
+url = "https://github.com/chronotope/chrono/issues/499"
+categories = ["code-execution", "memory-corruption"]
+keywords = ["segfault"]
+related = ["CVE-2020-26235", "RUSTSEC-2020-0071"]
+
+[versions]
+patched = []
+```
+
+# Potential segfault in `localtime_r` invocations
+
+### Impact
+
+Unix-like operating systems may segfault due to dereferencing a dangling pointer in specific circumstances. This requires an environment variable to be set in a different thread than the affected functions. This may occur without the user's knowledge, notably in a third-party library.
+
+### Workarounds
+
+No workarounds are known.
+
+### References
+
+- [time-rs/time#293](https://github.com/time-rs/time/issues/293)


### PR DESCRIPTION
This is an advisory similar to `RUSTSEC-2020-0071` impacting usages of `localtime_r` within `chrono` itself, since the API is used in a cross-thread manner in an unsound way.