### PR TITLE
Add patched version to DashMap advisory

### DIFF
--- a/crates/dashmap/RUSTSEC-2022-0002.md
+++ b/crates/dashmap/RUSTSEC-2022-0002.md
@@ -24,7 +24,7 @@ keywords = ["segfault", "use-after-free"]
 "dashmap::setref::one::Ref::key" = [">= 5.0.0"]
 
 [versions]
-patched = []
+patched = [">= 5.1.0"]
 unaffected = ["< 5.0.0"]
 ```
 


### PR DESCRIPTION
v5.1.0 has just shipped with a fix