### PR TITLE
sass-rs is deprecated

### DIFF
--- a/crates/sass-rs/RUSTSEC-0000-0000.md
+++ b/crates/sass-rs/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "sass-rs"
+date = "2021-04-07"
+url = "https://github.com/compass-rs/sass-rs/issues/83"
+informational = "unmaintained"
+keywords = ["sass", "scss", "libsass"]
+[versions]
+patched = []
+```
+
+# `sass-rs` has been deprecated
+
+The `sass-rs` crate is not maintained anymore as libsass is deprecated.
+Consider using https://github.com/connorskees/grass or https://github.com/kaj/rsass instead.
+(Author's recomendation.)

--- a/crates/sass-rs/RUSTSEC-0000-0000.md
+++ b/crates/sass-rs/RUSTSEC-0000-0000.md
@@ -1,4 +1,4 @@
-```
+```toml
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "sass-rs"


### PR DESCRIPTION
Issue: https://github.com/compass-rs/sass-rs/issues/83

The deprecation/unmaintained status is also now noted in the README: https://github.com/compass-rs/sass-rs

> **This crate is not maintained anymore as libsass is deprecated. Consider using <https://github.com/connorskees/grass> or <https://github.com/kaj/rsass> instead.**