### PR TITLE
Add advisory for CVE-2022-21658

### DIFF
--- a/rust/std/CVE-2022-21658.md
+++ b/rust/std/CVE-2022-21658.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "CVE-2022-21658"
+package = "std"
+categories = ["file-disclosure"]
+date = "2021-01-16"
+url = "https://blog.rust-lang.org/2022/01/20/cve-2022-21658.html"
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:N/I:L/A:H"
+
+[affected]
+[affected.functions]
+"std::fs::remove_dir_all" = ["<= 1.58.1"]
+
+[versions]
+patched = [">= 1.58.1"]
+```
+
+# Time-of-check time-of-use race condition can allow attacker to delete files they do not have access to delete
+
+In the standard library in Rust before 1.58.1, an attacker with unprivileged access to a system could trick a privileged program using `std::fs::remove_dir_all` into deleting files they don't have access to delete by creating a symlink in a directory that would be removed by a `std::fs::remove_dir_all` call due to a Time-of-check time-of-use race condition around this function's check for symbolic links. The function should remove the symbolic links rather than recursively deleting the linked file or directory.


### PR DESCRIPTION
Closes: https://github.com/rustsec/advisory-db/issues/1154

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>