### PR TITLE
Withdraw RUSTSEC-2020-0159: unsound `localtime_r` call in `chrono`

### DIFF
--- a/crates/chrono/RUSTSEC-2020-0159.md
+++ b/crates/chrono/RUSTSEC-2020-0159.md
@@ -7,6 +7,8 @@ url = "https://github.com/chronotope/chrono/issues/499"
 categories = ["code-execution", "memory-corruption"]
 keywords = ["segfault"]
 related = ["CVE-2020-26235", "RUSTSEC-2020-0071"]
+withdrawn = "2022-05-12" # see rustsec/advisory-db#1190
+yanked = true
 
 [versions]
 patched = []


### PR DESCRIPTION
Per rustsec/advisory-db#1190, it would be good to move to a policy where we don't file advisories against crates which perform unsynchronized reads from the process environment, and instead focus only on crates which modify the process environment in an unsynchronized manner.