### PR TITLE
RUSTSEC-2021-0134: Remove recursive_reference from the list of alternatives

### DIFF
--- a/crates/rental/RUSTSEC-2021-0134.md
+++ b/crates/rental/RUSTSEC-2021-0134.md
@@ -17,6 +17,5 @@ The author encourages users to explore other solutions, or maintain a fork.
 Maintained alternatives include:
 
 * [`ouroboros`](https://crates.io/crates/ouroboros)
-* [`recursive_reference`](https://crates.io/crates/recursive_reference)
 * [`fortify`](https://crates.io/crates/fortify)
 * [`escher`](https://crates.io/crates/escher)


### PR DESCRIPTION
The author of `recursive_referene` has reached out to me and clarified that it does not serve the same use cases as `rental`