### PR TITLE
Update RUSTSEC-2020-0150.md

### DIFF
--- a/crates/disrustor/RUSTSEC-2020-0150.md
+++ b/crates/disrustor/RUSTSEC-2020-0150.md
@@ -9,7 +9,7 @@ aliases = ["CVE-2020-36470"]
 cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
 
 [versions]
-patched = []
+patched = [">= 0.3"]
 ```
 
 # RingBuffer can create multiple mutable references and cause data races


### PR DESCRIPTION
This CVE has been fixed in version 0.3. Please see https://github.com/sklose/disrustor/issues/1 for details.