### PR TITLE
Mark cargo-download unmaintained

### DIFF
--- a/crates/cargo-download/RUSTSEC-0000-0000.md
+++ b/crates/cargo-download/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "cargo-download"
+date = "2021-12-25"
+url = "https://github.com/Xion/cargo-download"
+informational = "unmaintained"
+[versions]
+patched = []
+```
+
+# cargo-download is unmaintained
+
+The cargo download subcommand (via cargo-download crate) is broken and maintainer has disappeared from GitHub and hasn't had any commits for a year. 
+
+Using this downloader will result to corrupted crates.
+
+Maintainer has not responded to maintenance takeover.
+
+Just use wget / curl directly.


### PR DESCRIPTION
Use of this crate will result into corrupted crate downloads due to lacking flush into filesystem.

No activity in over a year either in the repo or from the publisher(s)

Issue where maintenance takeover has been proposed around 2 Oct
https://github.com/Xion/cargo-download/issues/10

Critical PR that would resolve the write flush
https://github.com/Xion/cargo-download/pull/11
