### PR TITLE
Revert "Withdraw RUSTSEC-2020-0071: Potential segfault in the time crate (#1242)"

### DIFF
--- a/crates/time/RUSTSEC-2020-0071.md
+++ b/crates/time/RUSTSEC-2020-0071.md
@@ -8,8 +8,6 @@ categories = ["code-execution", "memory-corruption"]
 cvss = "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 keywords = ["segfault"]
 aliases = ["CVE-2020-26235"]
-withdrawn = "2022-05-13" # see rustsec/advisory-db#1190
-yanked = true
 
 [affected]
 # any Unix-like OS


### PR DESCRIPTION
This reverts commit a47cd63007d20e5e0d58c4de945ac2e6b7cd70d0.

The advisory was withdrawn based on discussions around whether read-only
environment variable access constitutes a vulnerability.

However, per the `time` crate's author @jhpratt, the crate also modifies
the environment and therefore the advisory should *not* be withdrawn:

https://github.com/rustsec/advisory-db/pull/1242#issuecomment-1144903688