### PR TITLE
add hyper uninitialized memory advisory

### DIFF
--- a/crates/hyper/RUSTSEC-0000-0000.md
+++ b/crates/hyper/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "hyper"
+date = "2022-05-10"
+informational = "unsound"
+url = "https://github.com/hyperium/hyper/pull/2545"
+
+[versions]
+patched = [">= 0.4.12"]
+```
+
+# Parser creates invalid uninitialized value
+
+Affected versions of this crate called `mem::uninitialized()` in the HTTP1 parser to create values of type `httparse::Header` (from the `httparse` crate).
+This is unsound, since `Header` contains references and thus must be non-null.
+ 
+The flaw was corrected by avoiding the use of `mem::uninitialized()`, using `MaybeUninit` instead.


### PR DESCRIPTION
Adds an advisory for the fix in https://github.com/hyperium/hyper/pull/2545.