### PR TITLE
winapi-rs is unmaintained

### DIFF
--- a/crates/winapi/RUSTSEC-0000-0000.md
+++ b/crates/winapi/RUSTSEC-0000-0000.md
@@ -1,0 +1,14 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "winapi"
+date = "2021-08-16"
+url = "https://github.com/retep998/winapi-rs"
+informational = "unmaintained"
+[versions]
+patched = []
+```
+
+# winapi is unmaintained, use windows-rs instead
+
+The winapi-rs crate hasn't had any updates since November 2020, and in the meantime Microsoft has released it's windows-rs crate that's actively being developed, maintained and supports a much wider set of APIs.


### PR DESCRIPTION
This may be a bit controversial, but with winapi being so prevalent and getting so little support, I think it's important to drive community awareness.

Microsoft has taken it upon themselves to build and maintain an alternative: https://github.com/microsoft/windows-rs