### PR TITLE
Add fruity advisory for nvzqz/fruity#14

### DIFF
--- a/crates/fruity/RUSTSEC-0000-0000.md
+++ b/crates/fruity/RUSTSEC-0000-0000.md
@@ -1,0 +1,46 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "fruity"
+date = "2021-11-14"
+url = "https://github.com/nvzqz/fruity/issues/14"
+
+[affected]
+functions = {
+    "fruity::foundation::NSString::to_str" = ["> 0.0.0"],
+    "fruity::foundation::NSString::to_str_with_nul" = ["> 0.0.0"],
+    "fruity::foundation::NSString::to_string" = ["> 0.0.0"],
+    "fruity::foundation::NSString::to_string_with_nul" = ["> 0.0.0"],
+}
+
+[versions]
+patched = []
+```
+
+# Converting `NSString` to a String Truncates at Null Bytes
+
+Methods of [`NSString`] for conversion to a string may return a partial result.
+Since they call [`CStr::from_ptr`] on a pointer to the string buffer, the
+string is terminated at the first null byte, which might not be the end of the
+string.
+
+In addition to the vulnerable functions listed for this issue, the
+implementations of [`Display`], [`PartialEq`], [`PartialOrd`], and [`ToString`]
+for [`NSString`] are also affected, since they call those functions.
+
+
+## Example:
+
+```rust
+let string = NSString::from_str("null\0byte");
+println!("{}", string);
+```
+
+That example only prints the string "null".
+
+[`CStr::from_ptr`]: https://doc.rust-lang.org/std/ffi/struct.CStr.html#method.from_ptr
+[`Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
+[`NSString`]: https://docs.rs/fruity/0.2.0/fruity/foundation/struct.NSString.html
+[`PartialEq`]: https://doc.rust-lang.org/std/cmp/trait.PartialEq.html
+[`PartialOrd`]: https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html
+[`ToString`]: https://doc.rust-lang.org/std/string/trait.ToString.html

--- a/crates/fruity/RUSTSEC-0000-0000.md
+++ b/crates/fruity/RUSTSEC-0000-0000.md
@@ -4,7 +4,6 @@ id = "RUSTSEC-0000-0000"
 package = "fruity"
 date = "2021-11-14"
 url = "https://github.com/nvzqz/fruity/issues/14"
-
 [affected]
 functions = {
     "fruity::foundation::NSString::to_str" = ["> 0.0.0"],
@@ -12,7 +11,6 @@ functions = {
     "fruity::foundation::NSString::to_string" = ["> 0.0.0"],
     "fruity::foundation::NSString::to_string_with_nul" = ["> 0.0.0"],
 }
-
 [versions]
 patched = []
 ```

--- a/crates/fruity/RUSTSEC-0000-0000.md
+++ b/crates/fruity/RUSTSEC-0000-0000.md
@@ -26,6 +26,18 @@ In addition to the vulnerable functions listed for this issue, the
 implementations of [`Display`], [`PartialEq`], [`PartialOrd`], and [`ToString`]
 for [`NSString`] are also affected, since they call those functions.
 
+## Impact
+
+Since [`NSString`] is commonly used as the type for paths by the [Foundation]
+framework, null byte truncation might allow for easily bypassing file extension
+checks. For example, if a file name is provided by a user and validated to have
+one of a specific set of extensions, with validation taking place before
+truncation, an attacker can add an accepted extension after a null byte (e.g.,
+`file.exe\0.txt`). After truncation, the file name used by the application
+would be `file.exe`.
+
+It would be better to generate unique names for files, instead of using
+user-provided names, but not all applications take this approach.
 
 ## Example:
 
@@ -38,6 +50,7 @@ That example only prints the string "null".
 
 [`CStr::from_ptr`]: https://doc.rust-lang.org/std/ffi/struct.CStr.html#method.from_ptr
 [`Display`]: https://doc.rust-lang.org/std/fmt/trait.Display.html
+[Foundation]: https://developer.apple.com/documentation/foundation
 [`NSString`]: https://docs.rs/fruity/0.2.0/fruity/foundation/struct.NSString.html
 [`PartialEq`]: https://doc.rust-lang.org/std/cmp/trait.PartialEq.html
 [`PartialOrd`]: https://doc.rust-lang.org/std/cmp/trait.PartialOrd.html

--- a/crates/fruity/RUSTSEC-0000-0000.md
+++ b/crates/fruity/RUSTSEC-0000-0000.md
@@ -4,13 +4,13 @@ id = "RUSTSEC-0000-0000"
 package = "fruity"
 date = "2021-11-14"
 url = "https://github.com/nvzqz/fruity/issues/14"
-[affected]
-functions = {
-    "fruity::foundation::NSString::to_str" = ["> 0.0.0"],
-    "fruity::foundation::NSString::to_str_with_nul" = ["> 0.0.0"],
-    "fruity::foundation::NSString::to_string" = ["> 0.0.0"],
-    "fruity::foundation::NSString::to_string_with_nul" = ["> 0.0.0"],
-}
+
+[affected.functions]
+"fruity::foundation::NSString::to_str" = ["> 0.0.0"]
+"fruity::foundation::NSString::to_str_with_nul" = ["> 0.0.0"]
+"fruity::foundation::NSString::to_string" = ["> 0.0.0"]
+"fruity::foundation::NSString::to_string_with_nul" = ["> 0.0.0"]
+
 [versions]
 patched = []
 ```


### PR DESCRIPTION
Issue: nvzqz/fruity#14

A CVE request has been submitted as well.

Questions:
- Can I add trait implementations to the `functions` list?
- Should I create an unmaintained crate advisory too?
    - nvzqz/fruity#14
    - nvzqz/fruity#13