### PR TITLE
brotli2-sys CVE-2020-8927

### DIFF
--- a/crates/brotli2-sys/RUSTSEC-0000-0000.md
+++ b/crates/brotli2-sys/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+
+package = "brotli2-sys"
+
+date = "2021-12-20"
+
+categories = ["memory-corruption"]
+
+keywords = ["integer-overflow"]
+
+related = ["CVE-2020-8927"]
+
+[affected]
+
+# There isn't a patch for brotli2-sys, but version 1.0.9 of google/brotli is patched
+[versions]
+patched = []

--- a/crates/brotli2-sys/RUSTSEC-0000-0000.md
+++ b/crates/brotli2-sys/RUSTSEC-0000-0000.md
@@ -1,3 +1,4 @@
+```toml
 [advisory]
 id = "RUSTSEC-0000-0000"
 
@@ -5,14 +6,24 @@ package = "brotli2-sys"
 
 date = "2021-12-20"
 
+url = "https://github.com/bitemyapp/brotli2-rs/issues/45"
+
 categories = ["memory-corruption"]
 
 keywords = ["integer-overflow"]
 
-related = ["CVE-2020-8927"]
+aliases = ["CVE-2020-8927"]
 
 [affected]
 
 # There isn't a patch for brotli2-sys, but version 1.0.9 of google/brotli is patched
 [versions]
 patched = []
+```
+# Integer overflow in brotli2
+
+A buffer overflow exists in the Brotli library versions prior to 1.0.8 where an attacker controlling the input length of a "one-shot" decompression request to a script can trigger a crash, which happens when copying over chunks of data larger than 2 GiB.
+
+It is recommended to update your Brotli library to 1.0.8 or later. 
+
+If one cannot update, we recommend to use the "streaming" API as opposed to the "one-shot" API, and impose chunk size limits.


### PR DESCRIPTION
Hey, haven't submitted anything before. Brotli reported CVE-2020-8927. The brotli-sys crate is appears to link to a vulnerable version. I'm unsure if the brotli2 crate itself is vulnerable, but I think so based on the following:

https://docs.rs/brotli2/latest/src/brotli2/raw.rs.html#180-195

I also didn't see any limits imposed on the streaming reader/writer that would prevent those interfaces from being vulnerable.