### PR TITLE
RUSTSEC-2020-0159: remove "withdrawn"

### DIFF
--- a/crates/chrono/RUSTSEC-2020-0159.md
+++ b/crates/chrono/RUSTSEC-2020-0159.md
@@ -7,7 +7,6 @@ url = "https://github.com/chronotope/chrono/issues/499"
 categories = ["code-execution", "memory-corruption"]
 keywords = ["segfault"]
 related = ["CVE-2020-26235", "RUSTSEC-2020-0071"]
-withdrawn = "2022-05-12" # see rustsec/advisory-db#1190
 yanked = true
 
 [versions]

--- a/crates/chrono/RUSTSEC-2020-0159.md
+++ b/crates/chrono/RUSTSEC-2020-0159.md
@@ -7,7 +7,6 @@ url = "https://github.com/chronotope/chrono/issues/499"
 categories = ["code-execution", "memory-corruption"]
 keywords = ["segfault"]
 related = ["CVE-2020-26235", "RUSTSEC-2020-0071"]
-yanked = true
 
 [versions]
 patched = [">=0.4.20"]


### PR DESCRIPTION
Now that there's an actionable fix, we should encourage people to upgrade