### PR TITLE
Bump rust-admin 0.8.0 --skip-namecheck rustdecimal

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,13 +16,13 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cargo/bin
-        key: rustsec-admin-v0.7.0
+        key: rustsec-admin-v0.8.0
 
     - name: Install rustsec-admin
       run: |
         if [ ! -f $HOME/.cargo/bin/rustsec-admin ]; then
-            cargo install rustsec-admin --vers 0.7.0
+            cargo install rustsec-admin --vers 0.8.0
         fi
 
     - name: Lint advisories
-      run: rustsec-admin lint
+      run: rustsec-admin lint --skip-namecheck rustdecimal


### PR DESCRIPTION
Unblocks #1234 for rustdecimal

rustsec-admin 0.8.0 changes:
https://github.com/rustsec/rustsec/pull/620
https://github.com/rustsec/rustsec/pull/621

And adds --skip-namecheck rustdecimal