### PR TITLE
RUSTSEC-2022-0012: note that v0.10.0+ is patched

### DIFF
--- a/crates/arrow2/RUSTSEC-2022-0012.md
+++ b/crates/arrow2/RUSTSEC-2022-0012.md
@@ -7,7 +7,7 @@ url = "https://github.com/jorgecarleitao/arrow2/issues/880"
 categories = ["memory-corruption"]
 
 [versions]
-patched = [">= 0.7.1, < 0.8", ">= 0.8.2, < 0.9", ">= 0.9.2, < 0.10"]
+patched = [">= 0.7.1, < 0.8", ">= 0.8.2, < 0.9", ">= 0.9.2, < 0.10", ">= 0.10.0"]
 ```
 
 # Arrow2 allows double free in `safe` code


### PR DESCRIPTION
@jorgecarleitao can you confirm this is true?

----

As far as I can tell, v0.10.0+ was not affected by this bug [0]. The commit which
fixes the unsoundness landed in main before v0.10.0 was released.

[0]: https://github.com/jorgecarleitao/arrow2/commit/9d4342c5ff2ff1593232373a9998c3da18c7854d