### PR TITLE
Self-report double-checked-cell as unmaintained

### DIFF
--- a/crates/double-checked-cell/RUSTSEC-0000-0000.md
+++ b/crates/double-checked-cell/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "double-checked-cell"
+date = "2022-05-11"
+url = "https://github.com/niklasf/double-checked-cell/commit/9cf94d75316ef441033ce4c80def7c1a8c7643fe"
+informational = "unmaintained"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# double-checked-cell is unmaintained
+
+The author recommends switching to
+[`once_cell`](https://crates.io/crates/once_cell), which offers a superset
+of the functionality.


### PR DESCRIPTION
I'd like to report my own crate [double-checked-cell](https://crates.io/crates/double-checked-cell) as unmaintained, so that the remaining dependents are more likely to switch to a better alternative.