### PR TITLE
Add advisory for rustc_serialize

### DIFF
--- a/crates/rustc-serialize/RUSTSEC-0000-0000.md
+++ b/crates/rustc-serialize/RUSTSEC-0000-0000.md
@@ -1,0 +1,28 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rustc-serialize"
+date = "2022-01-01"
+categories = ["denial-of-service"]
+keywords = ["stack overflow"]
+
+[versions]
+patched = []
+
+[affected]
+functions = { "rustc_serialize::json::Json::from_str" = ["*"] }
+```
+
+# Stack overflow in rustc_serialize when parsing deeply nested JSON
+
+When parsing JSON using `json::Json::from_str`, there is no limit to the depth of the stack, therefore deeply nested objects can cause a stack overflow, which aborts the process.
+
+Example code that triggers the vulnerability is
+
+```rust
+fn main() {
+    let _ = rustc_serialize::json::Json::from_str(&"[0,[".repeat(10000));
+}
+```
+
+[serde](https://crates.io/crates/serde) is recommended as a replacement to rustc_serialize.


### PR DESCRIPTION
rustc_serialize is unmaintained (I'm assuming, there's a note in the readme that bugfixes will be merged, but the [repo itself](https://github.com/rust-lang-deprecated/rustc-serialize) is archived, so I suppose that's not happening), is it worth filing just an unmaintained advisory / filing two different advisories?