### PR TITLE
Correct year for CVE-2022-21658

### DIFF
--- a/rust/std/CVE-2022-21658.md
+++ b/rust/std/CVE-2022-21658.md
@@ -3,7 +3,7 @@
 id = "CVE-2022-21658"
 package = "std"
 categories = ["file-disclosure"]
-date = "2021-01-16"
+date = "2022-01-16"
 url = "https://blog.rust-lang.org/2022/01/20/cve-2022-21658.html"
 cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:N/I:L/A:H"
 


### PR DESCRIPTION
I accidentally put 2021.

Signed-off-by: Jesse Szwedko <jesse@szwedko.me>