### PR TITLE
Add out-of-bounds read advisory for rocksdb

### DIFF
--- a/crates/rocksdb/RUSTSEC-0000-0000.md
+++ b/crates/rocksdb/RUSTSEC-0000-0000.md
@@ -1,0 +1,27 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rocksdb"
+date = "2022-05-11"
+url = "https://github.com/rust-rocksdb/rust-rocksdb/pull/616"
+categories = ["memory-corruption"]
+keywords = ["out-of-bounds read"]
+
+[versions]
+patched = [">= 0.19.0"]
+
+[affected]
+functions = { "rocksdb::DBWithThreadMode::open_cf_descriptors_with_ttl" = ["*"] }
+```
+
+# Out-of-bounds read when opening multiple column families with TTL
+
+Affected versions of this crate called the RocksDB C API
+`rocksdb_open_column_families_with_ttl()` with a pointer to a single integer
+TTL value, but one TTL value for each column family is expected.
+
+This is only relevant when using
+`rocksdb::DBWithThreadMode::open_cf_descriptors_with_ttl()` with multiple
+column families.
+
+This bug has been fixed in v0.19.0.

--- a/crates/rocksdb/RUSTSEC-0000-0000.md
+++ b/crates/rocksdb/RUSTSEC-0000-0000.md
@@ -11,7 +11,7 @@ keywords = ["out-of-bounds read"]
 patched = [">= 0.19.0"]
 
 [affected]
-functions = { "rocksdb::DBWithThreadMode::open_cf_descriptors_with_ttl" = ["*"] }
+functions = { "rocksdb::DBWithThreadMode::open_cf_descriptors_with_ttl" = ["< 0.19.0"] }
 ```
 
 # Out-of-bounds read when opening multiple column families with TTL


### PR DESCRIPTION
Draft. Will complete when the fix has landed.