### PR TITLE
Report data race/memory corruption in crossbeam 0.2

### DIFF
--- a/crates/crossbeam/RUSTSEC-0000-0000.md
+++ b/crates/crossbeam/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "crossbeam"
+date = "2022-06-07"
+categories = ["thread-safety", "memory-corruption"]
+url = "https://github.com/crossbeam-rs/crossbeam/pull/98"
+
+[versions]
+patched = [">= 0.3.0"]
+```
+
+# `MsQueue` `push`/`pop` use the wrong orderings
+
+Affected versions of this crate use orderings which are too weak to support this data structure.
+It is likely this has caused memory corruption in the wild: <https://github.com/crossbeam-rs/crossbeam/issues/97#issuecomment-412785919>.


### PR DESCRIPTION
It is entirely unclear to me how far back this should extend, because it looks like crossbeam `0.2.9` and older don't compile (they try to do transmutes where the src and dst sizes don't match).