### PR TITLE
Add unmaintained `clipboard`

### DIFF
--- a/crates/clipboard/RUSTSEC-0000-0000.md
+++ b/crates/clipboard/RUSTSEC-0000-0000.md
@@ -4,7 +4,8 @@ id = "RUSTSEC-0000-0000"
 package = "clipboard"
 date = "2022-06-25"
 informational = "unmaintained"
-url = "https://github.com/aweinstock314/rust-clipboard/issues"
+url = "https://github.com/aweinstock314/rust-clipboard/issues/91"
+references = ["https://github.com/aweinstock314/rust-clipboard/issues/90"]
 
 [versions]
 patched = []

--- a/crates/clipboard/RUSTSEC-0000-0000.md
+++ b/crates/clipboard/RUSTSEC-0000-0000.md
@@ -4,22 +4,23 @@ id = "RUSTSEC-0000-0000"
 package = "clipboard"
 date = "2022-06-25"
 informational = "unmaintained"
-url = "https://github.com/aweinstock314/rust-clipboard/issues/91"
+url = "https://github.com/aweinstock314/rust-clipboard/issues"
 
 [versions]
 patched = []
 ```
 
-# clipboard is unmaintained
+# clipboard is Unmaintained
 
-The last release was almost 4 years ago and the repository is effectively abandoned, with many outstanding issues
-and pull requests that have no activity. Due to this, there is a very low chance any security issues would be
-fixed.
+Last release was almost 4 years ago and the repository with outstanding issues and pull requests seems to be abandoned by the maintainer.
 
-Additionally, the sole maintainer of the repository has not been very active in general, which has
-the chance of presenting heightened supply chain risk.
+In addition the sole maintainer account may be abandoned that may represent account takeover risk.
 
-Possible Alternative(s): 
+Current outstanding issues include vulnerable dependencies that all together may mean that security issues may not be addressed now or in the future.
+
+## Possible Alternative(s)
+
+The below list has not been vetted in any way and may or may not contain alternatives;
 
 - [`arboard`](https://crates.io/crates/arboard)
 - [`clipboard-win`](https://crates.io/crates/clipboard-win) (Windows only)

--- a/crates/clipboard/RUSTSEC-0000-0000.md
+++ b/crates/clipboard/RUSTSEC-0000-0000.md
@@ -1,0 +1,27 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "clipboard"
+date = "2022-06-25"
+informational = "unmaintained"
+url = "https://github.com/aweinstock314/rust-clipboard/issues/91"
+
+[versions]
+patched = []
+```
+
+# clipboard is unmaintained
+
+The last release was almost 4 years ago and the repository is effectively abandoned, with many outstanding issues
+and pull requests that have no activity. Due to this, there is a very low chance any security issues would be
+fixed.
+
+Additionally, the sole maintainer of the repository has not been very active in general, which has
+the chance of presenting heightened supply chain risk.
+
+Possible Alternative(s): 
+
+- [`arboard`](https://crates.io/crates/arboard)
+- [`clipboard-win`](https://crates.io/crates/clipboard-win) (Windows only)
+- [`copy-pasta`](https://crates.io/crates/copypasta)
+- [`x11-clipboard`](https://crates.io/crates/x11-clipboard) (Linux/BSD only)


### PR DESCRIPTION
This PR adds an maintenance warning about the `rust-clipboard` crate. It has not been updated in years and, at this point, two forks of it are the most viable alternatives. Due to its age, it also depends on several unsound crate versions too. As a disclaimer, I am the primary maintainer of the `arboard` crate.

I also included platform-specific alternatives in case users are only developing for a single platform. Please let me know if I should remove them. 