### PR TITLE
Security advisory on simple_asn1 version 0.6.0

### DIFF
--- a/crates/simple_asn1/RUSTSEC-0000-0000.md
+++ b/crates/simple_asn1/RUSTSEC-0000-0000.md
@@ -1,0 +1,46 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "simple_asn1"
+date = "2021-11-14"
+url = "https://github.com/acw/simple_asn1/issues/27"
+categories = ["denial-of-service"]
+keywords = ["panic", "string_slice"]
+#aliases = ["CVE-YYYY-NNNN"]
+#cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+
+[versions]
+patched = [">= 1.2.3"]
+unaffected = ["0.1.2"]
+
+[affected]
+#arch = ["x86"]
+#os = ["windows"]
+functions = { "crate_name::MyStruct::vulnerable_fn" = ["< 1.2.3"] }
+
+[versions]
+patched = [">=0.6.1"]
+unaffected = ["<0.6.0"]
+```
+
+# Panic on incorrect date input to `simple_asn1`
+
+Version 0.6.0 of the `simple_asn1` crate panics on certain malformed
+inputs to its parsing functions, including `from_der` and `der_decode`.
+Because this crate is frequently used with inputs from the network, this
+should be considered a security vulnerability.
+
+The issue occurs when parsing the old ASN.1 "UTCTime" time format.  If an
+attacker provides a UTCTime where the first character is ASCII but the
+second character is above 0x7f, a string slice operation in the
+`from_der_` function will try to slice into the middle of a UTF-8
+character, and cause a panic.
+
+This error was introduced in commit
+[`d7d39d709577710e9dc8`](https://github.com/acw/simple_asn1/commit/d7d39d709577710e9dc8833ee57d200eef366db8),
+which updated `simple_asn1` to use `time` instead of `chrono` because of
+[`RUSTSEC-2020-159`](https://rustsec.org/advisories/RUSTSEC-2020-0159).
+Versions of `simple_asn1` before 0.6.0 are not affected by this issue.
+
+The [patch](https://github.com/acw/simple_asn1/pull/28) was applied in
+`simple_asn1` version 0.6.1.

--- a/crates/simple_asn1/RUSTSEC-0000-0000.md
+++ b/crates/simple_asn1/RUSTSEC-0000-0000.md
@@ -10,15 +10,6 @@ keywords = ["panic", "string_slice"]
 #cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
 
 [versions]
-patched = [">= 1.2.3"]
-unaffected = ["0.1.2"]
-
-[affected]
-#arch = ["x86"]
-#os = ["windows"]
-functions = { "crate_name::MyStruct::vulnerable_fn" = ["< 1.2.3"] }
-
-[versions]
 patched = [">=0.6.1"]
 unaffected = ["<0.6.0"]
 ```


### PR DESCRIPTION
The maintainer has acknowledged and fixed this issue; see
https://github.com/acw/simple_asn1/pull/28 .

This is my first RustSec advisory; please check carefully to see if I have done anything incorrectly.  Thanks!