### PR TITLE
Add unmaintained crate advisory for `static_type_map`

### DIFF
--- a/crates/static_type_map/RUSTSEC-0000-0000.md
+++ b/crates/static_type_map/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "static_type_map"
+date = "2022-05-11"
+informational = "unmaintained"
+url = "https://github.com/malobre/erased_set/issues/6"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# `static_type_map` has been renamed to `erased_set`
+
+Please use the `erased_set` crate going forward:
+
+<https://github.com/malobre/erased_set>
+
+There will be no further releases of `static_type_map`.


### PR DESCRIPTION
It has been renamed to `erased_set`.

See latest [readme on crates.io](https://crates.io/crates/static_type_map) and https://github.com/malobre/erased_set/issues/6.