### PR TITLE
List `markdown` as unmaintained

### DIFF
--- a/crates/markdown/RUSTSEC-0000-0000.md
+++ b/crates/markdown/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+ [advisory]
+ id = "RUSTSEC-0000-0000"
+ package = "markdown"
+ date = "2020-11-09"
+ informational = "unmaintained"
+ url = "https://github.com/johannhof/markdown.rs/issues/48"
+
+ [versions]
+ patched = []
+ unaffected = []
+ ```
+
+ # `markdown` is unmaintained
+
+ The [`markdown`](https://crates.io/crates/markdown) crate is no longer actively maintained. For Markdown parsing, you can use the [pulldown-cmark](https://crates.io/crates/pulldown-cmark) crate.
+ 

--- a/crates/markdown/RUSTSEC-0000-0000.md
+++ b/crates/markdown/RUSTSEC-0000-0000.md
@@ -1,17 +1,17 @@
 ```toml
- [advisory]
- id = "RUSTSEC-0000-0000"
- package = "markdown"
- date = "2020-11-09"
- informational = "unmaintained"
- url = "https://github.com/johannhof/markdown.rs/issues/48"
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "markdown"
+date = "2020-11-09"
+informational = "unmaintained"
+url = "https://github.com/johannhof/markdown.rs/issues/48"
 
- [versions]
- patched = []
- unaffected = []
- ```
+[versions]
+patched = []
+unaffected = []
+```
 
- # `markdown` is unmaintained
+# `markdown` is unmaintained
 
- The [`markdown`](https://crates.io/crates/markdown) crate is no longer actively maintained. For Markdown parsing, you can use the [pulldown-cmark](https://crates.io/crates/pulldown-cmark) crate.
+The [`markdown`](https://crates.io/crates/markdown) crate is no longer actively maintained. For Markdown parsing, you can use the [pulldown-cmark](https://crates.io/crates/pulldown-cmark) crate.
  

--- a/crates/markdown/RUSTSEC-0000-0000.md
+++ b/crates/markdown/RUSTSEC-0000-0000.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "markdown"
-date = "2020-11-09"
+date = "2022-01-17"
 informational = "unmaintained"
 url = "https://github.com/johannhof/markdown.rs/issues/48"
 


### PR DESCRIPTION
The `markdown` crate is, naturally, the first one that comes up if you're searching crates.io for "markdown". Unfortunately, that particular crate has not received any updates since November of 2020 despite several known issues with open PRs. I opened https://github.com/johannhof/markdown.rs/issues/48 to request an update on maintenance status nearing a month ago and have not heard anything back.

I believe the best course is to list the crate as unmaintained so folks will (hopefully) correct course more quickly than I did 😅.