### PR TITLE
Add unmaintained advisory for audiotags

### DIFF
--- a/crates/audiotags/RUSTSEC-0000-0000.md
+++ b/crates/audiotags/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "audiotags"
+date = "2022-07-28"
+informational = "unmaintained"
+url = "https://github.com/TianyiShi2001/audiotags"
+
+[versions]
+patched = []
+```
+
+# `audiotags` is unmaintained
+
+The author no longer has time to maintain the crate,
+and the repository has been archived. The author
+recommends switching to [`lofty`](https://crates.io/crates/lofty).


### PR DESCRIPTION
The repo has sat dormant for nearly two years. I spoke with the author over email, and they no longer have time to work on the crate. They have since archived it.