### PR TITLE
fix platforms in RUSTSEC-2020-0071.md

### DIFF
--- a/crates/time/RUSTSEC-2020-0071.md
+++ b/crates/time/RUSTSEC-2020-0071.md
@@ -13,14 +13,13 @@ aliases = ["CVE-2020-26235"]
 # any Unix-like OS
 os = [
     "linux",
-    "Redox",
-    "rolaris",
+    "redox",
+    "solaris",
     "android",
     "ios",
     "macos",
     "netbsd",
     "openbsd",
-    "bitrig",
     "freebsd",
 ]
 [affected.functions]


### PR DESCRIPTION
Change platform names to those recognized by `platforms` crate

Drop `bitrig` which is not recognized by rustc