### PR TITLE
Add advisory for tokio-rs/tokio#4225

### DIFF
--- a/crates/tokio/RUSTSEC-0000-0000.md
+++ b/crates/tokio/RUSTSEC-0000-0000.md
@@ -27,7 +27,7 @@ of the channel can concurrently access a shared memory location, resulting in a
 data race. This has been observed to [cause memory corruption][corruption].
 
 Note that the race only occurs when **both** halves of the channel are used
-after one half has called `close`. Code where `close` is not used, or where the
+after the `Receiver` half has called `close`. Code where `close` is not used, or where the
 `Receiver` is not `await`ed and `try_recv` is not called after calling `close`,
 is not affected.
 

--- a/crates/tokio/RUSTSEC-0000-0000.md
+++ b/crates/tokio/RUSTSEC-0000-0000.md
@@ -11,10 +11,8 @@ keywords = ["race condition", "freeform", "keywords"]
 patched = [">= 1.8.4, < 1.9.0", ">= 1.13.1"]
 unaffected = ["< 0.1.14"]
 
-[affected]
-functions = {
-    "tokio::sync::oneshot::Receiver::close" = ["<= 1.13.0, >= 0.1.14"]
-}
+[affected.functions]
+"tokio::sync::oneshot::Receiver::close" = ["<= 1.13.0, >= 0.1.14"]
 ```
 
 # Data race when sending and receiving after closing a `oneshot` channel

--- a/crates/tokio/RUSTSEC-0000-0000.md
+++ b/crates/tokio/RUSTSEC-0000-0000.md
@@ -1,0 +1,40 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tokio"
+date = "2021-11-16"
+url = "https://github.com/tokio-rs/tokio/issues/4225"
+categories = ["memory corruption"]
+keywords = ["race condition", "freeform", "keywords"]
+
+[versions]
+patched = [">= 1.8.4, < 1.9.0", ">= 1.13.1"]
+unaffected = ["< 0.1.14"]
+
+[affected]
+functions = {
+    "tokio::sync::oneshot::Receiver::close" = ["< 1.8.3, >= 0.1.14"]
+}
+```
+
+# Data race when sending and receiving after closing a `oneshot` channel
+
+If a `tokio::sync::oneshot` channel is closed (via the
+[`oneshot::Receiver::close`] method), a data race may occur if the
+`oneshot::Sender::send` method is called while the corresponding
+`oneshot::Receiver` is `await`ed or calling `try_recv`.
+
+When these methods are called concurrently on a closed channel, the two halves
+of the channel can concurrently access a shared memory location, resulting in a
+data race. This has been observed to [cause memory corruption][corruption].
+
+Note that the race only occurs when **both** halves of the channel are used
+after one half has called `close`. Code where `close` is not used, or where the
+`Receiver` is not `await`ed and `try_recv` is not called after calling `close`,
+is not affected.
+
+See [tokio#4225][issue] for more details.
+
+[corruption]: https://github.com/tokio-rs/tokio/issues/4225#issuecomment-967434847
+[issue]: https://github.com/tokio-rs/tokio/issues/4225
+[`oneshot::Receiver::close`]: https://docs.rs/tokio/1.14.0/tokio/sync/oneshot/struct.Receiver.html#method.close

--- a/crates/tokio/RUSTSEC-0000-0000.md
+++ b/crates/tokio/RUSTSEC-0000-0000.md
@@ -13,7 +13,7 @@ unaffected = ["< 0.1.14"]
 
 [affected]
 functions = {
-    "tokio::sync::oneshot::Receiver::close" = ["< 1.8.3, >= 0.1.14"]
+    "tokio::sync::oneshot::Receiver::close" = ["<= 1.13.0, >= 0.1.14"]
 }
 ```
 

--- a/crates/tokio/RUSTSEC-0000-0000.md
+++ b/crates/tokio/RUSTSEC-0000-0000.md
@@ -4,8 +4,8 @@ id = "RUSTSEC-0000-0000"
 package = "tokio"
 date = "2021-11-16"
 url = "https://github.com/tokio-rs/tokio/issues/4225"
-categories = ["memory corruption"]
-keywords = ["race condition", "freeform", "keywords"]
+categories = ["memory-corruption", "thread-safety"]
+keywords = ["race condition"]
 
 [versions]
 patched = [">= 1.8.4, < 1.9.0", ">= 1.13.1"]


### PR DESCRIPTION
If a `tokio::sync::oneshot` channel is closed (via the
`oneshot::Receiver::close`]method), a data race may occur if the
`oneshot::Sender::send` method is called while the corresponding
`oneshot::Receiver` is `await`ed or calling `try_recv`.

When these methods are called concurrently on a closed channel, the two halves
of the channel can concurrently access a shared memory location, resulting in a
data race. This has been observed to [cause memory corruption][corruption].

Note that the race only occurs when **both** halves of the channel are used
after one half has called `close`. Code where `close` is not used, or where the
`Receiver` is not `await`ed and `try_recv` is not called after calling `close`,
is not affected.

See tokio-rs/tokio#4225 for more details.

This issue was patched in v1.13.1. The patch was backported to the current
LTS version (v1.8.x) in release v1.8.4.