### PR TITLE
Add unmaintained crate advisory for `ftd2xx-embedded-hal`

### DIFF
--- a/crates/ftd2xx-embedded-hal/RUSTSEC-0000-0000.md
+++ b/crates/ftd2xx-embedded-hal/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "ftd2xx-embedded-hal"
+date = "2022-01-22"
+informational = "unmaintained"
+url = "https://github.com/newAM/ftd2xx-embedded-hal/pull/40"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# crate has been renamed to `ftdi-embedded-hal`
+
+This crate has been renamed from `ftd2xx-embedded-hal` to `ftdi-embedded-hal`.
+
+The new repository location is:
+
+<https://github.com/ftdi-rs/ftdi-embedded-hal>


### PR DESCRIPTION
Has been renamed to `ftdi-embedded-hal`.