### PR TITLE
Add cvss information from nvd

### DIFF
--- a/crates/abi_stable/RUSTSEC-2020-0105.md
+++ b/crates/abi_stable/RUSTSEC-2020-0105.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0105"
 package = "abi_stable"
 aliases = ["CVE-2020-36212", "CVE-2020-36213"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-12-21"
 url = "https://github.com/rodrimati1992/abi_stable_crates/issues/44"
 categories = ["memory-corruption"]

--- a/crates/abox/RUSTSEC-2020-0121.md
+++ b/crates/abox/RUSTSEC-2020-0121.md
@@ -6,6 +6,7 @@ date = "2020-11-10"
 url = "https://github.com/SonicFrog/abox/issues/1"
 categories = ["memory-corruption", "thread-safety"]
 aliases = ["CVE-2020-36441"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = [">= 0.4.1"]

--- a/crates/actix-codec/RUSTSEC-2020-0049.md
+++ b/crates/actix-codec/RUSTSEC-2020-0049.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0049"
 package = "actix-codec"
 aliases = ["CVE-2020-35902"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 categories = ["memory-corruption"]
 date = "2020-01-30"
 url = "https://github.com/actix/actix-net/issues/91"

--- a/crates/actix-http/RUSTSEC-2020-0048.md
+++ b/crates/actix-http/RUSTSEC-2020-0048.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0048"
 package = "actix-http"
 aliases = ["CVE-2020-35901"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 categories = ["memory-corruption"]
 date = "2020-01-24"
 url = "https://github.com/actix/actix-web/issues/1321"

--- a/crates/actix-http/RUSTSEC-2021-0081.md
+++ b/crates/actix-http/RUSTSEC-2021-0081.md
@@ -5,6 +5,7 @@ package = "actix-http"
 date = "2021-06-16"
 keywords = ["smuggling", "http", "reverse proxy", "request smuggling"]
 aliases = ["CVE-2021-38512"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
 
 [versions]
 patched = ["^ 2.2.1", ">= 3.0.0-beta.9"]

--- a/crates/actix-service/RUSTSEC-2020-0046.md
+++ b/crates/actix-service/RUSTSEC-2020-0046.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0046"
 package = "actix-service"
 aliases = ["CVE-2020-35899"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 categories = ["memory-corruption"]
 date = "2020-01-08"
 informational = "unsound"

--- a/crates/actix-utils/RUSTSEC-2020-0045.md
+++ b/crates/actix-utils/RUSTSEC-2020-0045.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0045"
 package = "actix-utils"
 aliases = ["CVE-2020-35898"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H"
 categories = ["memory-corruption"]
 date = "2020-01-08"
 informational = "unsound"

--- a/crates/adtensor/RUSTSEC-2021-0045.md
+++ b/crates/adtensor/RUSTSEC-2021-0045.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0045"
 package = "adtensor"
 aliases = ["CVE-2021-29936"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2021-01-11"
 url = "https://github.com/charles-r-earp/adtensor/issues/4"
 categories = ["memory-corruption"]

--- a/crates/alg_ds/RUSTSEC-2020-0033.md
+++ b/crates/alg_ds/RUSTSEC-2020-0033.md
@@ -5,6 +5,7 @@ package = "alg_ds"
 date = "2020-08-25"
 url = "https://gitlab.com/dvshapkin/alg-ds/-/issues/1"
 aliases = ["CVE-2020-36432"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = []

--- a/crates/alpm-rs/RUSTSEC-2020-0032.md
+++ b/crates/alpm-rs/RUSTSEC-2020-0032.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0032"
 package = "alpm-rs"
 aliases = ["CVE-2020-35885"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2020-08-20"
 informational = "unsound"
 url = "https://github.com/pigeonhands/rust-arch/issues/2"

--- a/crates/ammonia/RUSTSEC-2019-0001.md
+++ b/crates/ammonia/RUSTSEC-2019-0001.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0001"
 package = "ammonia"
 aliases = ["CVE-2019-15542"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2019-04-27"
 keywords = ["stack-overflow", "crash"]
 url = "https://github.com/rust-ammonia/ammonia/blob/master/CHANGELOG.md#210"

--- a/crates/aovec/RUSTSEC-2020-0099.md
+++ b/crates/aovec/RUSTSEC-2020-0099.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0099"
 package = "aovec"
 aliases = ["CVE-2020-36207"]
+cvss = "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H"
 date = "2020-12-10"
 categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]

--- a/crates/appendix/RUSTSEC-2020-0149.md
+++ b/crates/appendix/RUSTSEC-2020-0149.md
@@ -6,6 +6,7 @@ date = "2020-11-15"
 url = "https://github.com/krl/appendix/issues/6"
 categories = ["memory-corruption", "thread-safety"]
 aliases = ["CVE-2020-36469"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
 
 [versions]
 patched = []

--- a/crates/arc-swap/RUSTSEC-2020-0091.md
+++ b/crates/arc-swap/RUSTSEC-2020-0091.md
@@ -7,6 +7,7 @@ url = "https://github.com/vorner/arc-swap/issues/45"
 categories = ["memory-corruption"]
 keywords = ["dangling reference"]
 aliases = ["CVE-2020-35711"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 
 [versions]
 patched = [">= 0.4.8, < 1.0.0-0", ">= 1.1.0"]

--- a/crates/arenavec/RUSTSEC-2021-0040.md
+++ b/crates/arenavec/RUSTSEC-2021-0040.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0040"
 package = "arenavec"
 aliases = ["CVE-2021-29930", "CVE-2021-29931"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2021-01-12"
 url = "https://github.com/ibabushkin/arenavec/issues/1"
 categories = ["memory-corruption"]

--- a/crates/array-queue/RUSTSEC-2020-0047.md
+++ b/crates/array-queue/RUSTSEC-2020-0047.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0047"
 package = "array-queue"
 aliases = ["CVE-2020-35900"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
 date = "2020-09-26"
 keywords = ["memory-corruption", "uninitialized-memory", "use-after-free"]
 url = "https://github.com/raviqqe/array-queue/issues/2"

--- a/crates/array-tools/RUSTSEC-2020-0132.md
+++ b/crates/array-tools/RUSTSEC-2020-0132.md
@@ -6,6 +6,7 @@ date = "2020-12-31"
 url = "https://github.com/L117/array-tools/issues/2"
 categories = ["memory-corruption"]
 aliases = ["CVE-2020-36452"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = [">= 0.3.2"]

--- a/crates/arrayfire/RUSTSEC-2018-0011.md
+++ b/crates/arrayfire/RUSTSEC-2018-0011.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2018-0011"
 package = "arrayfire"
 aliases = ["CVE-2018-20998"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 categories = ["memory-corruption"]
 date = "2018-12-18"
 keywords = ["enum", "repr"]

--- a/crates/asn1_der/RUSTSEC-2019-0007.md
+++ b/crates/asn1_der/RUSTSEC-2019-0007.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0007"
 package = "asn1_der"
 aliases = ["CVE-2019-15549"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2019-06-13"
 keywords = ["dos"]
 url = "https://github.com/KizzyCode/asn1_der/issues/1"

--- a/crates/async-coap/RUSTSEC-2020-0124.md
+++ b/crates/async-coap/RUSTSEC-2020-0124.md
@@ -6,6 +6,7 @@ date = "2020-12-08"
 url = "https://github.com/google/rust-async-coap/issues/33"
 categories = ["memory-corruption", "thread-safety"]
 aliases = ["CVE-2020-36444"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = []

--- a/crates/atom/RUSTSEC-2020-0044.md
+++ b/crates/atom/RUSTSEC-2020-0044.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0044"
 package = "atom"
 aliases = ["CVE-2020-35897"]
+cvss = "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-09-21"
 informational = "unsound"
 url = "https://github.com/slide-rs/atom/issues/13"

--- a/crates/atomic-option/RUSTSEC-2020-0113.md
+++ b/crates/atomic-option/RUSTSEC-2020-0113.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0113"
 package = "atomic-option"
 aliases = ["CVE-2020-36219"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-10-31"
 url = "https://github.com/reem/rust-atomic-option/issues/4"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/autorand/RUSTSEC-2020-0103.md
+++ b/crates/autorand/RUSTSEC-2020-0103.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0103"
 package = "autorand"
 aliases = ["CVE-2020-36210"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
 date = "2020-12-31"
 url = "https://github.com/mersinvald/autorand-rs/issues/5"
 categories = ["memory-corruption"]

--- a/crates/av-data/RUSTSEC-2021-0007.md
+++ b/crates/av-data/RUSTSEC-2021-0007.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0007"
 package = "av-data"
 aliases = ["CVE-2021-25904"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2021-01-07"
 url = "https://github.com/rust-av/rust-av/issues/136"
 categories = ["memory-exposure", "privilege-escalation"]

--- a/crates/bam/RUSTSEC-2021-0027.md
+++ b/crates/bam/RUSTSEC-2021-0027.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0027"
 package = "bam"
 aliases = ["CVE-2021-28027"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2021-01-07"
 url = "https://gitlab.com/tprodanov/bam/-/issues/4"
 categories = ["memory-corruption"]

--- a/crates/base64/RUSTSEC-2017-0004.md
+++ b/crates/base64/RUSTSEC-2017-0004.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2017-0004"
 package = "base64"
 aliases = ["CVE-2017-1000430"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2017-05-03"
 keywords = ["memory-corruption"]
 url = "https://github.com/alicemaz/rust-base64/commit/24ead980daf11ba563e4fb2516187a56a71ad319"

--- a/crates/basic_dsp_matrix/RUSTSEC-2021-0009.md
+++ b/crates/basic_dsp_matrix/RUSTSEC-2021-0009.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0009"
 package = "basic_dsp_matrix"
 aliases = ["CVE-2021-25906"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2021-01-10"
 url = "https://github.com/liebharc/basic_dsp/issues/47"
 categories = ["memory-corruption"]

--- a/crates/beef/RUSTSEC-2020-0122.md
+++ b/crates/beef/RUSTSEC-2020-0122.md
@@ -6,6 +6,7 @@ date = "2020-10-28"
 url = "https://github.com/maciejhirsz/beef/issues/37"
 categories = ["memory-corruption", "thread-safety"]
 aliases = ["CVE-2020-36442"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = [">= 0.5.0"]

--- a/crates/bigint/RUSTSEC-2020-0025.md
+++ b/crates/bigint/RUSTSEC-2020-0025.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0025"
 package = "bigint"
 aliases = ["CVE-2020-35880"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2020-05-07"
 informational = "unmaintained"
 url = "https://github.com/paritytech/bigint/commit/7e71521a61b009afc94c91135353102658550d42"

--- a/crates/bitvec/RUSTSEC-2020-0007.md
+++ b/crates/bitvec/RUSTSEC-2020-0007.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0007"
 package = "bitvec"
 aliases = ["CVE-2020-35862"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 categories = ["memory-corruption"]
 date = "2020-03-27"
 url = "https://github.com/myrrlyn/bitvec/issues/55"

--- a/crates/blake2/RUSTSEC-2019-0019.md
+++ b/crates/blake2/RUSTSEC-2019-0019.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0019"
 package = "blake2"
 aliases = ["CVE-2019-16143"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 categories = ["crypto-failure"]
 date = "2019-08-25"
 url = "https://github.com/RustCrypto/MACs/issues/19"

--- a/crates/bra/RUSTSEC-2021-0008.md
+++ b/crates/bra/RUSTSEC-2021-0008.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0008"
 package = "bra"
 aliases = ["CVE-2021-25905"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H"
 date = "2021-01-02"
 url = "https://github.com/Enet4/bra-rs/issues/1"
 categories = ["memory-exposure"]

--- a/crates/branca/RUSTSEC-2020-0075.md
+++ b/crates/branca/RUSTSEC-2020-0075.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0075"
 package = "branca"
 aliases = ["CVE-2020-35918"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-11-29"
 url = "https://github.com/return/branca/issues/24"
 categories = ["denial-of-service"]

--- a/crates/bumpalo/RUSTSEC-2020-0006.md
+++ b/crates/bumpalo/RUSTSEC-2020-0006.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0006"
 package = "bumpalo"
 aliases = ["CVE-2020-35861"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
 categories = ["memory-exposure"]
 date = "2020-03-24"
 url = "https://github.com/fitzgen/bumpalo/issues/69"

--- a/crates/bunch/RUSTSEC-2020-0130.md
+++ b/crates/bunch/RUSTSEC-2020-0130.md
@@ -6,6 +6,7 @@ date = "2020-11-12"
 url = "https://github.com/krl/bunch/issues/1"
 categories = ["memory-corruption", "thread-safety"]
 aliases = ["CVE-2020-36450"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = []

--- a/crates/buttplug/RUSTSEC-2020-0112.md
+++ b/crates/buttplug/RUSTSEC-2020-0112.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0112"
 package = "buttplug"
 aliases = ["CVE-2020-36218"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-12-18"
 url = "https://github.com/buttplugio/buttplug-rs/issues/225"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/byte_struct/RUSTSEC-2021-0032.md
+++ b/crates/byte_struct/RUSTSEC-2021-0032.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0032"
 package = "byte_struct"
 aliases = ["CVE-2021-28033"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2021-03-01"
 url = "https://github.com/wwylele/byte-struct-rs/issues/1"
 categories = ["memory-corruption"]

--- a/crates/cache/RUSTSEC-2020-0128.md
+++ b/crates/cache/RUSTSEC-2020-0128.md
@@ -6,6 +6,7 @@ date = "2020-11-24"
 url = "https://github.com/krl/cache/issues/1"
 categories = ["memory-corruption", "thread-safety"]
 aliases = ["CVE-2020-36448"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = []

--- a/crates/cache/RUSTSEC-2021-0006.md
+++ b/crates/cache/RUSTSEC-2021-0006.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0006"
 package = "cache"
 aliases = ["CVE-2021-25903"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2021-01-01"
 url = "https://github.com/krl/cache/issues/2"
 informational = "unsound"

--- a/crates/calamine/RUSTSEC-2021-0015.md
+++ b/crates/calamine/RUSTSEC-2021-0015.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0015"
 package = "calamine"
 aliases = ["CVE-2021-26951"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2021-01-06"
 url = "https://github.com/tafia/calamine/issues/199"
 categories = ["memory-corruption", "memory-exposure"]

--- a/crates/cbox/RUSTSEC-2020-0005.md
+++ b/crates/cbox/RUSTSEC-2020-0005.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0005"
 package = "cbox"
 aliases = ["CVE-2020-35860"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 categories = ["memory-corruption"]
 date = "2020-03-19"
 url = "https://github.com/TomBebbington/cbox-rs/issues/2"

--- a/crates/cdr/RUSTSEC-2021-0012.md
+++ b/crates/cdr/RUSTSEC-2021-0012.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0012"
 package = "cdr"
 aliases = ["CVE-2021-26305"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2021-01-02"
 url = "https://github.com/hrektts/cdr-rs/issues/10"
 categories = ["memory-exposure"]

--- a/crates/cgc/RUSTSEC-2020-0148.md
+++ b/crates/cgc/RUSTSEC-2020-0148.md
@@ -7,6 +7,7 @@ url = "https://github.com/playXE/cgc/issues/5"
 categories = ["memory-corruption"]
 keywords = ["memory-safety", "aliasing", "concurrency"]
 aliases = ["CVE-2020-36466", "CVE-2020-36467", "CVE-2020-36468"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
 
 [versions]
 patched = []

--- a/crates/chacha20/RUSTSEC-2019-0029.md
+++ b/crates/chacha20/RUSTSEC-2019-0029.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0029"
 package = "chacha20"
 aliases = ["CVE-2019-25005"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
 categories = ["crypto-failure"]
 date = "2019-10-22"
 url = "https://github.com/RustCrypto/stream-ciphers/pull/64"

--- a/crates/chttp/RUSTSEC-2019-0016.md
+++ b/crates/chttp/RUSTSEC-2019-0016.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0016"
 package = "chttp"
 aliases = ["CVE-2019-16140"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2019-09-01"
 keywords = ["memory-management", "memory-corruption"]
 url = "https://github.com/sagebind/isahc/issues/2"

--- a/crates/chunky/RUSTSEC-2020-0035.md
+++ b/crates/chunky/RUSTSEC-2020-0035.md
@@ -6,6 +6,7 @@ date = "2020-08-25"
 informational = "unsound"
 url = "https://github.com/aeplay/chunky/issues/2"
 aliases = ["CVE-2020-36433"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
 
 [versions]
 patched = []

--- a/crates/claxon/RUSTSEC-2018-0004.md
+++ b/crates/claxon/RUSTSEC-2018-0004.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2018-0004"
 package = "claxon"
 aliases = ["CVE-2018-20992"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N"
 date = "2018-08-25"
 keywords = ["uninitialized-memory"]
 url = "https://github.com/ruuda/claxon/commit/8f28ec275e412dd3af4f3cda460605512faf332c"

--- a/crates/compact_arena/RUSTSEC-2019-0015.md
+++ b/crates/compact_arena/RUSTSEC-2019-0015.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0015"
 package = "compact_arena"
 aliases = ["CVE-2019-16139"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 categories = ["memory-corruption"]
 date = "2019-05-21"
 keywords = ["uninitialized-memory"]

--- a/crates/comrak/RUSTSEC-2021-0026.md
+++ b/crates/comrak/RUSTSEC-2021-0026.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0026"
 package = "comrak"
 aliases = ["CVE-2021-27671"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
 date = "2021-02-21"
 url = "https://github.com/kivikakk/comrak/releases/tag/0.9.1"
 categories = ["format-injection"]

--- a/crates/concread/RUSTSEC-2020-0092.md
+++ b/crates/concread/RUSTSEC-2020-0092.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0092"
 package = "concread"
 aliases = ["CVE-2020-35928"]
+cvss = "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-11-13"
 url = "https://github.com/kanidm/concread/issues/48"
 categories = ["thread-safety"]

--- a/crates/conquer-once/RUSTSEC-2020-0101.md
+++ b/crates/conquer-once/RUSTSEC-2020-0101.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0101"
 package = "conquer-once"
 aliases = ["CVE-2020-36208"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
 date = "2020-12-22"
 url = "https://github.com/oliver-giersch/conquer-once/issues/3"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/conqueue/RUSTSEC-2020-0117.md
+++ b/crates/conqueue/RUSTSEC-2020-0117.md
@@ -6,6 +6,7 @@ date = "2020-11-24"
 url = "https://github.com/longshorej/conqueue/issues/9"
 categories = ["memory-corruption", "thread-safety"]
 aliases = ["CVE-2020-36437"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = [">= 0.4.0"]

--- a/crates/containers/RUSTSEC-2021-0010.md
+++ b/crates/containers/RUSTSEC-2021-0010.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0010"
 package = "containers"
 aliases = ["CVE-2021-25907"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2021-01-12"
 url = "https://github.com/strake/containers.rs/issues/2"
 categories = ["memory-corruption"]

--- a/crates/convec/RUSTSEC-2020-0125.md
+++ b/crates/convec/RUSTSEC-2020-0125.md
@@ -6,6 +6,7 @@ date = "2020-11-24"
 url = "https://github.com/krl/convec/issues/2"
 categories = ["memory-corruption", "thread-safety"]
 aliases = ["CVE-2020-36445"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = []

--- a/crates/cookie/RUSTSEC-2017-0005.md
+++ b/crates/cookie/RUSTSEC-2017-0005.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2017-0005"
 package = "cookie"
 aliases = ["CVE-2017-18589"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2017-05-06"
 keywords = ["crash"]
 url = "https://github.com/alexcrichton/cookie-rs/pull/86"

--- a/crates/cranelift-codegen/RUSTSEC-2021-0067.md
+++ b/crates/cranelift-codegen/RUSTSEC-2021-0067.md
@@ -7,6 +7,7 @@ url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-hpq
 categories = ["code-execution", "memory-corruption", "memory-exposure"]
 keywords = ["miscompile", "sandbox", "wasm"]
 aliases = ["CVE-2021-32629", "GHSA-hpqh-2wqx-7qp5"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
 
 [versions]
 patched = [">= 0.73.1"]

--- a/crates/crayon/RUSTSEC-2020-0037.md
+++ b/crates/crayon/RUSTSEC-2020-0037.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0037"
 package = "crayon"
 aliases = ["CVE-2020-35889"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2020-08-31"
 informational = "unsound"
 url = "https://github.com/shawnscode/crayon/issues/87"

--- a/crates/crossbeam-deque/RUSTSEC-2021-0093.md
+++ b/crates/crossbeam-deque/RUSTSEC-2021-0093.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0093"
 package = "crossbeam-deque"
 aliases = ["GHSA-pqqp-xmhj-wgcw", "CVE-2021-32810"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 categories = ["memory-corruption"]
 date = "2021-07-30"
 url = "https://github.com/crossbeam-rs/crossbeam/security/advisories/GHSA-pqqp-xmhj-wgcw"

--- a/crates/crossbeam/RUSTSEC-2018-0009.md
+++ b/crates/crossbeam/RUSTSEC-2018-0009.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2018-0009"
 package = "crossbeam"
 aliases = ["CVE-2018-20996"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2018-12-09"
 keywords = ["concurrency", "memory-management", "memory-corruption"]
 url = "https://github.com/crossbeam-rs/crossbeam-epoch/issues/82"

--- a/crates/dces/RUSTSEC-2020-0139.md
+++ b/crates/dces/RUSTSEC-2020-0139.md
@@ -7,6 +7,7 @@ url = "https://gitlab.redox-os.org/redox-os/dces-rust/-/issues/8"
 categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
 aliases = ["CVE-2020-36459"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = []

--- a/crates/diesel/RUSTSEC-2021-0037.md
+++ b/crates/diesel/RUSTSEC-2021-0037.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0037"
 package = "diesel"
 aliases = ["CVE-2021-28305"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2021-03-05"
 url = "https://github.com/diesel-rs/diesel/pull/2663"
 categories = ["memory-corruption"]

--- a/crates/disrustor/RUSTSEC-2020-0150.md
+++ b/crates/disrustor/RUSTSEC-2020-0150.md
@@ -6,6 +6,7 @@ date = "2020-12-17"
 url = "https://github.com/sklose/disrustor/issues/1"
 categories = ["memory-corruption", "thread-safety"]
 aliases = ["CVE-2020-36470"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
 
 [versions]
 patched = []

--- a/crates/dync/RUSTSEC-2020-0050.md
+++ b/crates/dync/RUSTSEC-2020-0050.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0050"
 package = "dync"
 aliases = ["CVE-2020-35903"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-09-27"
 informational = "unsound"
 url = "https://github.com/elrnv/dync/issues/4"

--- a/crates/endian_trait/RUSTSEC-2021-0039.md
+++ b/crates/endian_trait/RUSTSEC-2021-0039.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0039"
 package = "endian_trait"
 aliases = ["CVE-2021-29929"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2021-01-04"
 url = "https://gitlab.com/myrrlyn/endian_trait/-/issues/1"
 categories = ["memory-corruption"]

--- a/crates/eventio/RUSTSEC-2020-0108.md
+++ b/crates/eventio/RUSTSEC-2020-0108.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0108"
 package = "eventio"
 aliases = ["CVE-2020-36216"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-12-20"
 url = "https://github.com/petabi/eventio/issues/33"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/failure/RUSTSEC-2019-0036.md
+++ b/crates/failure/RUSTSEC-2019-0036.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0036"
 package = "failure"
 aliases = ["CVE-2020-25575", "CVE-2019-25010"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2019-11-13"
 informational = "unsound"
 keywords = ["unsound"]

--- a/crates/failure/RUSTSEC-2020-0036.md
+++ b/crates/failure/RUSTSEC-2020-0036.md
@@ -6,6 +6,7 @@ date = "2020-05-02"
 informational = "unmaintained"
 url = "https://github.com/rust-lang-nursery/failure/pull/347"
 aliases = ["CVE-2020-25575"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = []

--- a/crates/fil-ocl/RUSTSEC-2021-0011.md
+++ b/crates/fil-ocl/RUSTSEC-2021-0011.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0011"
 package = "fil-ocl"
 aliases = ["CVE-2021-25908"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2021-01-04"
 url = "https://github.com/cogciprocate/ocl/issues/194"
 categories = ["memory-corruption"]

--- a/crates/flatbuffers/RUSTSEC-2019-0028.md
+++ b/crates/flatbuffers/RUSTSEC-2019-0028.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0028"
 package = "flatbuffers"
 aliases = ["CVE-2019-25004"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2019-10-20"
 url = "https://github.com/google/flatbuffers/issues/5530"
 

--- a/crates/flatbuffers/RUSTSEC-2020-0009.md
+++ b/crates/flatbuffers/RUSTSEC-2020-0009.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0009"
 package = "flatbuffers"
 aliases = ["CVE-2020-35864"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-04-11"
 url = "https://github.com/google/flatbuffers/issues/5825"
 

--- a/crates/futures-intrusive/RUSTSEC-2020-0072.md
+++ b/crates/futures-intrusive/RUSTSEC-2020-0072.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0072"
 package = "futures-intrusive"
 aliases = ["CVE-2020-35915"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-10-31"
 url = "https://github.com/Matthias247/futures-intrusive/issues/53"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/futures-task/RUSTSEC-2020-0060.md
+++ b/crates/futures-task/RUSTSEC-2020-0060.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0060"
 package = "futures-task"
 aliases = ["CVE-2020-35906"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H"
 date = "2020-09-04"
 url = "https://github.com/rust-lang/futures-rs/pull/2206"
 categories = ["code-execution", "memory-corruption"]

--- a/crates/futures-task/RUSTSEC-2020-0061.md
+++ b/crates/futures-task/RUSTSEC-2020-0061.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0061"
 package = "futures-task"
 aliases = ["CVE-2020-35907"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-05-03"
 url = "https://github.com/rust-lang/futures-rs/issues/2091"
 categories = ["denial-of-service"]

--- a/crates/futures-util/RUSTSEC-2020-0059.md
+++ b/crates/futures-util/RUSTSEC-2020-0059.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0059"
 package = "futures-util"
 aliases = ["CVE-2020-35905"]
+cvss = "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-10-22"
 url = "https://github.com/rust-lang/futures-rs/issues/2239"
 categories = ["thread-safety"]

--- a/crates/futures-util/RUSTSEC-2020-0062.md
+++ b/crates/futures-util/RUSTSEC-2020-0062.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0062"
 package = "futures-util"
 aliases = ["CVE-2020-35908"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-01-24"
 url = "https://github.com/rust-lang/futures-rs/issues/2050"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/generator/RUSTSEC-2019-0020.md
+++ b/crates/generator/RUSTSEC-2019-0020.md
@@ -6,6 +6,7 @@ date = "2019-09-06"
 keywords = ["memory-corruption"]
 url = "https://github.com/Xudong-Huang/generator-rs/issues/9"
 aliases = ["CVE-2019-16144"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 
 [versions]
 patched = [">= 0.6.18"]

--- a/crates/generator/RUSTSEC-2020-0151.md
+++ b/crates/generator/RUSTSEC-2020-0151.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0151"
 package = "generator"
 aliases = ["CVE-2020-36471"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-11-16"
 url = "https://github.com/Xudong-Huang/generator-rs/issues/27"
 categories = ["memory-corruption"]

--- a/crates/generic-array/RUSTSEC-2020-0146.md
+++ b/crates/generic-array/RUSTSEC-2020-0146.md
@@ -7,6 +7,7 @@ url = "https://github.com/fizyk20/generic-array/issues/98"
 categories = ["memory-corruption"]
 keywords = ["soundness"]
 aliases = ["CVE-2020-36465"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 
 [versions]
 patched = [

--- a/crates/gfwx/RUSTSEC-2020-0104.md
+++ b/crates/gfwx/RUSTSEC-2020-0104.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0104"
 package = "gfwx"
 aliases = ["CVE-2020-36211"]
+cvss = "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H"
 date = "2020-12-08"
 url = "https://github.com/Devolutions/gfwx-rs/issues/7"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/glsl-layout/RUSTSEC-2021-0005.md
+++ b/crates/glsl-layout/RUSTSEC-2021-0005.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0005"
 package = "glsl-layout"
 aliases = ["CVE-2021-25902"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2021-01-10"
 url = "https://github.com/rustgd/glsl-layout/pull/10"
 categories = ["memory-corruption"]

--- a/crates/grep-cli/RUSTSEC-2021-0071.md
+++ b/crates/grep-cli/RUSTSEC-2021-0071.md
@@ -7,6 +7,7 @@ url = "https://github.com/BurntSushi/ripgrep/issues/1773"
 categories = ["code-execution"]
 keywords = ["windows", "ripgrep", "PATH", "arbitrary", "binary"]
 aliases = ["CVE-2021-3013"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = [">= 0.1.6"]

--- a/crates/hashconsing/RUSTSEC-2020-0107.md
+++ b/crates/hashconsing/RUSTSEC-2020-0107.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0107"
 package = "hashconsing"
 aliases = ["CVE-2020-36215"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-11-10"
 url = "https://github.com/AdrienChampion/hashconsing/issues/1"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/heapless/RUSTSEC-2020-0145.md
+++ b/crates/heapless/RUSTSEC-2020-0145.md
@@ -8,6 +8,7 @@ categories = ["memory-corruption", "memory-exposure"]
 keywords = ["use-after-free"]
 informational = "unsound"
 aliases = ["CVE-2020-36464"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 
 [affected.functions]
 "heapless::vec::IntoIter::clone" = ["<= 0.6"]

--- a/crates/http/RUSTSEC-2019-0033.md
+++ b/crates/http/RUSTSEC-2019-0033.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0033"
 package = "http"
 aliases = ["CVE-2020-25574", "CVE-2019-25008"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 categories = ["denial-of-service"]
 date = "2019-11-16"
 keywords = ["http", "integer-overflow", "DoS"]

--- a/crates/http/RUSTSEC-2019-0034.md
+++ b/crates/http/RUSTSEC-2019-0034.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0034"
 package = "http"
 aliases = ["CVE-2019-25009"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 categories = ["memory-corruption"]
 date = "2019-11-16"
 keywords = ["memory-safety", "double-free", "unsound"]

--- a/crates/hyper/RUSTSEC-2016-0002.md
+++ b/crates/hyper/RUSTSEC-2016-0002.md
@@ -4,6 +4,7 @@ id = "RUSTSEC-2016-0002"
 package = "hyper"
 date = "2016-05-09"
 aliases = ["CVE-2016-10932"]
+cvss = "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N"
 related = ["RUSTSEC-2016-0001"]
 categories = ["crypto-failure"]
 keywords = ["ssl", "mitm"]

--- a/crates/hyper/RUSTSEC-2017-0002.md
+++ b/crates/hyper/RUSTSEC-2017-0002.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2017-0002"
 package = "hyper"
 aliases = ["CVE-2017-18587"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N"
 date = "2017-01-23"
 url = "https://github.com/hyperium/hyper/wiki/Security-001"
 

--- a/crates/hyper/RUSTSEC-2020-0008.md
+++ b/crates/hyper/RUSTSEC-2020-0008.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0008"
 package = "hyper"
 aliases = ["CVE-2020-35863"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 categories = ["format-injection"]
 date = "2020-03-19"
 keywords = ["http", "request-smuggling"]

--- a/crates/hyper/RUSTSEC-2021-0020.md
+++ b/crates/hyper/RUSTSEC-2021-0020.md
@@ -7,6 +7,7 @@ url = "https://github.com/hyperium/hyper/security/advisories/GHSA-6hfq-h8hq-87mf
 categories = ["format-injection"]
 keywords = ["http", "request-smuggling"]
 aliases = ["CVE-2021-21299", "GHSA-6hfq-h8hq-87mf"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = [">= 0.14.3", "0.13.10", "0.12.36"]

--- a/crates/hyper/RUSTSEC-2021-0078.md
+++ b/crates/hyper/RUSTSEC-2021-0078.md
@@ -6,6 +6,7 @@ date = "2021-07-07"
 url = "https://github.com/hyperium/hyper/security/advisories/GHSA-f3pg-qwvg-p99c"
 keywords = ["parsing", "http"]
 aliases = ["CVE-2021-32715", "GHSA-f3pg-qwvg-p99c"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N"
 
 [versions]
 patched = [">= 0.14.10"]

--- a/crates/hyper/RUSTSEC-2021-0079.md
+++ b/crates/hyper/RUSTSEC-2021-0079.md
@@ -6,6 +6,7 @@ date = "2021-07-07"
 url = "https://github.com/hyperium/hyper/security/advisories/GHSA-5h46-h7hh-c6x9"
 keywords = ["http", "parsing", "data loss"]
 aliases = ["CVE-2021-32714", "GHSA-5h46-h7hh-c6x9"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H"
 
 [versions]
 patched = [">= 0.14.10"]

--- a/crates/im/RUSTSEC-2020-0096.md
+++ b/crates/im/RUSTSEC-2020-0096.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0096"
 package = "im"
 aliases = ["CVE-2020-36204"]
+cvss = "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-11-09"
 url = "https://github.com/bodil/im-rs/issues/157"
 categories = ["thread-safety"]

--- a/crates/image/RUSTSEC-2019-0014.md
+++ b/crates/image/RUSTSEC-2019-0014.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0014"
 package = "image"
 aliases = ["CVE-2019-16138"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2019-08-21"
 keywords = ["drop", "use-after-free"]
 url = "https://github.com/image-rs/image/pull/985"

--- a/crates/image/RUSTSEC-2020-0073.md
+++ b/crates/image/RUSTSEC-2020-0073.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0073"
 package = "image"
 aliases = ["CVE-2020-35916"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-11-12"
 url = "https://github.com/image-rs/image/issues/1357"
 informational = "unsound"

--- a/crates/insert_many/RUSTSEC-2021-0042.md
+++ b/crates/insert_many/RUSTSEC-2021-0042.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0042"
 package = "insert_many"
 aliases = ["CVE-2021-29933"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2021-01-26"
 url = "https://github.com/rphmeier/insert_many/issues/1"
 categories = ["memory-corruption"]

--- a/crates/internment/RUSTSEC-2020-0017.md
+++ b/crates/internment/RUSTSEC-2020-0017.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0017"
 package = "internment"
 aliases = ["CVE-2020-35874"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 categories = ["memory-corruption"]
 date = "2020-05-28"
 url = "https://github.com/droundy/internment/issues/11"

--- a/crates/internment/RUSTSEC-2021-0036.md
+++ b/crates/internment/RUSTSEC-2021-0036.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0036"
 package = "internment"
 aliases = ["CVE-2021-28037"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2021-03-03"
 url = "https://github.com/droundy/internment/issues/20"
 categories = ["thread-safety"]

--- a/crates/kekbit/RUSTSEC-2020-0129.md
+++ b/crates/kekbit/RUSTSEC-2020-0129.md
@@ -6,6 +6,7 @@ date = "2020-12-18"
 url = "https://github.com/motoras/kekbit/issues/34"
 categories = ["memory-corruption", "thread-safety"]
 aliases = ["CVE-2020-36449"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = [">= 0.3.4"]

--- a/crates/late-static/RUSTSEC-2020-0102.md
+++ b/crates/late-static/RUSTSEC-2020-0102.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0102"
 package = "late-static"
 aliases = ["CVE-2020-36209"]
+cvss = "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H"
 date = "2020-11-10"
 url = "https://github.com/Richard-W/late-static/issues/1"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/lazy-init/RUSTSEC-2021-0004.md
+++ b/crates/lazy-init/RUSTSEC-2021-0004.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0004"
 package = "lazy-init"
 aliases = ["CVE-2021-25901"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
 date = "2021-01-17"
 categories = ["memory-corruption"]
 url = "https://github.com/khuey/lazy-init/issues/9"

--- a/crates/lettre/RUSTSEC-2020-0069.md
+++ b/crates/lettre/RUSTSEC-2020-0069.md
@@ -7,6 +7,7 @@ url = "https://github.com/lettre/lettre/pull/508/commits/bbe7cc5381c5380b54fb8bb
 categories = ["code-execution", "file-disclosure"]
 keywords = ["email", "sendmail"]
 aliases = ["CVE-2020-28247"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N"
 
 [versions]
 patched = [">= 0.10.0-alpha.4", "< 0.10.0-alpha.1, >= 0.9.5", "< 0.9.0, >= 0.8.4", "< 0.8.0, >= 0.7.1"]

--- a/crates/lever/RUSTSEC-2020-0137.md
+++ b/crates/lever/RUSTSEC-2020-0137.md
@@ -7,6 +7,7 @@ url = "https://github.com/vertexclique/lever/issues/15"
 categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
 aliases = ["CVE-2020-36457"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = [">= 0.1.1"]

--- a/crates/lexer/RUSTSEC-2020-0138.md
+++ b/crates/lexer/RUSTSEC-2020-0138.md
@@ -6,6 +6,7 @@ date = "2020-11-10"
 url = "https://gitlab.com/nathanfaucett/rs-lexer/-/issues/2"
 categories = ["memory-corruption", "thread-safety"]
 aliases = ["CVE-2020-36458"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = []

--- a/crates/libflate/RUSTSEC-2019-0010.md
+++ b/crates/libflate/RUSTSEC-2019-0010.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0010"
 package = "libflate"
 aliases = ["CVE-2019-15552"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2019-07-04"
 keywords = ["drop", "use-after-free"]
 url = "https://github.com/sile/libflate/issues/35"

--- a/crates/libp2p-core/RUSTSEC-2019-0004.md
+++ b/crates/libp2p-core/RUSTSEC-2019-0004.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0004"
 package = "libp2p-core"
 aliases = ["CVE-2019-15545"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
 date = "2019-05-15"
 
 [versions]

--- a/crates/libp2p-deflate/RUSTSEC-2020-0123.md
+++ b/crates/libp2p-deflate/RUSTSEC-2020-0123.md
@@ -6,6 +6,7 @@ date = "2020-01-24"
 url = "https://github.com/libp2p/rust-libp2p/issues/1932"
 categories = ["memory-exposure"]
 aliases = ["CVE-2020-36443"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = [">= 0.27.1"]

--- a/crates/libpulse-binding/RUSTSEC-2018-0020.md
+++ b/crates/libpulse-binding/RUSTSEC-2018-0020.md
@@ -6,6 +6,7 @@ date = "2018-12-22"
 url = "https://github.com/advisories/GHSA-6gvc-4jvj-pwq4"
 categories = ["memory-corruption"]
 aliases = ["GHSA-6gvc-4jvj-pwq4", "CVE-2018-25001"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N"
 
 [versions]
 patched = [">= 2.5.0"]

--- a/crates/libsbc/RUSTSEC-2020-0120.md
+++ b/crates/libsbc/RUSTSEC-2020-0120.md
@@ -7,6 +7,7 @@ url = "https://github.com/mvertescher/libsbc-rs/issues/4"
 categories = ["memory-corruption", "thread-safety"]
 informational = "unsound"
 aliases = ["CVE-2020-36440"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = [">= 0.1.5"]

--- a/crates/libsecp256k1/RUSTSEC-2019-0027.md
+++ b/crates/libsecp256k1/RUSTSEC-2019-0027.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0027"
 package = "libsecp256k1"
 aliases = ["CVE-2019-25003"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
 categories = ["crypto-failure"]
 date = "2019-10-14"
 keywords = ["crypto", "sidechannel"]

--- a/crates/linea/RUSTSEC-2019-0021.md
+++ b/crates/linea/RUSTSEC-2019-0021.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0021"
 package = "linea"
 aliases = ["CVE-2019-16880"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 categories = ["memory-corruption"]
 date = "2019-09-14"
 keywords = ["double free"]

--- a/crates/linked-hash-map/RUSTSEC-2020-0026.md
+++ b/crates/linked-hash-map/RUSTSEC-2020-0026.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0026"
 package = "linked-hash-map"
 aliases = ["CVE-2020-25573"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2020-06-23"
 informational = "unsound"
 url = "https://github.com/contain-rs/linked-hash-map/pull/100"

--- a/crates/lucet-runtime-internals/RUSTSEC-2020-0004.md
+++ b/crates/lucet-runtime-internals/RUSTSEC-2020-0004.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0004"
 package = "lucet-runtime-internals"
 aliases = ["CVE-2020-35859"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:H"
 categories = ["memory-corruption", "memory-exposure"]
 date = "2020-01-24"
 url = "https://github.com/bytecodealliance/lucet/pull/401"

--- a/crates/magnetic/RUSTSEC-2020-0088.md
+++ b/crates/magnetic/RUSTSEC-2020-0088.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0088"
 package = "magnetic"
 aliases = ["CVE-2020-35925"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-11-29"
 url = "https://github.com/johnshaw/magnetic/issues/9"
 categories = ["thread-safety"]

--- a/crates/marc/RUSTSEC-2021-0014.md
+++ b/crates/marc/RUSTSEC-2021-0014.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0014"
 package = "marc"
 aliases = ["CVE-2021-26308"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
 date = "2021-01-26"
 url = "https://github.com/blackbeam/rust-marc/issues/7"
 categories = ["memory-exposure"]

--- a/crates/max7301/RUSTSEC-2020-0152.md
+++ b/crates/max7301/RUSTSEC-2020-0152.md
@@ -7,6 +7,7 @@ url = "https://github.com/edarc/max7301/issues/1"
 categories = ["memory-corruption"]
 keywords = ["concurrency"]
 aliases = ["CVE-2020-36472"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
 
 [versions]
 patched = [">= 0.2.0"]

--- a/crates/may_queue/RUSTSEC-2020-0111.md
+++ b/crates/may_queue/RUSTSEC-2020-0111.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0111"
 package = "may_queue"
 aliases = ["CVE-2020-36217"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-11-10"
 url = "https://github.com/Xudong-Huang/may/issues/88"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/mdbook/RUSTSEC-2021-0001.md
+++ b/crates/mdbook/RUSTSEC-2021-0001.md
@@ -7,6 +7,7 @@ url = "https://groups.google.com/g/rustlang-security-announcements/c/3-sO6of29O0
 categories = ["code-execution"]
 keywords = ["xss"]
 aliases = ["CVE-2020-26297"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N"
 
 [versions]
 patched = [">= 0.4.5"]

--- a/crates/memoffset/RUSTSEC-2019-0011.md
+++ b/crates/memoffset/RUSTSEC-2019-0011.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0011"
 package = "memoffset"
 aliases = ["CVE-2019-15553"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
 date = "2019-07-16"
 informational = "unsound"
 url = "https://github.com/Gilnaa/memoffset/issues/9#issuecomment-505461490"

--- a/crates/mio/RUSTSEC-2020-0081.md
+++ b/crates/mio/RUSTSEC-2020-0081.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0081"
 package = "mio"
 aliases = ["CVE-2020-35922"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-11-02"
 url = "https://github.com/tokio-rs/mio/issues/1386"
 keywords = ["memory", "layout", "cast"]

--- a/crates/miow/RUSTSEC-2020-0080.md
+++ b/crates/miow/RUSTSEC-2020-0080.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0080"
 package = "miow"
 aliases = ["CVE-2020-35921"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-11-13"
 url = "https://github.com/yoshuawuyts/miow/issues/38"
 keywords = ["memory", "layout", "cast"]

--- a/crates/model/RUSTSEC-2020-0140.md
+++ b/crates/model/RUSTSEC-2020-0140.md
@@ -7,6 +7,7 @@ url = "https://github.com/spacejam/model/issues/3"
 categories = ["thread-safety"]
 informational = "unsound"
 aliases = ["CVE-2020-36460"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = []

--- a/crates/mozwire/RUSTSEC-2020-0030.md
+++ b/crates/mozwire/RUSTSEC-2020-0030.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0030"
 package = "mozwire"
 aliases = ["CVE-2020-35883"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:H"
 categories = []
 date = "2020-08-18"
 keywords = ["file-overwrite"]

--- a/crates/ms3d/RUSTSEC-2021-0016.md
+++ b/crates/ms3d/RUSTSEC-2021-0016.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0016"
 package = "ms3d"
 aliases = ["CVE-2021-26952"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
 date = "2021-01-26"
 url = "https://github.com/andrewhickman/ms3d/issues/1"
 categories = ["memory-exposure"]

--- a/crates/multihash/RUSTSEC-2020-0068.md
+++ b/crates/multihash/RUSTSEC-2020-0068.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0068"
 package = "multihash"
 aliases = ["CVE-2020-35909"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-11-08"
 url = "https://github.com/multiformats/rust-multihash/pull/72"
 categories = ["denial-of-service"]

--- a/crates/multiqueue/RUSTSEC-2020-0143.md
+++ b/crates/multiqueue/RUSTSEC-2020-0143.md
@@ -6,6 +6,7 @@ date = "2020-12-25"
 url = "https://github.com/schets/multiqueue/issues/31"
 categories = ["memory-corruption", "thread-safety"]
 aliases = ["CVE-2020-36463"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = []

--- a/crates/multiqueue2/RUSTSEC-2020-0106.md
+++ b/crates/multiqueue2/RUSTSEC-2020-0106.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0106"
 package = "multiqueue2"
 aliases = ["CVE-2020-36214"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-12-19"
 url = "https://github.com/abbychau/multiqueue2/issues/10"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/nano_arena/RUSTSEC-2021-0031.md
+++ b/crates/nano_arena/RUSTSEC-2021-0031.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0031"
 package = "nano_arena"
 aliases = ["CVE-2021-28032"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2021-01-31"
 url = "https://github.com/bennetthardwick/nano-arena/issues/1"
 categories = ["memory-corruption"]

--- a/crates/nb-connect/RUSTSEC-2021-0021.md
+++ b/crates/nb-connect/RUSTSEC-2021-0021.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0021"
 package = "nb-connect"
 aliases = ["CVE-2021-27376"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2021-02-14"
 url = "https://github.com/smol-rs/nb-connect/issues/1"
 keywords = ["memory", "layout", "cast"]

--- a/crates/net2/RUSTSEC-2020-0078.md
+++ b/crates/net2/RUSTSEC-2020-0078.md
@@ -7,6 +7,7 @@ url = "https://github.com/deprecrated/net2-rs/issues/105"
 keywords = ["memory", "layout", "cast"]
 informational = "unsound"
 aliases = ["CVE-2020-35919"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 
 [versions]
 patched = [">= 0.2.36"]

--- a/crates/noise_search/RUSTSEC-2020-0141.md
+++ b/crates/noise_search/RUSTSEC-2020-0141.md
@@ -6,6 +6,7 @@ date = "2020-12-10"
 url = "https://github.com/pipedown/noise/issues/72"
 categories = ["memory-corruption", "thread-safety"]
 aliases = ["CVE-2020-36461"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = []

--- a/crates/obstack/RUSTSEC-2020-0040.md
+++ b/crates/obstack/RUSTSEC-2020-0040.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0040"
 package = "obstack"
 aliases = ["CVE-2020-35894"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
 date = "2020-09-03"
 informational = "unsound"
 url = "https://github.com/petertodd/rust-obstack/issues/4"

--- a/crates/once_cell/RUSTSEC-2019-0017.md
+++ b/crates/once_cell/RUSTSEC-2019-0017.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0017"
 package = "once_cell"
 aliases = ["CVE-2019-16141"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2019-09-01"
 keywords = ["undefined_behavior"]
 url = "https://github.com/matklad/once_cell/issues/46"

--- a/crates/openssl-src/RUSTSEC-2020-0015.md
+++ b/crates/openssl-src/RUSTSEC-2020-0015.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0015"
 package = "openssl-src"
 aliases = ["CVE-2020-1967"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 categories = ["denial-of-service"]
 date = "2020-04-25"
 url = "https://www.openssl.org/news/secadv/20200421.txt"

--- a/crates/openssl-src/RUSTSEC-2021-0055.md
+++ b/crates/openssl-src/RUSTSEC-2021-0055.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0055"
 package = "openssl-src"
 aliases = ["CVE-2021-3449"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
 categories = ["denial-of-service"]
 date = "2021-05-01"
 url = "https://www.openssl.org/news/secadv/20210325.txt"

--- a/crates/openssl-src/RUSTSEC-2021-0056.md
+++ b/crates/openssl-src/RUSTSEC-2021-0056.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0056"
 package = "openssl-src"
 aliases = ["CVE-2021-3450"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N"
 categories = ["crypto-failure"]
 date = "2021-05-01"
 url = "https://www.openssl.org/news/secadv/20210325.txt"

--- a/crates/openssl-src/RUSTSEC-2021-0057.md
+++ b/crates/openssl-src/RUSTSEC-2021-0057.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0057"
 package = "openssl-src"
 aliases = ["CVE-2021-23840"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 categories = ["denial-of-service"]
 date = "2021-05-01"
 url = "https://www.openssl.org/news/secadv/20210216.txt"

--- a/crates/openssl-src/RUSTSEC-2021-0058.md
+++ b/crates/openssl-src/RUSTSEC-2021-0058.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0058"
 package = "openssl-src"
 aliases = ["CVE-2021-23841"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
 categories = ["denial-of-service"]
 date = "2021-05-01"
 url = "https://www.openssl.org/news/secadv/20210216.txt"

--- a/crates/openssl-src/RUSTSEC-2021-0097.md
+++ b/crates/openssl-src/RUSTSEC-2021-0097.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0097"
 package = "openssl-src"
 aliases = ["CVE-2021-3711"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 categories = ["crypto-failure"]
 date = "2021-08-24"
 url = "https://www.openssl.org/news/secadv/20210824.txt"

--- a/crates/openssl-src/RUSTSEC-2021-0098.md
+++ b/crates/openssl-src/RUSTSEC-2021-0098.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0098"
 package = "openssl-src"
 aliases = ["CVE-2021-3712"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:H"
 categories = ["denial-of-service", "crypto-failure"]
 date = "2021-08-24"
 url = "https://www.openssl.org/news/secadv/20210824.txt"

--- a/crates/openssl/RUSTSEC-2016-0001.md
+++ b/crates/openssl/RUSTSEC-2016-0001.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2016-0001"
 package = "openssl"
 aliases = ["CVE-2016-10931"]
+cvss = "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2016-11-05"
 keywords = ["ssl", "mitm"]
 url = "https://github.com/sfackler/rust-openssl/releases/tag/v0.9.0"

--- a/crates/openssl/RUSTSEC-2018-0010.md
+++ b/crates/openssl/RUSTSEC-2018-0010.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2018-0010"
 package = "openssl"
 aliases = ["CVE-2018-20997"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2018-06-01"
 keywords = ["memory-corruption"]
 url = "https://github.com/sfackler/rust-openssl/pull/942"

--- a/crates/ordered-float/RUSTSEC-2020-0082.md
+++ b/crates/ordered-float/RUSTSEC-2020-0082.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0082"
 package = "ordered-float"
 aliases = ["CVE-2020-35923"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-12-06"
 url = "https://github.com/reem/rust-ordered-float/pull/71"
 categories = []

--- a/crates/ordnung/RUSTSEC-2020-0038.md
+++ b/crates/ordnung/RUSTSEC-2020-0038.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0038"
 package = "ordnung"
 aliases = ["CVE-2020-35890", "CVE-2020-35891"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-09-03"
 url = "https://github.com/maciejhirsz/ordnung/issues/8"
 

--- a/crates/orion/RUSTSEC-2018-0012.md
+++ b/crates/orion/RUSTSEC-2018-0012.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2018-0012"
 package = "orion"
 aliases = ["CVE-2018-20999"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2018-12-20"
 url = "https://github.com/brycx/orion/issues/46"
 

--- a/crates/os_str_bytes/RUSTSEC-2020-0012.md
+++ b/crates/os_str_bytes/RUSTSEC-2020-0012.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0012"
 package = "os_str_bytes"
 aliases = ["CVE-2020-35865"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-04-24"
 url = "https://github.com/dylni/os_str_bytes/pull/1"
 

--- a/crates/outer_cgi/RUSTSEC-2021-0051.md
+++ b/crates/outer_cgi/RUSTSEC-2021-0051.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0051"
 package = "outer_cgi"
 aliases = ["CVE-2021-30454"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2021-01-31"
 url = "https://github.com/SolraBizna/outer_cgi/issues/1"
 categories = ["memory-exposure"]

--- a/crates/ozone/RUSTSEC-2020-0022.md
+++ b/crates/ozone/RUSTSEC-2020-0022.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0022"
 package = "ozone"
 aliases = ["CVE-2020-35877", "CVE-2020-35878"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2020-07-04"
 
 [versions]

--- a/crates/pancurses/RUSTSEC-2019-0005.md
+++ b/crates/pancurses/RUSTSEC-2019-0005.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0005"
 package = "pancurses"
 aliases = ["CVE-2019-15546"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
 date = "2019-06-15"
 url = "https://github.com/RustSec/advisory-db/issues/106"
 

--- a/crates/parc/RUSTSEC-2020-0134.md
+++ b/crates/parc/RUSTSEC-2020-0134.md
@@ -6,6 +6,7 @@ date = "2020-11-14"
 url = "https://github.com/hyyking/rustracts/pull/6"
 categories = ["memory-corruption", "thread-safety"]
 aliases = ["CVE-2020-36454"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = []

--- a/crates/parse_duration/RUSTSEC-2021-0041.md
+++ b/crates/parse_duration/RUSTSEC-2021-0041.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0041"
 aliases = ["CAN-2021-1000007", "CVE-2021-29932"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 package = "parse_duration"
 date = "2021-03-18"
 url = "https://github.com/zeta12ti/parse_duration/issues/21"

--- a/crates/portaudio-rs/RUSTSEC-2019-0022.md
+++ b/crates/portaudio-rs/RUSTSEC-2019-0022.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0022"
 package = "portaudio-rs"
 aliases = ["CVE-2019-16881"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 categories = ["code-execution", "memory-corruption"]
 date = "2019-09-14"
 keywords = ["audio", "ffi"]

--- a/crates/portaudio/RUSTSEC-2016-0003.md
+++ b/crates/portaudio/RUSTSEC-2016-0003.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2016-0003"
 package = "portaudio"
 aliases = ["CVE-2016-10933"]
+cvss = "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
 date = "2016-08-01"
 keywords = ["ssl", "mitm"]
 url = "https://github.com/RustAudio/rust-portaudio/issues/144"

--- a/crates/postscript/RUSTSEC-2021-0017.md
+++ b/crates/postscript/RUSTSEC-2021-0017.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0017"
 package = "postscript"
 aliases = ["CVE-2021-26953"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
 date = "2021-01-30"
 url = "https://github.com/bodoni/postscript/issues/1"
 categories = ["memory-exposure"]

--- a/crates/prost/RUSTSEC-2020-0002.md
+++ b/crates/prost/RUSTSEC-2020-0002.md
@@ -5,6 +5,7 @@ date = "2020-01-16"
 id = "RUSTSEC-2020-0002"
 package = "prost"
 aliases = ["CVE-2020-35858"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 keywords = ["stack overflow"]
 url = "https://github.com/danburkert/prost/issues/267"
 

--- a/crates/protobuf/RUSTSEC-2019-0003.md
+++ b/crates/protobuf/RUSTSEC-2019-0003.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0003"
 package = "protobuf"
 aliases = ["CVE-2019-15544"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 categories = ["denial-of-service"]
 date = "2019-06-08"
 keywords = ["oom", "panic"]

--- a/crates/pyo3/RUSTSEC-2020-0074.md
+++ b/crates/pyo3/RUSTSEC-2020-0074.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0074"
 package = "pyo3"
 aliases = ["CVE-2020-35917"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-11-28"
 url = "https://github.com/PyO3/pyo3/pull/1297"
 keywords = ["memory-corruption"]

--- a/crates/quinn/RUSTSEC-2021-0035.md
+++ b/crates/quinn/RUSTSEC-2021-0035.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0035"
 package = "quinn"
 aliases = ["CVE-2021-28036"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
 date = "2021-03-04"
 url = "https://github.com/quinn-rs/quinn/issues/968"
 keywords = ["memory", "layout", "cast"]

--- a/crates/qwutils/RUSTSEC-2021-0018.md
+++ b/crates/qwutils/RUSTSEC-2021-0018.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0018"
 package = "qwutils"
 aliases = ["CVE-2021-26954"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
 date = "2021-02-03"
 url = "https://github.com/qwertz19281/rust_utils/issues/3"
 categories = ["memory-corruption"]

--- a/crates/rand_core/RUSTSEC-2019-0035.md
+++ b/crates/rand_core/RUSTSEC-2019-0035.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0035"
 package = "rand_core"
 aliases = ["GHSA-mmc9-pwm7-qj5w", "CVE-2020-25576"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2019-04-19"
 informational = "unsound"
 url = "https://github.com/rust-random/rand/blob/master/rand_core/CHANGELOG.md#050---2019-06-06"

--- a/crates/rand_core/RUSTSEC-2021-0023.md
+++ b/crates/rand_core/RUSTSEC-2021-0023.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0023"
 package = "rand_core"
 aliases = ["CVE-2021-27378"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2021-02-12"
 url = "https://github.com/rust-random/rand/pull/1096"
 categories = ["crypto-failure"]

--- a/crates/rcu_cell/RUSTSEC-2020-0131.md
+++ b/crates/rcu_cell/RUSTSEC-2020-0131.md
@@ -6,6 +6,7 @@ date = "2020-11-14"
 url = "https://github.com/Xudong-Huang/rcu_cell/issues/3"
 categories = ["memory-corruption", "thread-safety"]
 aliases = ["CVE-2020-36451"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = []

--- a/crates/reffers/RUSTSEC-2020-0094.md
+++ b/crates/reffers/RUSTSEC-2020-0094.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0094"
 package = "reffers"
 aliases = ["CVE-2020-36203"]
+cvss = "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-12-01"
 url = "https://github.com/diwic/reffers-rs/issues/7"
 informational = "unsound"

--- a/crates/renderdoc/RUSTSEC-2019-0018.md
+++ b/crates/renderdoc/RUSTSEC-2019-0018.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0018"
 package = "renderdoc"
 aliases = ["CVE-2019-16142"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2019-09-02"
 keywords = ["undefined_behavior"]
 url = "https://github.com/ebkalderon/renderdoc-rs/pull/32"

--- a/crates/reorder/RUSTSEC-2021-0050.md
+++ b/crates/reorder/RUSTSEC-2021-0050.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0050"
 package = "reorder"
 aliases = ["CVE-2021-29941", "CVE-2021-29942"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L"
 date = "2021-02-24"
 url = "https://github.com/tiby312/reorder/issues/1"
 keywords = ["memory-corruption", "out-of-bounds"]

--- a/crates/rgb/RUSTSEC-2020-0029.md
+++ b/crates/rgb/RUSTSEC-2020-0029.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0029"
 package = "rgb"
 aliases = ["CVE-2020-25016"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"
 date = "2020-06-14"
 informational = "unsound"
 keywords = ["type confusion"]

--- a/crates/rio/RUSTSEC-2020-0021.md
+++ b/crates/rio/RUSTSEC-2020-0021.md
@@ -5,6 +5,7 @@ date = "2020-05-11"
 id = "RUSTSEC-2020-0021"
 package = "rio"
 aliases = ["CVE-2020-35876"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 url = "https://github.com/spacejam/rio/issues/11"
 
 [versions]

--- a/crates/rkyv/RUSTSEC-2021-0054.md
+++ b/crates/rkyv/RUSTSEC-2021-0054.md
@@ -7,6 +7,7 @@ url = "https://github.com/djkoloski/rkyv/issues/113"
 categories = ["memory-exposure"]
 keywords = ["uninitialized", "memory", "information", "leak"]
 aliases = ["CVE-2021-31919"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
 
 [versions]
 patched = [">= 0.6.0"]

--- a/crates/rocket/RUSTSEC-2020-0028.md
+++ b/crates/rocket/RUSTSEC-2020-0028.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0028"
 package = "rocket"
 aliases = ["CVE-2020-35882"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2020-05-27"
 informational = "unsound"
 url = "https://github.com/SergioBenitez/Rocket/issues/1312"

--- a/crates/rocket/RUSTSEC-2021-0044.md
+++ b/crates/rocket/RUSTSEC-2021-0044.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0044"
 package = "rocket"
 aliases = ["CVE-2021-29935"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L"
 date = "2021-02-09"
 url = "https://github.com/SergioBenitez/Rocket/issues/1534"
 informational = "unsound"

--- a/crates/rulinalg/RUSTSEC-2020-0023.md
+++ b/crates/rulinalg/RUSTSEC-2020-0023.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0023"
 package = "rulinalg"
 aliases = ["CVE-2020-35879"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2020-02-11"
 url = "https://github.com/AtheMathmo/rulinalg/issues/201"
 

--- a/crates/rusb/RUSTSEC-2020-0098.md
+++ b/crates/rusb/RUSTSEC-2020-0098.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0098"
 package = "rusb"
 aliases = ["CVE-2020-36206"]
+cvss = "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H"
 date = "2020-12-18"
 url = "https://github.com/a1ien/rusb/issues/44"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/ruspiro-singleton/RUSTSEC-2020-0115.md
+++ b/crates/ruspiro-singleton/RUSTSEC-2020-0115.md
@@ -7,6 +7,7 @@ url = "https://github.com/RusPiRo/ruspiro-singleton/issues/10"
 categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
 aliases = ["CVE-2020-36435"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = [">= 0.4.1"]

--- a/crates/safe-transmute/RUSTSEC-2018-0013.md
+++ b/crates/safe-transmute/RUSTSEC-2018-0013.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2018-0013"
 package = "safe-transmute"
 aliases = ["CVE-2018-21000"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2018-11-27"
 keywords = ["memory-corruption"]
 url = "https://github.com/nabijaczleweli/safe-transmute-rs/pull/36"

--- a/crates/scottqueue/RUSTSEC-2020-0133.md
+++ b/crates/scottqueue/RUSTSEC-2020-0133.md
@@ -6,6 +6,7 @@ date = "2020-11-15"
 url = "https://github.com/rossdylan/rust-scottqueue/issues/1"
 categories = ["memory-corruption", "thread-safety"]
 aliases = ["CVE-2020-36453"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = []

--- a/crates/scratchpad/RUSTSEC-2021-0030.md
+++ b/crates/scratchpad/RUSTSEC-2021-0030.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0030"
 package = "scratchpad"
 aliases = ["CVE-2021-28031"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2021-02-18"
 url = "https://github.com/okready/scratchpad/issues/1"
 categories = ["memory-corruption"]

--- a/crates/security-framework/RUSTSEC-2017-0003.md
+++ b/crates/security-framework/RUSTSEC-2017-0003.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2017-0003"
 package = "security-framework"
 aliases = ["CVE-2017-18588"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N"
 date = "2017-03-15"
 keywords = ["mitm"]
 url = "https://github.com/sfackler/rust-security-framework/pull/27"

--- a/crates/serde_cbor/RUSTSEC-2019-0025.md
+++ b/crates/serde_cbor/RUSTSEC-2019-0025.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0025"
 package = "serde_cbor"
 aliases = ["CVE-2019-25001"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 categories = ["crypto-failure"]
 date = "2019-10-03"
 keywords = ["stack-overflow", "crash", "denial-of-service"]

--- a/crates/signal-simple/RUSTSEC-2020-0126.md
+++ b/crates/signal-simple/RUSTSEC-2020-0126.md
@@ -6,6 +6,7 @@ date = "2020-11-15"
 url = "https://github.com/kitsuneninetails/signal-rust/issues/2"
 categories = ["memory-corruption", "thread-safety"]
 aliases = ["CVE-2020-36446"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = []

--- a/crates/simd-json/RUSTSEC-2019-0008.md
+++ b/crates/simd-json/RUSTSEC-2019-0008.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0008"
 package = "simd-json"
 aliases = ["CVE-2019-15550"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2019-06-24"
 keywords = ["simd"]
 url = "https://github.com/Licenser/simdjson-rs/pull/27"

--- a/crates/sized-chunks/RUSTSEC-2020-0041.md
+++ b/crates/sized-chunks/RUSTSEC-2020-0041.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0041"
 package = "sized-chunks"
 aliases = ["CVE-2020-25791", "CVE-2020-25792", "CVE-2020-25793", "CVE-2020-25794", "CVE-2020-25795", "CVE-2020-25796"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-09-06"
 url = "https://github.com/bodil/sized-chunks/issues/11"
 

--- a/crates/slice-deque/RUSTSEC-2018-0008.md
+++ b/crates/slice-deque/RUSTSEC-2018-0008.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2018-0008"
 package = "slice-deque"
 aliases = ["CVE-2018-20995"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2018-12-05"
 keywords = ["memory-corruption", "rce"]
 url = "https://github.com/gnzlbg/slice_deque/issues/57"

--- a/crates/slice-deque/RUSTSEC-2019-0002.md
+++ b/crates/slice-deque/RUSTSEC-2019-0002.md
@@ -4,6 +4,7 @@ id = "RUSTSEC-2019-0002"
 package = "slice-deque"
 date = "2019-05-07"
 aliases = ["CVE-2019-15543"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 related = ["RUSTSEC-2018-0008"]
 keywords = ["memory-corruption", "rce"]
 

--- a/crates/slice-deque/RUSTSEC-2021-0047.md
+++ b/crates/slice-deque/RUSTSEC-2021-0047.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0047"
 package = "slice-deque"
 aliases = ["CVE-2021-29938"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2021-02-19"
 url = "https://github.com/gnzlbg/slice_deque/issues/90"
 categories = ["memory-corruption"]

--- a/crates/slock/RUSTSEC-2020-0135.md
+++ b/crates/slock/RUSTSEC-2020-0135.md
@@ -6,6 +6,7 @@ date = "2020-11-17"
 url = "https://github.com/BrokenLamp/slock-rs/issues/2"
 categories = ["memory-corruption", "thread-safety"]
 aliases = ["CVE-2020-36455"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = []

--- a/crates/smallvec/RUSTSEC-2018-0003.md
+++ b/crates/smallvec/RUSTSEC-2018-0003.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2018-0003"
 package = "smallvec"
 aliases = ["CVE-2018-20991"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2018-07-19"
 keywords = ["memory-corruption"]
 url = "https://github.com/servo/rust-smallvec/issues/96"

--- a/crates/smallvec/RUSTSEC-2019-0009.md
+++ b/crates/smallvec/RUSTSEC-2019-0009.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0009"
 package = "smallvec"
 aliases = ["CVE-2019-15551"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2019-06-06"
 keywords = ["double free", "use after free", "arbitrary code execution"]
 url = "https://github.com/servo/rust-smallvec/issues/148"

--- a/crates/smallvec/RUSTSEC-2019-0012.md
+++ b/crates/smallvec/RUSTSEC-2019-0012.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0012"
 package = "smallvec"
 aliases = ["CVE-2019-15554"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 categories = ["code-execution", "memory-corruption"]
 date = "2019-07-19"
 url = "https://github.com/servo/rust-smallvec/issues/149"

--- a/crates/smallvec/RUSTSEC-2021-0003.md
+++ b/crates/smallvec/RUSTSEC-2021-0003.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0003"
 package = "smallvec"
 aliases = ["CVE-2021-25900"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2021-01-08"
 url = "https://github.com/servo/rust-smallvec/issues/252"
 categories = ["memory-corruption"]

--- a/crates/socket2/RUSTSEC-2020-0079.md
+++ b/crates/socket2/RUSTSEC-2020-0079.md
@@ -7,6 +7,7 @@ url = "https://github.com/rust-lang/socket2-rs/issues/119"
 keywords = ["memory", "layout", "cast"]
 informational = "unsound"
 aliases = ["CVE-2020-35920"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 
 [versions]
 patched = [">= 0.3.16"]

--- a/crates/sodiumoxide/RUSTSEC-2017-0001.md
+++ b/crates/sodiumoxide/RUSTSEC-2017-0001.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2017-0001"
 package = "sodiumoxide"
 aliases = ["CVE-2017-1000168"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N"
 date = "2017-01-26"
 keywords = ["cryptography"]
 url = "https://github.com/dnaq/sodiumoxide/issues/154"

--- a/crates/sodiumoxide/RUSTSEC-2019-0026.md
+++ b/crates/sodiumoxide/RUSTSEC-2019-0026.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0026"
 package = "sodiumoxide"
 aliases = ["CVE-2019-25002"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2019-10-11"
 keywords = ["cryptography"]
 url = "https://github.com/sodiumoxide/sodiumoxide/pull/381"

--- a/crates/spin/RUSTSEC-2019-0013.md
+++ b/crates/spin/RUSTSEC-2019-0013.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0013"
 package = "spin"
 aliases = ["CVE-2019-16137"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2019-08-27"
 keywords = ["atomic", "ordering", "spin", "lock", "mutex", "rwlock"]
 url = "https://github.com/mvdnes/spin-rs/issues/65"

--- a/crates/stack/RUSTSEC-2020-0042.md
+++ b/crates/stack/RUSTSEC-2020-0042.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0042"
 package = "stack"
 aliases = ["CVE-2020-35895"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2020-09-24"
 url = "https://github.com/arcnmx/stack-rs/issues/4"
 

--- a/crates/stack_dst/RUSTSEC-2021-0033.md
+++ b/crates/stack_dst/RUSTSEC-2021-0033.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0033"
 package = "stack_dst"
 aliases = ["CVE-2021-28034", "CVE-2021-28035"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2021-02-22"
 url = "https://github.com/thepowersgang/stack_dst-rs/issues/5"
 categories = ["memory-corruption"]

--- a/crates/stackvector/RUSTSEC-2021-0048.md
+++ b/crates/stackvector/RUSTSEC-2021-0048.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0048"
 package = "stackvector"
 aliases = ["CVE-2021-29939"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L"
 date = "2021-02-19"
 url = "https://github.com/Alexhuszagh/rust-stackvector/issues/2"
 categories = ["memory-corruption"]

--- a/crates/string-interner/RUSTSEC-2019-0023.md
+++ b/crates/string-interner/RUSTSEC-2019-0023.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2019-0023"
 package = "string-interner"
 aliases = ["CVE-2019-16882"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
 date = "2019-08-24"
 keywords = ["use after free"]
 url = "https://github.com/Robbepop/string-interner/issues/9"

--- a/crates/syncpool/RUSTSEC-2020-0142.md
+++ b/crates/syncpool/RUSTSEC-2020-0142.md
@@ -6,6 +6,7 @@ date = "2020-11-29"
 url = "https://github.com/Chopinsky/byte_buffer/issues/2"
 categories = ["memory-corruption"]
 aliases = ["CVE-2020-36462"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = [">= 0.1.6"]

--- a/crates/sys-info/RUSTSEC-2020-0100.md
+++ b/crates/sys-info/RUSTSEC-2020-0100.md
@@ -7,6 +7,7 @@ url = "https://github.com/FillZpp/sys-info-rs/issues/63"
 categories = ["memory-corruption"]
 keywords = ["concurrency", "double free"]
 aliases = ["CVE-2020-36434"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = [">= 0.8.0"]

--- a/crates/tar/RUSTSEC-2018-0002.md
+++ b/crates/tar/RUSTSEC-2018-0002.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2018-0002"
 package = "tar"
 aliases = ["CVE-2018-20990"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
 date = "2018-06-29"
 keywords = ["file-overwrite"]
 url = "https://github.com/alexcrichton/tar-rs/pull/156"

--- a/crates/tar/RUSTSEC-2021-0080.md
+++ b/crates/tar/RUSTSEC-2021-0080.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0080"
 package = "tar"
 aliases = ["CVE-2021-38511"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
 date = "2021-07-19"
 url = "https://github.com/alexcrichton/tar-rs/issues/238"
 

--- a/crates/telemetry/RUSTSEC-2021-0046.md
+++ b/crates/telemetry/RUSTSEC-2021-0046.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0046"
 package = "telemetry"
 aliases = ["CVE-2021-29937"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2021-02-17"
 url = "https://github.com/Yoric/telemetry.rs/issues/45"
 categories = ["memory-corruption"]

--- a/crates/thex/RUSTSEC-2020-0090.md
+++ b/crates/thex/RUSTSEC-2020-0090.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0090"
 package = "thex"
 aliases = ["CVE-2020-35927"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-12-08"
 categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]

--- a/crates/through/RUSTSEC-2021-0049.md
+++ b/crates/through/RUSTSEC-2021-0049.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0049"
 package = "through"
 aliases = ["CVE-2021-29940"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2021-02-18"
 url = "https://github.com/gretchenfrage/through/issues/1"
 categories = ["memory-corruption"]

--- a/crates/ticketed_lock/RUSTSEC-2020-0119.md
+++ b/crates/ticketed_lock/RUSTSEC-2020-0119.md
@@ -6,6 +6,7 @@ date = "2020-11-17"
 url = "https://github.com/kvark/ticketed_lock/issues/7"
 categories = ["memory-corruption", "thread-safety"]
 aliases = ["CVE-2020-36439"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = [">= 0.3.0"]

--- a/crates/tiny_future/RUSTSEC-2020-0118.md
+++ b/crates/tiny_future/RUSTSEC-2020-0118.md
@@ -7,6 +7,7 @@ url = "https://github.com/KizzyCode/tiny_future/issues/1"
 categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
 aliases = ["CVE-2020-36438"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = [">= 0.4.0"]

--- a/crates/tiny_http/RUSTSEC-2020-0031.md
+++ b/crates/tiny_http/RUSTSEC-2020-0031.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0031"
 package = "tiny_http"
 aliases = ["CVE-2020-35884"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N"
 date = "2020-06-16"
 keywords = ["http", "request-smuggling"]
 url = "https://github.com/tiny-http/tiny-http/issues/173"

--- a/crates/tokio-rustls/RUSTSEC-2020-0019.md
+++ b/crates/tokio-rustls/RUSTSEC-2020-0019.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0019"
 package = "tokio-rustls"
 aliases = ["CVE-2020-35875"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 categories = ["denial-of-service"]
 date = "2020-05-19"
 keywords = ["tls", "ssl", "DoS"]

--- a/crates/toolshed/RUSTSEC-2020-0136.md
+++ b/crates/toolshed/RUSTSEC-2020-0136.md
@@ -7,6 +7,7 @@ url = "https://github.com/ratel-rust/toolshed/issues/12"
 categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
 aliases = ["CVE-2020-36456"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = []

--- a/crates/tough/RUSTSEC-2020-0024.md
+++ b/crates/tough/RUSTSEC-2020-0024.md
@@ -4,6 +4,7 @@ id = "RUSTSEC-2020-0024"
 package = "tough"
 date = "2020-07-09"
 aliases = ["CVE-2020-15093", "GHSA-5q2r-92f9-4m49"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:H/A:N"
 related = ["CVE-2020-6174"]
 url = "https://github.com/awslabs/tough/security/advisories/GHSA-5q2r-92f9-4m49"
 

--- a/crates/traitobject/RUSTSEC-2020-0027.md
+++ b/crates/traitobject/RUSTSEC-2020-0027.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0027"
 package = "traitobject"
 aliases = ["CVE-2020-35881"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 categories = ["memory-corruption"]
 date = "2020-06-01"
 informational = "unsound"

--- a/crates/truetype/RUSTSEC-2021-0029.md
+++ b/crates/truetype/RUSTSEC-2021-0029.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0029"
 package = "truetype"
 aliases = ["CVE-2021-28030"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
 date = "2021-02-17"
 url = "https://github.com/bodoni/truetype/issues/11"
 categories = ["memory-exposure"]

--- a/crates/trust-dns-proto/RUSTSEC-2018-0007.md
+++ b/crates/trust-dns-proto/RUSTSEC-2018-0007.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2018-0007"
 package = "trust-dns-proto"
 aliases = ["CVE-2018-20994"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2018-10-09"
 keywords = ["stack-overflow", "crash"]
 

--- a/crates/trust-dns-server/RUSTSEC-2020-0001.md
+++ b/crates/trust-dns-server/RUSTSEC-2020-0001.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0001"
 package = "trust-dns-server"
 aliases = ["CVE-2020-35857"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 categories = ["denial-of-service"]
 date = "2020-01-06"
 keywords = ["stack-overflow", "crash"]

--- a/crates/try-mutex/RUSTSEC-2020-0087.md
+++ b/crates/try-mutex/RUSTSEC-2020-0087.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0087"
 package = "try-mutex"
 aliases = ["CVE-2020-35924"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-11-17"
 url = "https://github.com/mpdn/try-mutex/issues/2"
 categories = ["thread-safety"]

--- a/crates/unicycle/RUSTSEC-2020-0116.md
+++ b/crates/unicycle/RUSTSEC-2020-0116.md
@@ -6,6 +6,7 @@ date = "2020-11-15"
 url = "https://github.com/udoprog/unicycle/issues/8"
 categories = ["memory-corruption", "thread-safety"]
 aliases = ["CVE-2020-36436"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = [">= 0.7.1"]

--- a/crates/untrusted/RUSTSEC-2018-0001.md
+++ b/crates/untrusted/RUSTSEC-2018-0001.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2018-0001"
 package = "untrusted"
 aliases = ["CVE-2018-20989"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2018-06-21"
 keywords = ["crash"]
 url = "https://github.com/briansmith/untrusted/pull/20"

--- a/crates/uu_od/RUSTSEC-2021-0043.md
+++ b/crates/uu_od/RUSTSEC-2021-0043.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0043"
 package = "uu_od"
 aliases = ["CVE-2021-29934"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L"
 date = "2021-02-17"
 url = "https://github.com/uutils/coreutils/issues/1729"
 categories = ["memory-exposure"]

--- a/crates/v9/RUSTSEC-2020-0127.md
+++ b/crates/v9/RUSTSEC-2020-0127.md
@@ -6,6 +6,7 @@ date = "2020-12-18"
 url = "https://github.com/purpleposeidon/v9/issues/1"
 categories = ["memory-corruption", "thread-safety"]
 aliases = ["CVE-2020-36447"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
 patched = []

--- a/crates/va-ts/RUSTSEC-2020-0114.md
+++ b/crates/va-ts/RUSTSEC-2020-0114.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0114"
 package = "va-ts"
 aliases = ["CVE-2020-36220"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-12-22"
 url = "https://github.com/video-audio/va-ts/issues/4"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/wasmtime/RUSTSEC-2021-0110.md
+++ b/crates/wasmtime/RUSTSEC-2021-0110.md
@@ -7,6 +7,7 @@ references = ["https://github.com/bytecodealliance/wasmtime/security/advisories/
 categories = ["memory-corruption", "memory-exposure"]
 keywords = ["use-after-free", "out-of-bounds read", "out-of-bounds write", "Wasm", "garbage collection"]
 aliases = ["CVE-2021-39216", "CVE-2021-39219", "CVE-2021-39218"]
+cvss = "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:H"
 
 [versions]
 patched = [">= 0.30.0"]

--- a/crates/ws/RUSTSEC-2020-0043.md
+++ b/crates/ws/RUSTSEC-2020-0043.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0043"
 package = "ws"
 aliases = ["CVE-2020-35896"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 categories = ["denial-of-service"]
 date = "2020-09-25"
 keywords = ["websocket", "dos", "ddos", "oom", "memory", "remotely"]

--- a/crates/xcb/RUSTSEC-2020-0097.md
+++ b/crates/xcb/RUSTSEC-2020-0097.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2020-0097"
 package = "xcb"
 aliases = ["CVE-2020-36205"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-12-10"
 url = "https://github.com/rtbo/rust-xcb/issues/93"
 categories = ["memory-corruption", "thread-safety"]

--- a/crates/yaml-rust/RUSTSEC-2018-0006.md
+++ b/crates/yaml-rust/RUSTSEC-2018-0006.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2018-0006"
 package = "yaml-rust"
 aliases = ["CVE-2018-20993"]
+cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 date = "2018-09-17"
 keywords = ["crash"]
 url = "https://github.com/chyh1990/yaml-rust/pull/109"

--- a/crates/yottadb/RUSTSEC-2021-0022.md
+++ b/crates/yottadb/RUSTSEC-2021-0022.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0022"
 package = "yottadb"
 aliases = ["CVE-2021-27377"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 date = "2021-02-09"
 url = "https://gitlab.com/YottaDB/Lang/YDBRust/-/issues/40"
 categories = ["memory-corruption"]


### PR DESCRIPTION
Adds the base cvss information, fetched from nvd using the CVE ids in the aliases.
This was done using the following quick-and-dirty shell script:

```shell
#!/bin/bash

set -e

cd crates

for adv in $(ls -1 */*.md | sort); do
  echo "${adv}"
  # skip if cvss already defined
  if grep -q "^cvss =" "${adv}"; then
    echo "   already has a cvss filed, skipping"
    continue;
  fi
  if ! grep -q "^aliases = .*CVE.*" "${adv}"; then
    echo "   does not have aliases, skipping"
    continue;
  fi
  r_aliases=$(grep aliases ${adv} | cut -d "=" -f2 | sed "s/[,\"\[\]]*//g")
  # define an array
  aliases=(${r_aliases})

  for alias in "${aliases[@]}"; do
    if echo ${alias} | grep -q CVE
    then
      echo "   querying ${alias}"
      vector=$(curl -sS https://services.nvd.nist.gov/rest/json/cve/1.0/${alias} | jq '.result.CVE_Items[0].impact.baseMetricV3.cvssV3.vectorString')
      if [ "$vector" = "null" ]
      then
        echo "   can't find information"
        continue
      fi
      # insert as many cvss line as CVEs is vectors are different
      if ! grep -q "cvss = ${vector}" "${adv}"
      then
        sed -i "/^aliases.*=.*/a cvss = ${vector}" "${adv}"
      fi
      # rate limiting for nvd api
      sleep 0.5
    fi
  done
  # remove cvss for advisories with several different vectors
  num=$(grep -c "cvss =" "${adv}")
  if [ "$num" -gt "1" ]
  then
    sed -i '/cvss =/d' "${adv}"
    echo "   ${adv} has aliases with ${num} different vectors, skipping"
  fi
done
```

* When the advisory has several CVE aliases with different cvss, the advisory is skipped
* When the advisory already has a cvss field, it is skipped

In the future, this could be properly added to an automated curation tool that would keep information in sync with external sources.

We could also add CWE data to the advisories (but I'm not sure it would be relevant for rustsec).