### PR TITLE
Add unmaintained advisory for term_size

### DIFF
--- a/crates/term_size/RUSTSEC-0000-0000.md
+++ b/crates/term_size/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "term_size"
+date = "2020-11-03"
+informational = "unmaintained"
+url = "https://github.com/clap-rs/term_size-rs/pull/31"
+[versions]
+patched = []
+unaffected = []
+```
+
+# `term_size` is unmaintained; use `terminal_size` instead
+
+The [`term_size`](https://crates.io/crates/term_size) crate is no longer maintained. Consider using
+[`terminal_size`](https://crates.io/crates/terminal_size) instead.


### PR DESCRIPTION
Note that I've used the date when the unmaintained status was announced in the project's README for the date field.