### PR TITLE
Add entry for libp2p-core vulnerability

### DIFF
--- a/crates/libp2p-core/RUSTSEC-0000-0000.md
+++ b/crates/libp2p-core/RUSTSEC-0000-0000.md
@@ -9,6 +9,7 @@ categories = ["crypto-failure"]
 functions = { "libp2p_core::PeerRecord::from_signed_envelope" = [">= 0.30.0-rc.1"] }
 
 [versions]
+unaffected = ["< 0.30.0-rc.1"]
 patched = [">= 0.31.1"]
 ```
 

--- a/crates/libp2p-core/RUSTSEC-0000-0000.md
+++ b/crates/libp2p-core/RUSTSEC-0000-0000.md
@@ -6,7 +6,7 @@ date = "2022-02-07"
 categories = ["crypto-failure"]
 
 [affected]
-functions = { "libp2p_core::PeerRecord::from_signed_envelope" = [">= 0.30.0"] }
+functions = { "libp2p_core::PeerRecord::from_signed_envelope" = [">= 0.30.0-rc.1"] }
 
 [versions]
 patched = [">= 0.31.1"]

--- a/crates/libp2p-core/RUSTSEC-0000-0000.md
+++ b/crates/libp2p-core/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libp2p-core"
+date = "2022-02-07"
+categories = ["crypto-failure"]
+
+[affected]
+functions = { "libp2p_core::PeerRecord::from_signed_envelope" = [">= 0.30.0"] }
+
+[versions]
+patched = [">= 0.31.1"]
+```
+
+# Failure to verify the public key of a `SignedEnvelope` against the `PeerId` in a `PeerRecord`
+
+Affected versions of this crate did not check that the public key the signature was created with matches the peer ID of the peer record. 
+Any combination was considered valid.
+
+This allows an attacker to republish an existing `PeerRecord` with a different `PeerId`.


### PR DESCRIPTION
I am a maintainer of this crate and we have already published a fix for it. Opening this advisory so folks get notified of the vulnerability and can upgrade quickly.