### PR TITLE
Fix async-graphql patched

### DIFF
--- a/crates/async-graphql/RUSTSEC-2022-0037.md
+++ b/crates/async-graphql/RUSTSEC-2022-0037.md
@@ -10,7 +10,7 @@ aliases = ["GHSA-xq3c-8gqm-v648"]
 related = ["GHSA-4rx6-g5vg-5f3j"]
 
 [versions]
-patched = [">= 0.15.10"]
+patched = [">= 4.0.6"]
 ```
 
 # Denial of service on deeply nested fragment requests


### PR DESCRIPTION
@djc looks like I didn't catch the patched on async-graphql

https://github.com/rustsec/advisory-db/issues/1285
https://github.com/rustsec/advisory-db/pull/1290
https://github.com/rustsec/advisory-db/pull/1298

Could you sanity ok this for me pls ? Thanks