### PR TITLE
Add advisory for unicase

### DIFF
--- a/crates/unicase/RUSTSEC-0000-0000.md
+++ b/crates/unicase/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "unicase"
+date = "2019-11-02"
+url = "https://github.com/seanmonstar/unicase/issues/38"
+keywords = ["partial string comparison"]
+
+[versions]
+patched = [">= 2.6.0"]
+unaffected = ["< 2.0.0"]
+```
+
+# Incorrect check for string equality
+
+Affected versions of this crate did not properly check for string equality allowing substrings of a string to be considered equal.
+
+This can be used to bypass protection mechanisms.
+
+The flaw was corrected in commit [c14856b](https://github.com/seanmonstar/unicase/commit/c14856b0ef9b2e6d8dce802d1a9d5b83a7ce2118) by modifying the code to use a manual implementation of `Iterator::eq` rather than `Iterator::all`.


### PR DESCRIPTION
I think this is a valid vulnerability, see CVE-2000-0979, CVE-2002-1374 and CVE-2014-6394 for similar vulnerabilities. In short, unicase used to consider `"abc"` and `"a"` to be equal.