### PR TITLE
Add notice `ed25519-dalek`

### DIFF
--- a/crates/ed25519-dalek/RUSTSEC-0000-0000.md
+++ b/crates/ed25519-dalek/RUSTSEC-0000-0000.md
@@ -14,6 +14,8 @@ patched = []
 
 Potential signature exploit with [PoC](https://github.com/MystenLabs/ed25519-unsafe-libs) is proposed.
 
+Exploit would require public API misuse that would result to private key exposure.
+
 No patched versions are available at this time.
 
 While a pull request with some fixes is outstanding,

--- a/crates/ed25519-dalek/RUSTSEC-0000-0000.md
+++ b/crates/ed25519-dalek/RUSTSEC-0000-0000.md
@@ -5,12 +5,12 @@ package = "ed25519-dalek"
 date = "2022-02-16"
 url = "https://github.com/dalek-cryptography/ed25519-dalek/issues/209"
 references = ["https://github.com/MystenLabs/ed25519-unsafe-libs", "https://github.com/dalek-cryptography/ed25519-dalek/pull/205", "https://github.com/dalek-cryptography/ed25519-dalek/issues/192"]
-categories = ["crypto-failure"]
+informational = "notice"
 
 [versions]
 patched = []
 ```
-# ed25519-dalek is Unmaintained and potential Exploit
+# ed25519-dalek is Unmaintained and Public API misuse concern
 
 Potential signature exploit with [PoC](https://github.com/MystenLabs/ed25519-unsafe-libs) is proposed.
 

--- a/crates/ed25519-dalek/RUSTSEC-0000-0000.md
+++ b/crates/ed25519-dalek/RUSTSEC-0000-0000.md
@@ -1,0 +1,28 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "ed25519-dalek"
+date = "2022-02-16"
+url = "https://github.com/dalek-cryptography/ed25519-dalek/issues/209"
+references = ["https://github.com/MystenLabs/ed25519-unsafe-libs", "https://github.com/dalek-cryptography/ed25519-dalek/pull/205", "https://github.com/dalek-cryptography/ed25519-dalek/issues/192"]
+categories = ["crypto-failure"]
+
+[versions]
+patched = []
+```
+# ed25519-dalek is Unmaintained and potential Exploit
+
+Potential signature exploit with [PoC](https://github.com/MystenLabs/ed25519-unsafe-libs) is proposed.
+
+No patched versions are available at this time.
+
+While a pull request with some fixes is outstanding,
+
+The maintainer(s) appear to be unresponsive.
+
+## Possible Alternatives
+
+Alternatives may or may not be available:
+
+- [ed25519-compact](https://crates.io/crates/ed25519-compact)
+- [Awesome Rust Cryptography](https://github.com/The-DevX-Initiative/RCIG_Coordination_Repo/blob/main/Awesome_Rust_Cryptography.md)

--- a/crates/rust-crypto/RUSTSEC-2016-0005.md
+++ b/crates/rust-crypto/RUSTSEC-2016-0005.md
@@ -23,9 +23,6 @@ is actively maintained.*
 We recommend you switch to one of the following crates instead, depending on
 which algorithms you need:
 
-- [dalek-cryptography GitHub Org]:
-  - Key agreement: [`x25519-dalek`]
-  - Signature algorithms: [`ed25519-dalek`]
 - [`ring`]:
   - AEAD algorithms: AES-GCM, ChaCha20Poly1305
   - Digest algorithms: SHA-256, SHA-384, SHA-512, SHA-512/256 (legacy: SHA-1)
@@ -54,7 +51,6 @@ which algorithms you need:
   - Password hashing: PBKDF2
   - Stream ciphers: ChaCha20 (IETF version), XChaCha20
 
-[dalek-cryptography GitHub Org]: https://github.com/dalek-cryptography
 [RustCrypto GitHub Org]: https://github.com/RustCrypto
 [`aes`]: https://crates.io/crates/aes
 [`aes-ctr`]: https://crates.io/crates/aes-ctr

--- a/crates/sodiumoxide/RUSTSEC-2021-0137.md
+++ b/crates/sodiumoxide/RUSTSEC-2021-0137.md
@@ -21,7 +21,6 @@ Alternatives may be found - not in any specific order:
 - [RustCrypto/xsalsa20poly1305](https://github.com/RustCrypto/AEADs/tree/master/xsalsa20poly1305) (`crypto_secretbox`)
 - [Signatory](https://crates.io/crates/signatory)
 - [ed25519-compact](https://crates.io/crates/ed25519-compact)
-- [ed25519-dalek](https://github.com/dalek-cryptography/ed25519-dalek)
 - [ring](https://github.com/briansmith/ring)
 
 Recommendations can be also found from:


### PR DESCRIPTION
Closes #1360 

**NOTE: This does NOT necessarily mean the crypto on ed25519-dalek is inherently broken or insecure as of now**

_e.g. Depending on how we classify / see broken / insecure - people often see crypto-failure where pub API was not misused_

https://github.com/dalek-cryptography/ed25519-dalek/issues/192
https://github.com/dalek-cryptography/ed25519-dalek/issues/209
https://github.com/dalek-cryptography/ed25519-dalek/pull/205

EDIT: This is about older versions having pub API weakness which needs a notice. Not a maintenance issue at this stage.

Will Merge when the new release is merged which is still some time away.