### PR TITLE
Add advisory for rust-embed path traversal

### DIFF
--- a/crates/rust-embed/RUSTSEC-0000-0000.md
+++ b/crates/rust-embed/RUSTSEC-0000-0000.md
@@ -1,0 +1,36 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rust-embed"
+date = "2021-11-29"
+url = "https://github.com/pyros2097/rust-embed/issues/159"
+categories = ["file-disclosure"]
+
+[versions]
+patched = [">= 6.3.0"]
+```
+
+# RustEmbed generated `get` method allows for directory traversal when reading files from disk
+
+When running in debug mode and the `debug-embed` (off by default) feature is
+not enabled, the generated `get` method does not check that the input path is
+a child of the folder given. 
+
+This allows attackers to read arbitrary files in the file system if they have
+control over the filename given. The following code will print the contents of
+your `/etc/passwd` if adjusted with a correct number of `../`s depending on
+where it is run from.
+
+```rust
+#[derive(rust_embed::RustEmbed)]
+#[folder = "src/"]
+pub struct Asset;
+
+fn main() {
+    let d = Asset::get("../../../etc/passwd").unwrap().data;
+    println!("{}", String::from_utf8_lossy(&d));
+}
+```
+
+The flaw was corrected by canonicalizing the input filename and ensuring that
+it starts with the canonicalized folder path.


### PR DESCRIPTION
Reported this in https://github.com/pyros2097/rust-embed/issues/159. It is *somewhat* unlikely that people will hit it in a production environment since it does require you to be running in a debug mode, but https://github.com/agora-org/agora/issues/270 is an example of where it was vulnerable.