### PR TITLE
Add unmaintained notice for magic and magic-sys

### DIFF
--- a/crates/magic-sys/RUSTSEC-0000-0000.md
+++ b/crates/magic-sys/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "magic-sys"
+date = "2020-02-05"
+informational = "unmaintained"
+url = "https://github.com/robo9k/rust-magic-sys"
+
+[versions]
+patched = []
+```
+
+# magic-sys is unmaintained
+
+The magic-sys crate hasn't had any updates since November 2021:
+
+* The author is unresponse on GitHub issues
+* The author's GitHub description states that all their code is provided as-is with no active maintenance

--- a/crates/magic/RUSTSEC-0000-0000.md
+++ b/crates/magic/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "magic"
+date = "2020-02-05"
+informational = "unmaintained"
+url = "https://github.com/robo9k/rust-magic"
+
+[versions]
+patched = []
+```
+
+# magic is unmaintained
+
+The magic crate hasn't had any updates since November 2021:
+
+* The author is unresponse on GitHub issues
+* The author's GitHub description states that all their code is provided as-is with no active maintenance


### PR DESCRIPTION
* The authors GitHub page @robo9k states that all their repositories are provided-as is and no maintenance is intended.
* The author is unresponsive on GitHub issues
* Both crates didn't have any new commits since November 2021

It may also be worth a shot to add the unmaintainced notice to the authors' other crates: https://crates.io/users/robo9k