### PR TITLE
Add rs-async-zip Zip Traversal issue to DB

### DIFF
--- a/crates/async_zip/RUSTSEC-0000-0000.md
+++ b/crates/async_zip/RUSTSEC-0000-0000.md
@@ -1,0 +1,57 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "async_zip"
+date = "2022-01-04"
+url = "https://gist.github.com/snoopysecurity/007503097536b557bc22a7ef24f4d11d"
+keywords = ["zip traversal"]
+
+[versions]
+patched = []
+
+[affected]
+functions = { "async_zip::read::fs::ZipFileReader::new" = ["*"] }
+```
+
+# Zip Traversal in async_zip when extracting files from a Zip
+
+ZIP Path traversal is possible during extraction due to no validation and sanitization of filenames.
+
+Example code that triggers the vulnerability:
+
+```rust
+use std::path::Path;
+use std::sync::Arc;
+
+use async_zip::read::fs::ZipFileReader;
+use tokio::fs::File;
+
+#[tokio::main]
+
+async fn main() {
+
+    let zip = Arc::new(ZipFileReader::new("/maliciouszip.zip").await.unwrap());
+
+    println!("Extracting Archive");
+    let mut handles = Vec::with_capacity(zip.entries().len());
+    for (index, entry) in zip.entries().iter().enumerate() {
+        if entry.dir() {
+            continue;
+        }
+        let local_zip = zip.clone();
+        handles.push(tokio::spawn(async move {
+            let reader = local_zip.entry_reader(index).await.unwrap();
+            let path_str = format!("./output/{}", reader.entry().name());
+            let path = Path::new(&path_str);
+            tokio::fs::create_dir_all(path.parent().unwrap()).await.unwrap();
+            let mut output = File::create(path).await.unwrap();
+            reader.copy_to_end_crc(&mut output, 65536).await.unwrap();
+        }));
+
+    }
+
+    for handle in handles {
+        handle.await.unwrap();
+    }
+}
+```


### PR DESCRIPTION
A Zip Traversal issue exists in rs-async-zip. Makes sense to add it. Examples of other libraries that have fixed it can be seen here: https://github.com/snyk/zip-slip-vulnerability#affected-libraries. 

To reproduce this issue, you can follow the steps here: https://gist.github.com/snoopysecurity/007503097536b557bc22a7ef24f4d11d

This issue was privately disclosed to the maintainer. He has stated that he has made conscious decision not to mitigate any sort of traversal attacks within the library itself. He has however added a notice to to the example code like here https://github.com/Majored/rs-async-zip/blob/main/examples/fs_parallel_extract.rs#L10 but the library itself does not do any sanitization.