### PR TITLE
RUSTSEC-2016-0015: remove `sodiumoxide` recommendation

### DIFF
--- a/crates/rust-crypto/RUSTSEC-2016-0005.md
+++ b/crates/rust-crypto/RUSTSEC-2016-0005.md
@@ -46,15 +46,6 @@ which algorithms you need:
 - [`secp256k1`]:
   - Key agreement: ECDH (secp256k1 only)
   - Signature algorithms: ECDSA (secp256k1 only)
-- [`sodiumoxide`]:
-  - AEAD algorithms: ChaCha20Poly1305 (IETF version)
-  - Digest algorithms: SHA-256, SHA-512
-  - HMAC
-  - Key agreement: X25519 + BLAKE2b
-  - Password hashing: Argon2(i/d), scrypt
-  - Public key encryption: NaCl "Box" (X25519 + XSalsa20Poly1305)
-  - Signature algorithms: Ed25519
-  - Short-input PRF: SipHash24
 - [`orion`]:
   - AEAD algorithms: ChaCha20Poly1305 (IETF version), XChaCha20Poly1305
   - Digest algorithms: SHA-512, BLAKE2b
@@ -90,7 +81,6 @@ which algorithms you need:
 [`sha-1`]: https://crates.io/crates/sha-1
 [`sha2`]: https://crates.io/crates/sha2
 [`sha3`]: https://crates.io/crates/sha3
-[`sodiumoxide`]: https://crates.io/crates/sodiumoxide
 [`x25519-dalek`]: https://crates.io/crates/x25519-dalek
 [`xsalsa20poly1305`]: https://crates.io/crates/xsalsa20poly1305
 [`orion`]: https://crates.io/crates/orion


### PR DESCRIPTION
`sodiumoxide` is unmaintained itself. See #1090.

We haven't filed a specific unmaintained crate advisory for it yet, but probably should.