### PR TITLE
Undefined behavior in `dashmap`

### DIFF
--- a/crates/dashmap/RUSTSEC-0000-0000.md
+++ b/crates/dashmap/RUSTSEC-0000-0000.md
@@ -5,10 +5,11 @@ package = "dashmap"
 date = "2022-01-10"
 url = "https://github.com/xacrimon/dashmap/issues/167"
 categories = ["memory-corruption"]
-keywords = ["segfault"]
+keywords = ["segfault", "use-after-free"]
 
 [versions]
 patched = []
+unaffected = ["< 5.0.0"]
 ```
 
 # Unsoundness in `Ref::value`

--- a/crates/dashmap/RUSTSEC-0000-0000.md
+++ b/crates/dashmap/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "dashmap"
+date = "2022-01-10"
+url = "https://github.com/xacrimon/dashmap/issues/167"
+categories = ["memory-corruption"]
+keywords = ["segfault"]
+
+[versions]
+patched = []
+```
+
+# Unsoundness in `Ref::value`
+
+Reference returned by `Ref::value` may outlive the `Ref` and escape the lock. This cause undefined behavior and may result in a segfault.
+
+More information in [`dashmap#167`](https://github.com/xacrimon/dashmap/issues/167) issue.

--- a/crates/dashmap/RUSTSEC-0000-0000.md
+++ b/crates/dashmap/RUSTSEC-0000-0000.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-0000-0000"
 package = "dashmap"
 date = "2022-01-10"
 url = "https://github.com/xacrimon/dashmap/issues/167"
-categories = ["memory-corruption"]
+categories = ["memory-exposure", "memory-corruption"]
 keywords = ["segfault", "use-after-free"]
 
 [versions]

--- a/crates/dashmap/RUSTSEC-0000-0000.md
+++ b/crates/dashmap/RUSTSEC-0000-0000.md
@@ -7,13 +7,30 @@ url = "https://github.com/xacrimon/dashmap/issues/167"
 categories = ["memory-exposure", "memory-corruption"]
 keywords = ["segfault", "use-after-free"]
 
+[affected.functions]
+"dashmap::mapref::multiple::RefMulti::key" = [">= 5.0.0"]
+"dashmap::mapref::multiple::RefMulti::value" = [">= 5.0.0"]
+"dashmap::mapref::multiple::RefMulti::pair" = [">= 5.0.0"]
+"dashmap::mapref::multiple::RefMutMulti::key" = [">= 5.0.0"]
+"dashmap::mapref::multiple::RefMutMulti::pair" = [">= 5.0.0"]
+"dashmap::mapref::multiple::RefMutMulti::pair_mut" = [">= 5.0.0"]
+"dashmap::mapref::one::Ref::key" = [">= 5.0.0"]
+"dashmap::mapref::one::Ref::value" = [">= 5.0.0"]
+"dashmap::mapref::one::Ref::pair" = [">= 5.0.0"]
+"dashmap::mapref::one::RefMut::key" = [">= 5.0.0"]
+"dashmap::mapref::one::RefMut::pair" = [">= 5.0.0"]
+"dashmap::mapref::one::RefMut::pair_mut" = [">= 5.0.0"]
+"dashmap::setref::multiple::RefMulti::key" = [">= 5.0.0"]
+"dashmap::setref::one::Ref::key" = [">= 5.0.0"]
+
 [versions]
 patched = []
 unaffected = ["< 5.0.0"]
 ```
 
-# Unsoundness in `Ref::value`
+# Unsoundness in `dashmap` references
 
-Reference returned by `Ref::value` may outlive the `Ref` and escape the lock. This causes undefined behavior and may result in a segfault.
+Reference returned by some methods of `Ref` (and similar types) may outlive the `Ref` and escape the lock.
+This causes undefined behavior and may result in a segfault.
 
 More information in [`dashmap#167`](https://github.com/xacrimon/dashmap/issues/167) issue.

--- a/crates/dashmap/RUSTSEC-0000-0000.md
+++ b/crates/dashmap/RUSTSEC-0000-0000.md
@@ -14,6 +14,6 @@ unaffected = ["< 5.0.0"]
 
 # Unsoundness in `Ref::value`
 
-Reference returned by `Ref::value` may outlive the `Ref` and escape the lock. This cause undefined behavior and may result in a segfault.
+Reference returned by `Ref::value` may outlive the `Ref` and escape the lock. This causes undefined behavior and may result in a segfault.
 
 More information in [`dashmap#167`](https://github.com/xacrimon/dashmap/issues/167) issue.


### PR DESCRIPTION
Undefined behavior may occur when using the `Ref::value` of `dashmap`. See https://github.com/xacrimon/dashmap/issues/167 for more information.

Example vulnerable code:
```rust
use dashmap::DashMap;

fn main() {
    let x = DashMap::new();

    x.insert(1, 1);

    let borrow = x.get(&1).unwrap();
    let val = borrow.value();
    std::mem::drop(borrow);
    let mut borrow_mut = x.get_mut(&1).unwrap();
    let val_mut = borrow_mut.value_mut(); // non-exclusive mutable reference!!!
    println!("{}", val);
}
```

I'm unsure about in which categories this issue falls and what to write in the description.