### PR TITLE
Add unmaintained advisory for lmdb

### DIFF
--- a/crates/lmdb/RUSTSEC-0000-0000.md
+++ b/crates/lmdb/RUSTSEC-0000-0000.md
@@ -11,4 +11,6 @@ patched = []
 
 # lmdb is unmaintained, use lmdb-rkv instead
 
-The lmdb crate hasn't had any updates since August 2018, which caused mozilla to fork it and release their own crate.
+The lmdb crate hasn't had any updates since August 2018.
+
+Mozilla's [lmdb-rkv](https://github.com/mozilla/lmdb-rs) fork of the crate has received additional maintenance work beyond that and is the best available replacement.

--- a/crates/lmdb/RUSTSEC-0000-0000.md
+++ b/crates/lmdb/RUSTSEC-0000-0000.md
@@ -1,0 +1,14 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "lmdb"
+date = "2022-01-05"
+url = "https://github.com/danburkert/lmdb-rs"
+informational = "unmaintained"
+[versions]
+patched = []
+```
+
+# lmdb is unmaintained, use lmdb-rkv instead
+
+The lmdb crate hasn't had any updates since August 2018, which caused mozilla to fork it and release their own crate.


### PR DESCRIPTION
The `lmdb` crate https://github.com/danburkert/lmdb-rs has been unmaintained since roughly August 2018. This prompted mozilla to fork it and create their own crate [`lmdb-rkv`](https://crates.io/crates/lmdb-rkv)...which is ironically, also unmaintained.