### PR TITLE
Mark arrow advisories as fixed in 6.4.0

### DIFF
--- a/crates/arrow/RUSTSEC-2021-0116.md
+++ b/crates/arrow/RUSTSEC-2021-0116.md
@@ -8,7 +8,7 @@ categories = ["memory-exposure"]
 keywords = ["buffer-overflow"]
 
 [versions]
-patched = []
+patched = [">= 6.4.0"]
 ```
 
 # `BinaryArray` does not perform bound checks on reading values and offsets

--- a/crates/arrow/RUSTSEC-2021-0117.md
+++ b/crates/arrow/RUSTSEC-2021-0117.md
@@ -8,7 +8,7 @@ categories = ["memory-exposure"]
 keywords = ["buffer-overflow"]
 
 [versions]
-patched = []
+patched = [">= 6.4.0"]
 ```
 
 # `DecimalArray` does not perform bound checks on accessing values and offsets

--- a/crates/arrow/RUSTSEC-2021-0118.md
+++ b/crates/arrow/RUSTSEC-2021-0118.md
@@ -8,7 +8,7 @@ categories = ["memory-exposure"]
 keywords = ["buffer-overflow"]
 
 [versions]
-patched = []
+patched = [">= 6.4.0"]
 ```
 
 # `FixedSizeBinaryArray` does not perform bound checks on accessing values and offsets


### PR DESCRIPTION
It looks to me like all the outstanding arrow-rs advisories were fixed, as mentioned in https://github.com/apache/arrow-rs/issues/817, and those fixes were released in version 6.4.0. @alamb can you confirm?