### PR TITLE
Add use after free advisory for lru crate

### DIFF
--- a/crates/lru/RUSTSEC-0000-0000.md
+++ b/crates/lru/RUSTSEC-0000-0000.md
@@ -1,3 +1,4 @@
+```toml
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "lru"
@@ -12,6 +13,7 @@ keywords = ["use-after-free"]
 
 [versions]
 patched = [">= 0.7.1"]
+```
 
 # Use after free in lru crate
 

--- a/crates/lru/RUSTSEC-0000-0000.md
+++ b/crates/lru/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "lru"
+date = "2021-12-21"
+url = "https://github.com/jeromefroe/lru-rs/issues/120"
+categories = ["memory-exposure"]
+keywords = ["use-after-free"]
+
+[affected.functions]
+"lru::LruCache::iter" = ["< 0.7.1"]
+"lru::LruCache::iter_mut" = ["< 0.7.1"]
+
+[versions]
+patched = [">= 0.7.1"]
+
+# Use after free in lru crate
+
+Lru crate has use after free vulnerability.
+
+Lru crate has two functions for getting an iterator. Both iterators give
+references to key and value. Calling specific functions, like pop(), will remove
+and free the value, and but it's still possible to access the reference of value
+which is already dropped causing use after free.

--- a/crates/lru/RUSTSEC-0000-0000.md
+++ b/crates/lru/RUSTSEC-0000-0000.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-0000-0000"
 package = "lru"
 date = "2021-12-21"
 url = "https://github.com/jeromefroe/lru-rs/issues/120"
-categories = ["memory-exposure"]
+categories = ["memory-corruption"]
 keywords = ["use-after-free"]
 
 [affected.functions]


### PR DESCRIPTION
# Use after free in lru crate

Lru crate has use after free vulnerability.

Lru crate has two functions for getting an iterator. Both iterators give
references to key and value. Calling specific functions, like pop(), will remove
and free the value, and but it's still possible to access the reference of value
which is already dropped causing use after free.

More information in upstream repository issue: https://github.com/jeromefroe/lru-rs/issues/120 and the already released fix can be found from https://github.com/jeromefroe/lru-rs/pull/121