### PR TITLE
Add advisory documenting cargo-husky's behaviour

### DIFF
--- a/crates/cargo-husky/RUSTSEC-0000-0000.md
+++ b/crates/cargo-husky/RUSTSEC-0000-0000.md
@@ -1,0 +1,54 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "cargo-husky"
+date = "2022-05-10"
+url = "https://crates.io/crates/cargo-husky/1.5.0"
+categories = ["code-execution"]
+keywords = ["intentional"]
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# cargo-husky's build.rs edits git hooks of the building user
+
+The *purpose* of the [cargo-husky
+package](https://lib.rs/crates/cargo-husky) is to automatatically
+install git hooks into the user's git tree, so that future git
+operations by the user will run various checks etc.  The precise
+git hooks are controlled by the depending packages.
+
+A user who obtains the source code for something which depends on
+cargo-husky, and runs `cargo test`, will likely find that their git
+hooks have been amended.
+
+## Working as intended
+
+This behaviour of cargo-husky is by design.  It is precisely the
+intent of the authors of the cargo-husky package, and presumably also
+of the authors of the packages which declare a dependency on
+cargo-husky.
+
+However, more relevant is the likely intent and opinion of the user
+who is running the build:
+
+A user who builds a package which has no outstanding RustSec
+advisories is entitled to expect that the RustSec project is not aware
+of intentional use of build.rs (or proc macros, etc.) to perform
+surprising actions like modifying files outside the build tree.
+
+## Clarification
+
+The existence of this advisory does not mean that the cargo-husky
+package ought not to exist.  There are no doubt situations where it is
+appropriate.  Imposing cargo-husky's behaviour on users building a
+package remains a choice for that package's authors.
+
+However, when cargo-husky is used by "general crates" in the Rust
+ecosystem, users ought to be at least warned about it.  The RustSec
+database is the right publication channel for that warning.
+
+Whether to use software with this behaviour, and what countermeasures
+to take, is then a decision for the properly informed user.


### PR DESCRIPTION
Hi.   Someone I know was recently surprised to discover some things cargo-husky had done on their system. On reflection, I concluded that the behaviour, while intentional, is something that a user who builds a depending package ought to be told about, via the RustSec advisory database.

Here is my proposal for that advisory.

I discussed this with cargo-husky upstream in https://github.com/rhysd/cargo-husky/issues/34 and they said they were OK with my submitting this here.