### PR TITLE
Adds maintained alternative to slice_deque

### DIFF
--- a/crates/slice-deque/RUSTSEC-2020-0158.md
+++ b/crates/slice-deque/RUSTSEC-2020-0158.md
@@ -13,3 +13,7 @@ patched = []
 # slice-deque is unmaintained
 
 The author of the `slice-deque` crate is unresponsive and is not receiving security patches.
+
+Maintained alternatives:
+
+- [`slice-ring-buffer`](https://crates.io/crates/slice-ring-buffer)


### PR DESCRIPTION
I decided to fork slice_deque due to the outstanding security
advisory and not getting a response from the creator.

This adds a mention to the original advisory to help people 'patch' the issue.
