### PR TITLE
Add tower-http 2022 version

### DIFF
--- a/crates/tower-http/RUSTSEC-0000-0000.md
+++ b/crates/tower-http/RUSTSEC-0000-0000.md
@@ -1,0 +1,28 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tower-http"
+date = "2022-01-21"
+url = "https://github.com/tower-rs/tower-http/pull/204"
+categories = ["file-disclosure"]
+keywords = ["directory traversal", "http"]
+
+[affected]
+os = ["windows"]
+
+[versions]
+patched = [">= 0.2.1", ">= 0.1.3, < 0.2.0"]
+```
+
+# Improper validation of Windows paths could lead to directory traversal attack
+
+`tower_http::services::fs::ServeDir` didn't correctly validate Windows paths
+meaning paths like `/foo/bar/c:/windows/web/screen/img101.png` would be allowed
+and respond with the contents of `c:/windows/web/screen/img101.png`. Thus users
+could potentially read files anywhere on the filesystem.
+
+This only impacts Windows. Linux and other unix likes are not impacted by this.
+
+See [tower-http#204] for more details.
+
+[tower-http#204]: https://github.com/tower-rs/tower-http/pull/204


### PR DESCRIPTION
See: https://github.com/rustsec/advisory-db/pull/1319
Moving existing tower advisory from year 2021 to 2022