### PR TITLE
Mark mio-uds as deprecated

### DIFF
--- a/crates/mio-uds/RUSTSEC-0000-0000.md
+++ b/crates/mio-uds/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "mio-uds"
+date = "2020-02-09"
+informational = "unmaintained"
+url = "https://github.com/deprecrated/mio-uds/commit/32d27e91be614936194d8555bdda8d8a776a9b8e"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# `mio-uds` is deprecated/unmaintained
+
+The [`mio-uds`](https://crates.io/crates/tokio-proto) crate has been deprecated. Unix Domain Sockets are supported in `mio` since its 0.7 release.

--- a/crates/mio-uds/RUSTSEC-0000-0000.md
+++ b/crates/mio-uds/RUSTSEC-0000-0000.md
@@ -13,4 +13,4 @@ unaffected = []
 
 # `mio-uds` is deprecated/unmaintained
 
-The [`mio-uds`](https://crates.io/crates/tokio-proto) crate has been deprecated. Unix Domain Sockets are supported in `mio` since its 0.7 release.
+The [`mio-uds`](https://crates.io/crates/mio-uds) crate has been deprecated. Unix Domain Sockets are supported in `mio` since its 0.7 release.


### PR DESCRIPTION
`mio-uds` has been deprecated for almost 2 years now, but it's still seeing >10,000 daily downloads. But it looks like most of those downloads are coming through `tokio-uds` and `tokio-signal`, both of which also seem to be deprecated. I've tried to trace back the common users of these crates too, but it seems like all the git repos I end up on for the crates don't depend on them anymore on the latest commit. The biggest user I was able to track down was `websocat`.

So I really have no idea how disruptive publishing this would be. It seems fair to expect people to migrate after almost 2 years, but this crate may also be deep in people's dependency trees, so I wouldn't be surprised if people have CI configs that start to break because they're denying informational advisories.