### PR TITLE
Add patched version to `im` RUSTSEC-2020-0096

### DIFF
--- a/crates/im/RUSTSEC-2020-0096.md
+++ b/crates/im/RUSTSEC-2020-0096.md
@@ -10,7 +10,7 @@ categories = ["thread-safety"]
 informational = "unsound"
 
 [versions]
-patched = []
+patched = [">= 15.1.0"]
 unaffected = ["< 12.0.0"]
 ```
 


### PR DESCRIPTION
Fixed in https://github.com/bodil/im-rs/commit/0b3a7b228b0fe70446393f55c8b893f349f3f6bd

Brought to our attention by https://github.com/rustsec/advisory-db/pull/569#issuecomment-1149020755