### PR TITLE
oqs: PQC signature scheme Rainbow level I parameterset broken

### DIFF
--- a/crates/oqs/RUSTSEC-0000-0000.md
+++ b/crates/oqs/RUSTSEC-0000-0000.md
@@ -1,0 +1,29 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "oqs"
+date = "2022-02-25"
+url = "https://groups.google.com/a/list.nist.gov/g/pqc-forum/c/KFgw5_qCXiI?pli=1"
+categories = ["crypto-failure"]
+
+
+# Optional: metadata which narrows the scope of what this advisory affects
+[affected.functions]
+"oqs::sig::Algorithm::RainbowIaClassic" = ["< 0.5.0, >= 0.2.0"]
+"oqs::sig::Algorithm::RainbowIaCyclic" = ["< 0.5.0, >= 0.2.0"]
+"oqs::sig::Algorithm::RainbowIaCyclicCompressed" = ["< 0.5.0, >= 0.2.0"]
+"oqs::sig::Algorithm::RainbowIClassic" = ["< 0.7.2, >= 0.5.0"]
+"oqs::sig::Algorithm::RainbowICircumzenithal" = ["< 0.7.2, >= 0.5.0"]
+"oqs::sig::Algorithm::RainbowICompressed" = ["< 0.7.2, >= 0.5.0"]
+
+
+# Versions which include fixes for this vulnerability (mandatory)
+[versions]
+patched = [">= 0.7.2"]
+```
+
+# Post-Quantum Signature scheme Rainbow level I parametersets broken
+
+Ward Beullens found a practical key-recovery attack against Rainbow.
+The level I parametersets are removed from liboqs starting from version `0.7.2`.
+Find the scientific details in [Breaking Rainbow Takes a Weekend on a Laptop](https://eprint.iacr.org/2022/214).

--- a/crates/oqs/RUSTSEC-0000-0000.md
+++ b/crates/oqs/RUSTSEC-0000-0000.md
@@ -25,3 +25,5 @@ patched = [">= 0.7.2"]
 Ward Beullens found a practical key-recovery attack against Rainbow.
 The level I parametersets are removed from liboqs starting from version `0.7.2`.
 Find the scientific details in [Breaking Rainbow Takes a Weekend on a Laptop](https://eprint.iacr.org/2022/214).
+
+This means all the `oqs::sig::Algorithm::RainbowI*` variants are insecure.

--- a/crates/oqs/RUSTSEC-0000-0000.md
+++ b/crates/oqs/RUSTSEC-0000-0000.md
@@ -6,15 +6,13 @@ date = "2022-02-25"
 url = "https://groups.google.com/a/list.nist.gov/g/pqc-forum/c/KFgw5_qCXiI?pli=1"
 categories = ["crypto-failure"]
 
-
-# Optional: metadata which narrows the scope of what this advisory affects
-[affected.functions]
-"oqs::sig::Algorithm::RainbowIaClassic" = ["< 0.5.0, >= 0.2.0"]
-"oqs::sig::Algorithm::RainbowIaCyclic" = ["< 0.5.0, >= 0.2.0"]
-"oqs::sig::Algorithm::RainbowIaCyclicCompressed" = ["< 0.5.0, >= 0.2.0"]
-"oqs::sig::Algorithm::RainbowIClassic" = ["< 0.7.2, >= 0.5.0"]
-"oqs::sig::Algorithm::RainbowICircumzenithal" = ["< 0.7.2, >= 0.5.0"]
-"oqs::sig::Algorithm::RainbowICompressed" = ["< 0.7.2, >= 0.5.0"]
+# affected enum variants ([affected.functions] requires functions)
+#"oqs::sig::Algorithm::RainbowIaClassic" = ["< 0.5.0, >= 0.2.0"]
+#"oqs::sig::Algorithm::RainbowIaCyclic" = ["< 0.5.0, >= 0.2.0"]
+#"oqs::sig::Algorithm::RainbowIaCyclicCompressed" = ["< 0.5.0, >= 0.2.0"]
+#"oqs::sig::Algorithm::RainbowIClassic" = ["< 0.7.2, >= 0.5.0"]
+#"oqs::sig::Algorithm::RainbowICircumzenithal" = ["< 0.7.2, >= 0.5.0"]
+#"oqs::sig::Algorithm::RainbowICompressed" = ["< 0.7.2, >= 0.5.0"]
 
 
 # Versions which include fixes for this vulnerability (mandatory)


### PR DESCRIPTION
The Rainbow I parameterset as packaged in liboqs has been proven to be vulnerable to cryptanalysis. It's been removed from the upcoming (but not yet out) 0.7.2 release.