### PR TITLE
Add soundness advisory for array-macro

### DIFF
--- a/crates/array-macro/RUSTSEC-0000-0000.md
+++ b/crates/array-macro/RUSTSEC-0000-0000.md
@@ -1,0 +1,38 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "array-macro"
+date = "2020-05-07"
+url = "https://gitlab.com/KonradBorowski/array-macro/-/commit/01940637dd8f3bfeeee3faf9639fa9ae52f19f4d"
+categories = ["memory-corruption"]
+informational = "unsound"
+
+[versions]
+patched = [">= 1.0.5"]
+unaffected = ["< 0.1.2"]
+```
+
+# `array!` macro is unsound in presence of traits that implement methods it calls internally
+
+Affected versions of this crate called some methods using auto-ref. The affected code looked like this.
+
+```rust
+let mut arr = $crate::__core::mem::MaybeUninit::uninit();
+let mut vec = $crate::__ArrayVec::<T>::new(arr.as_mut_ptr() as *mut T);
+```
+
+In this case, the problem is that `as_mut_ptr` is a method of `&mut MaybeUninit`, not `MaybeUninit`. This made it possible for traits to hijack the method calls in order to cause unsoundness.
+
+```rust
+trait AsMutPtr<T> {
+    fn as_mut_ptr(&self) -> *mut T;
+}
+impl<T> AsMutPtr<T> for std::mem::MaybeUninit<T> {
+    fn as_mut_ptr(&self) -> *mut T {
+        std::ptr::null_mut()
+    }
+}
+array![0; 1];
+```
+
+The flaw was corrected by explicitly referencing variables in macro body in order to avoid auto-ref.


### PR DESCRIPTION
This is somewhat ancient unsoundness issue (like, one that was fixed 20 months ago), but may as well report it, even if really nobody will care. It may have some educational value however - somebody may see this issue and realize there is a similar issue in macros they wrote. See https://github.com/rust-lang/unsafe-code-guidelines/issues/278 for more context.