### PR TITLE
oqs: SIKE and SIDH are insecure

### DIFF
--- a/crates/oqs/RUSTSEC-0000-0000.md
+++ b/crates/oqs/RUSTSEC-0000-0000.md
@@ -1,0 +1,37 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "oqs"
+date = "2022-07-30"
+categories = ["crypto-failure"]
+
+[affected.functions]
+"oqs::kem::Algorithm::SidhP434" = ["*"]
+"oqs::kem::Algorithm::SidhP503" = ["*"]
+"oqs::kem::Algorithm::SidhP610" = ["*"]
+"oqs::kem::Algorithm::SidhP751" = ["*"]
+"oqs::kem::Algorithm::SidhP434Compressed" = ["*"]
+"oqs::kem::Algorithm::SidhP503Compressed" = ["*"]
+"oqs::kem::Algorithm::SidhP610Compressed" = ["*"]
+"oqs::kem::Algorithm::SidhP751Compressed" = ["*"]
+"oqs::kem::Algorithm::SikeP434" = ["*"]
+"oqs::kem::Algorithm::SikeP503" = ["*"]
+"oqs::kem::Algorithm::SikeP610" = ["*"]
+"oqs::kem::Algorithm::SikeP751" = ["*"]
+"oqs::kem::Algorithm::SikeP434Compressed" = ["*"]
+"oqs::kem::Algorithm::SikeP503Compressed" = ["*"]
+"oqs::kem::Algorithm::SikeP610Compressed" = ["*"]
+"oqs::kem::Algorithm::SikeP751Compressed" = ["*"]
+
+
+[versions]
+patched = [">= 0.7.2"]
+```
+
+# Post-Quantum Key Encapsulation Mechanism SIKE broken
+
+Wouter Castryck and Thomas Decru presented an efficient key recovery attack on the SIDH protocol.
+As a result, the secret key of SIKEp751 can be recovered in a matter of hours.
+The SIKE and SIDH schemes will be removed from oqs 0.7.2.
+
+[An efficient key recovery attack on SIDH (preliminary version)](https://eprint.iacr.org/2022/975)


### PR DESCRIPTION
Wouter Castryck and Thomas Decru presented an efficient key recovery attack on the SIDH protocol.
As a result, the secret key of SIKEp751 can be recovered in a matter of hours.
The SIKE and SIDH schemes will be removed from the next oqs version 0.7.2.