### PR TITLE
cookie-rs is unmaintained

### DIFF
--- a/crates/cookie/RUSTSEC-0000-0000.md
+++ b/crates/cookie/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "cookie"
+date = "2021-12-28"
+url = "https://github.com/SergioBenitez/cookie-rs/issues/193#issuecomment-992705063"
+informational = "unmaintained"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# cookie is unmaintained
+
+The author of the `cookie` crate is unresponsive.


### PR DESCRIPTION
It appears @SergioBenitez hasn't made any GitHub contributions since September so it would be safe to mark `cookie-rs` as unmaintained.

![image](https://user-images.githubusercontent.com/19519553/147587813-34afbc8e-cee9-4101-972b-f8e4b9f511e9.png)
