### PR TITLE
Remove redundant lint check from assign-ids

### DIFF
--- a/.github/workflows/assign-ids.yml
+++ b/.github/workflows/assign-ids.yml
@@ -35,9 +35,6 @@ jobs:
         echo "This prevents duplicate ID assignment due to a race between those jobs." >> .duplicate-id-guard
         ls -R . | sha256sum >> .duplicate-id-guard
 
-    - name: Lint advisories
-      run: rustsec-admin lint
-
     - name: Create pull request
       uses: peter-evans/create-pull-request@v3
       with:


### PR DESCRIPTION
- rustdecimal ended up failing in CI at assign-id phase
- Lint check is done in the generated PR anyways so the lintcheck there is redundant where as on old push it wasn't