### PR TITLE
Add missing method to time vulnerability

### DIFF
--- a/crates/time/RUSTSEC-2020-0071.md
+++ b/crates/time/RUSTSEC-2020-0071.md
@@ -26,6 +26,7 @@ os = [
 [affected.functions]
 "time::at" = ["^0.1"]
 "time::at_utc" = ["^0.1"]
+"time::now" = ["^0.1"]
 "time::UtcOffset::local_offset_at" = ["< 0.2.23"]
 "time::UtcOffset::try_local_offset_at" = ["< 0.2.23"]
 "time::UtcOffset::current_local_offset" = ["< 0.2.23"]
@@ -57,6 +58,7 @@ The affected functions in time 0.1 (all versions) are:
 
 - `at`
 - `at_utc`
+- `now`
 
 Non-Unix targets (including Windows and wasm) are unaffected.
 
@@ -66,7 +68,7 @@ Pending a proper fix, the internal method that determines the local offset has b
 
 Users and library authors with time in their dependency tree should perform `cargo update`, which will pull in the updated, unaffected code.
 
-Users of time 0.1 do not have a patch and should upgrade to an unaffected version: time 0.2.23 or greater or the 0.3. series.
+Users of time 0.1 do not have a patch and should upgrade to an unaffected version: time 0.2.23 or greater or the 0.3 series.
 
 ### Workarounds
 


### PR DESCRIPTION
Missed this when I went through the 0.1 API previously.