### PR TITLE
add crossbeam advisories for incorrect (unsound) zeroed memory

### DIFF
--- a/crates/crossbeam-channel/RUSTSEC-0000-0000.md
+++ b/crates/crossbeam-channel/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "crossbeam-channel"
+date = "2022-05-10"
+informational = "unsound"
+url = "https://github.com/crossbeam-rs/crossbeam/pull/458"
+
+[versions]
+patched = [">= 0.4.3"]
+```
+
+# Channel creates zero value of any type
+
+Affected versions of this crate called `mem::zeroed()` to create values of a user-supplied type `T`.
+This is unsound e.g. if `T` is a reference type (which must be non-null).
+ 
+The flaw was corrected by avoiding the use of `mem::zeroed()`, using `MaybeUninit` instead.

--- a/crates/crossbeam-queue/RUSTSEC-0000-0000.md
+++ b/crates/crossbeam-queue/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "crossbeam-queue"
+date = "2022-05-10"
+informational = "unsound"
+url = "https://github.com/crossbeam-rs/crossbeam/pull/458"
+
+[versions]
+patched = [">= 0.2.3"]
+```
+
+# `SegQueue` creates zero value of any type
+
+Affected versions of this crate called `mem::zeroed()` to create values of a user-supplied type `T`.
+This is unsound e.g. if `T` is a reference type (which must be non-null).
+ 
+The flaw was corrected by avoiding the use of `mem::zeroed()`, using `MaybeUninit` instead.

--- a/crates/crossbeam/RUSTSEC-0000-0000.md
+++ b/crates/crossbeam/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "crossbeam"
+date = "2022-05-10"
+informational = "unsound"
+url = "https://github.com/crossbeam-rs/crossbeam/pull/458"
+
+[versions]
+patched = [">= 0.7.0"]
+```
+
+# `SegQueue` creates zero value of any type
+
+Affected versions of this crate called `mem::zeroed()` to create values of a user-supplied type `T`.
+This is unsound e.g. if `T` is a reference type (which must be non-null).
+ 
+The flaw was corrected by avoiding the use of `mem::zeroed()`, using `MaybeUninit` instead.


### PR DESCRIPTION
This issue is ancient and has been fixed long ago, but it showed up in a [crater run](https://crater-reports.s3.amazonaws.com/pr-87041-1/try%23ddc023471205c186b40f4bf8ffb598008dbf4885/reg/advantage-0.1.0/log.txt) not too long ago so it might still be worth adding this to the database (considering that there are no other advisories against crossbeam-queue that might urge people to update).

Cc https://github.com/crossbeam-rs/crossbeam/pull/458