### PR TITLE
Fix RUSTSEC-2022-0025,26,27 openssl-src for the 111 stream

### DIFF
--- a/crates/openssl-src/RUSTSEC-2022-0025.md
+++ b/crates/openssl-src/RUSTSEC-2022-0025.md
@@ -9,8 +9,7 @@ date = "2022-05-03"
 url = "https://www.openssl.org/news/secadv/20220503.txt"
 
 [versions]
-patched = [">= 300.0.6"]
-unaffected = ["< 300.0"]
+patched = [">= 300.0.6", ">= 111.20.0"]
 ```
 
 # Resource leakage when decoding certificates and keys

--- a/crates/openssl-src/RUSTSEC-2022-0025.md
+++ b/crates/openssl-src/RUSTSEC-2022-0025.md
@@ -9,7 +9,8 @@ date = "2022-05-03"
 url = "https://www.openssl.org/news/secadv/20220503.txt"
 
 [versions]
-patched = [">= 300.0.6", ">= 111.20.0"]
+patched = [">= 300.0.6"]
+unaffected = ["< 300.0.0"]
 ```
 
 # Resource leakage when decoding certificates and keys

--- a/crates/openssl-src/RUSTSEC-2022-0025.md
+++ b/crates/openssl-src/RUSTSEC-2022-0025.md
@@ -9,8 +9,7 @@ date = "2022-05-03"
 url = "https://www.openssl.org/news/secadv/20220503.txt"
 
 [versions]
-patched = [">= 300.0.6"]
-unaffected = ["< 300.0.0"]
+patched = [">= 111.20.0, < 300.0.0", ">= 300.0.6"]
 ```
 
 # Resource leakage when decoding certificates and keys

--- a/crates/openssl-src/RUSTSEC-2022-0026.md
+++ b/crates/openssl-src/RUSTSEC-2022-0026.md
@@ -9,7 +9,8 @@ date = "2022-05-03"
 url = "https://www.openssl.org/news/secadv/20220503.txt"
 
 [versions]
-patched = [">= 300.0.6", ">= 111.20.0"]
+patched = [">= 300.0.6"]
+unaffected = ["< 300.0.0"]
 ```
 
 # Incorrect MAC key used in the RC4-MD5 ciphersuite

--- a/crates/openssl-src/RUSTSEC-2022-0026.md
+++ b/crates/openssl-src/RUSTSEC-2022-0026.md
@@ -9,8 +9,7 @@ date = "2022-05-03"
 url = "https://www.openssl.org/news/secadv/20220503.txt"
 
 [versions]
-patched = [">= 300.0.6"]
-unaffected = ["< 300.0.0"]
+patched = [">= 111.20.0, < 300.0.0", ">= 300.0.6"]
 ```
 
 # Incorrect MAC key used in the RC4-MD5 ciphersuite

--- a/crates/openssl-src/RUSTSEC-2022-0026.md
+++ b/crates/openssl-src/RUSTSEC-2022-0026.md
@@ -9,8 +9,7 @@ date = "2022-05-03"
 url = "https://www.openssl.org/news/secadv/20220503.txt"
 
 [versions]
-patched = [">= 300.0.6"]
-unaffected = ["< 300.0"]
+patched = [">= 300.0.6", ">= 111.20.0"]
 ```
 
 # Incorrect MAC key used in the RC4-MD5 ciphersuite

--- a/crates/openssl-src/RUSTSEC-2022-0027.md
+++ b/crates/openssl-src/RUSTSEC-2022-0027.md
@@ -9,8 +9,7 @@ date = "2022-05-03"
 url = "https://www.openssl.org/news/secadv/20220503.txt"
 
 [versions]
-patched = [">= 300.0.6"]
-unaffected = ["< 300.0"]
+patched = [">= 300.0.6", ">= 111.20.0"]
 ```
 
 # `OCSP_basic_verify` may incorrectly verify the response signing certificate

--- a/crates/openssl-src/RUSTSEC-2022-0027.md
+++ b/crates/openssl-src/RUSTSEC-2022-0027.md
@@ -9,7 +9,8 @@ date = "2022-05-03"
 url = "https://www.openssl.org/news/secadv/20220503.txt"
 
 [versions]
-patched = [">= 300.0.6", ">= 111.20.0"]
+patched = [">= 300.0.6"]
+unaffected = ["< 300.0.0"]
 ```
 
 # `OCSP_basic_verify` may incorrectly verify the response signing certificate

--- a/crates/openssl-src/RUSTSEC-2022-0027.md
+++ b/crates/openssl-src/RUSTSEC-2022-0027.md
@@ -9,8 +9,7 @@ date = "2022-05-03"
 url = "https://www.openssl.org/news/secadv/20220503.txt"
 
 [versions]
-patched = [">= 300.0.6"]
-unaffected = ["< 300.0.0"]
+patched = [">= 111.20.0, < 300.0.0", ">= 300.0.6"]
 ```
 
 # `OCSP_basic_verify` may incorrectly verify the response signing certificate


### PR DESCRIPTION
Closes #1262 

On 2022-0025, 26 and 27 111 is affected and is reflected on openssl-src 111.20.0 that brings 1.1.1o (patched)

I folllowed RUSTSEC-2022-0014.md way to give effect to this