### PR TITLE
RUSTSEC-2020-0159 (chrono): add patched version

### DIFF
--- a/crates/chrono/RUSTSEC-2020-0159.md
+++ b/crates/chrono/RUSTSEC-2020-0159.md
@@ -11,7 +11,7 @@ withdrawn = "2022-05-12" # see rustsec/advisory-db#1190
 yanked = true
 
 [versions]
-patched = []
+patched = [">=0.4.20"]
 ```
 
 # Potential segfault in `localtime_r` invocations


### PR DESCRIPTION
The 0.4.20 release of `chrono` includes a pure-Rust replacement for `localtime_r` which eliminates this issue.