### PR TITLE
Add advisory `tempfile`

### DIFF
--- a/crates/tempdir/RUSTSEC-2018-0017.md
+++ b/crates/tempdir/RUSTSEC-2018-0017.md
@@ -13,5 +13,4 @@ unaffected = []
 
 # `tempdir` crate has been deprecated; use `tempfile` instead
 
-The [`tempdir`](https://crates.io/crates/tempdir) crate has been deprecated
-and the functionality is merged into [`tempfile`](https://crates.io/crates/tempfile).
+The [`tempdir`](https://crates.io/crates/tempdir) crate has been deprecated.

--- a/crates/tempfile/RUSTSEC-0000-0000.md
+++ b/crates/tempfile/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tempfile"
+date = "2022-05-01"
+url = "https://github.com/Stebalien/tempfile/issues/178"
+references = ["https://github.com/Stebalien/tempfile/pull/141", "https://github.com/Stebalien/tempfile/pull/162", "https://owasp.org/www-community/vulnerabilities/Insecure_Temporary_File"]
+keywords = ["tempfile"]
+[versions]
+patched = []
+```
+
+# tempfile uses predictable RNG
+
+tempfile makes security guarantees that are not met by using predictable random number generator.
+
+The vectors may or may not vary by the platform and the use of the library.

--- a/crates/temporary/RUSTSEC-2018-0022.md
+++ b/crates/temporary/RUSTSEC-2018-0022.md
@@ -28,5 +28,3 @@ fn random_seed(_: &Path, _: &str) -> [u64; 2] {
 This has been resolved in the 0.6.4 release.
 
 The crate is not intended to be used outside of a testing environment.
-
-For a general purpose crate to create temporary directories, [`tempfile`](https://crates.io/crates/tempfile) is an alternative for this crate.


### PR DESCRIPTION
Since this crate also advertises itself as being secure and portable it might be feasible to remove recommendations and / or flag an advisory either as informational or regular where the crate makes these guarantees and may not provide them.

https://github.com/Stebalien/tempfile/issues/178

We previously recommended to use `tempfile` at `temporary` here: https://github.com/rustsec/advisory-db/pull/1196

https://owasp.org/www-community/vulnerabilities/Insecure_Temporary_File

**Proposal**

Removing the recommendation to use `tempfile` from the earlier `temporary` advisory
Also removes advertised reference from `tempdir`

Should we also file an advisory in addition not recommending it ? 

There is no real PoC or anything but :woman_shrugging: 

Perhaps we should use the `informatonal = "notice"` category finally ?

@5225225 and @vks could you review this please ?