### PR TITLE
Add CVE for RUSTSEC-2021-0123

### DIFF
--- a/crates/fruity/RUSTSEC-2021-0123.md
+++ b/crates/fruity/RUSTSEC-2021-0123.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-2021-0123"
 package = "fruity"
+aliases = ["CVE-2021-43620"]
 date = "2021-11-14"
 url = "https://github.com/nvzqz/fruity/issues/14"
 


### PR DESCRIPTION
It's impressive how quickly this was assigned.

Initial PR: #1102