### PR TITLE
fix hyper patched version number

### DIFF
--- a/crates/hyper/RUSTSEC-2022-0022.md
+++ b/crates/hyper/RUSTSEC-2022-0022.md
@@ -7,7 +7,7 @@ informational = "unsound"
 url = "https://github.com/hyperium/hyper/pull/2545"
 
 [versions]
-patched = [">= 0.4.12"]
+patched = [">= 0.14.12"]
 ```
 
 # Parser creates invalid uninitialized value


### PR DESCRIPTION
I typo'd the version number in https://github.com/rustsec/advisory-db/pull/1232 *oops*