### PR TITLE
Report `rusqlite` closure lifetime issue

### DIFF
--- a/crates/rusqlite/RUSTSEC-0000-0000.md
+++ b/crates/rusqlite/RUSTSEC-0000-0000.md
@@ -1,0 +1,42 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rusqlite"
+date = "2021-12-07"
+url = "https://github.com/rusqlite/rusqlite/issues/1048"
+categories = ["memory-corruption"]
+keywords = ["use-after-free", "incorrect-lifetime"]
+
+[affected.functions]
+
+# Under `cfg(feature = "functions")`
+"rusqlite::Connection::create_scalar_function" = [">= 0.25.0, < 0.25.4", ">= 0.26.0, < 0.26.2"]
+"rusqlite::Connection::create_aggregate_function" = [">= 0.25.0, < 0.25.4", ">= 0.26.0, < 0.26.2"]
+"rusqlite::Connection::create_window_function" = [">= 0.25.0, < 0.25.4", ">= 0.26.0, < 0.26.2"]
+
+# Under `cfg(feature = "collation")`
+"rusqlite::Connection::create_collation" = [">= 0.25.0, < 0.25.4", ">= 0.26.0, < 0.26.2"]
+
+# Under `cfg(feature = "hooks")`
+"rusqlite::Connection::commit_hook" = [">= 0.25.0, < 0.25.4", ">= 0.26.0, < 0.26.2"]
+"rusqlite::Connection::rollback_hook" = [">= 0.25.0, < 0.25.4", ">= 0.26.0, < 0.26.2"]
+"rusqlite::Connection::update_hook" = [">= 0.25.0, < 0.25.4", ">= 0.26.0, < 0.26.2"]
+
+[versions]
+patched = [">= 0.26.2", "0.25.4"]
+unaffected = ["< 0.25.0"]
+```
+
+# Incorrect Lifetime Bounds on Closures in `rusqlite`
+
+The lifetime bound on several closure-accepting `rusqlite` functions (specifically, functions which register a callback to be later invoked by SQLite) was too relaxed. If a closure referencing borrowed values on the stack is was passed to one of these functions, it could allow Rust code to access objects on the stack after they have been dropped.
+
+The impacted functions are:
+
+- Under `cfg(feature = "functions")`: `Connection::create_scalar_function`, `Connection::create_aggregate_function` and `Connection::create_window_function`.
+- Under `cfg(feature = "hooks")`: `Connection::commit_hook`, `Connection::rollback_hook` and `Connection::update_hook`.
+- Under `cfg(feature = "collation")`: `Connection::create_collation`.
+
+The issue exists in all `0.25.*` versions prior to `0.25.4`, and all `0.26.*` versions prior to 0.26.2 (specifically: `0.25.0`, `0.25.1`, `0.25.2`, `0.25.3`, `0.26.0`, and `0.26.1`).
+
+The fix is available in versions `0.26.2` and newer, and also has been back-ported to `0.25.4`. As it does not exist in `0.24.*`, all affected versions should have an upgrade path to a semver-compatible release.


### PR DESCRIPTION
Advisory for issue reported as https://github.com/rusqlite/rusqlite/issues/1048.

This is a soundness hole in several `rusqlite` APIs where you can pass a closure with a too-short lifetime.

Doing so can lead to UAF. As a small mercy, it's somewhat unlikely to have code that uses these API incorrectly but silently works — most usage should either be fine, unless the code has not been tested at all.

That said, this is obviously not guaranteed — I've backported it to all affected major versions (0.25.x before 0.25.4 and 0.26.x before 0.26.2), and will yank the affected releases after filing this issue, so there should be no reason not to update.