### PR TITLE
Remove `yanked`

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,12 +16,12 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cargo/bin
-        key: rustsec-admin-v0.8.0
+        key: rustsec-admin-v0.8.1
 
     - name: Install rustsec-admin
       run: |
         if [ ! -f $HOME/.cargo/bin/rustsec-admin ]; then
-            cargo install rustsec-admin --vers 0.8.0
+            cargo install rustsec-admin --vers 0.8.1
         fi
 
     - name: Lint advisories

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ See [CONTRIBUTING.md] for more information.
 See [EXAMPLE_ADVISORY.md] for a template.
 
 Advisories are formatted in [Markdown] with [TOML] "front matter".
-Below is the schema of the "front matter" section of an advisory:
+
+Below is the schema of the [TOML] "front matter" section of an advisory:
 
 ```toml
 # Before you submit a PR using this template, **please delete the comments**
@@ -58,6 +59,9 @@ date = "2021-01-31"
 # URL to a long-form description of this issue, e.g. a GitHub issue/PR,
 # a change log entry, or a blogpost announcing the release (optional)
 url = "https://github.com/mystuff/mycrate/issues/123"
+
+# URL to additional helpful references regarding the advisory (optional)
+#references = ["https://github.com/mystuff/mycrate/discussions/1"]
 
 # Optional: Indicates the type of informational advisory
 #  - "unsound" for soundness issues
@@ -115,6 +119,8 @@ patched = [">= 1.2.0"]
 # Versions which were never vulnerable (optional)
 #unaffected = ["< 1.1.0"]
 ```
+
+The above [TOML] "front matter" is followed by the long description in [Markdown] format.
 
 ## License
 

--- a/crates/directories/RUSTSEC-2020-0054.md
+++ b/crates/directories/RUSTSEC-2020-0054.md
@@ -5,7 +5,6 @@ package = "directories"
 date = "2020-10-16"
 informational = "unmaintained"
 url = "https://github.com/dirs-dev/directories-rs"
-yanked = true
 withdrawn = "2021-04-19"
 
 [versions]

--- a/crates/dirs/RUSTSEC-2020-0053.md
+++ b/crates/dirs/RUSTSEC-2020-0053.md
@@ -5,7 +5,6 @@ package = "dirs"
 date = "2020-10-16"
 informational = "unmaintained"
 url = "https://github.com/dirs-dev/dirs-rs"
-yanked = true
 withdrawn = "2021-04-19"
 
 [versions]

--- a/crates/libpulse-binding/RUSTSEC-2020-0055.md
+++ b/crates/libpulse-binding/RUSTSEC-2020-0055.md
@@ -4,7 +4,6 @@ id = "RUSTSEC-2020-0055"
 package = "libpulse-binding"
 date = "2020-10-21"
 url = "https://rustsec.org/advisories/RUSTSEC-2018-0020.html"
-yanked = true
 withdrawn = "2020-10-22"
 
 [versions]

--- a/crates/spin/RUSTSEC-2019-0031.md
+++ b/crates/spin/RUSTSEC-2019-0031.md
@@ -5,7 +5,6 @@ package = "spin"
 date = "2019-11-21"
 informational = "unmaintained"
 url = "https://github.com/mvdnes/spin-rs/commit/7516c80"
-yanked = true
 withdrawn = "2020-10-08"
 
 [versions]

--- a/crates/tower-http/RUSTSEC-2021-0135.md
+++ b/crates/tower-http/RUSTSEC-2021-0135.md
@@ -7,7 +7,6 @@ url = "https://github.com/tower-rs/tower-http/pull/204"
 categories = ["file-disclosure"]
 keywords = ["directory traversal", "http"]
 withdrawn = "2022-08-14" # fixing date to 2022-01-21 see rustsec/advisory-db#1165
-yanked = true
 
 [affected]
 os = ["windows"]


### PR DESCRIPTION
CI will fail on this most probably as the 0.26.1 rustsec is not published that deprecates the field: https://github.com/rustsec/rustsec/pull/631
After the rustsec 0.26.1 is published this probably requires cache bump in CI linter as discussed here: https://github.com/rustsec/advisory-db/pull/1355
PR to bump the CI cache key: https://github.com/rustsec/advisory-db/pull/1363

**Before**
```
 grep -R yanked *
crates/crossbeam-utils/RUSTSEC-2022-0041.md:Affected 0.8.x releases have been yanked.
crates/libpulse-binding/RUSTSEC-2020-0055.md:yanked = true
crates/directories/RUSTSEC-2020-0054.md:yanked = true
crates/tower-http/RUSTSEC-2021-0135.md:yanked = true
crates/reorder/RUSTSEC-2021-0050.md:Previous versions have also been yanked from crates.io.
crates/spin/RUSTSEC-2019-0031.md:yanked = true
crates/spin/RUSTSEC-2019-0031.md:unaffected = [">= 0"] # workaround for `yanked = true` not removing the advisory
crates/sha2/RUSTSEC-2021-0100.md:The crate has since been yanked, but any users who upgraded to v0.9.7 should
crates/rustsec-example-crate/RUSTSEC-2019-0024.md:(Technically there is a third release, v0.0.0, which is yanked, but otherwise
crates/dirs/RUSTSEC-2020-0053.md:yanked = true
```

**After**
```
$ grep -R yanked *
crates/crossbeam-utils/RUSTSEC-2022-0041.md:Affected 0.8.x releases have been yanked.
crates/reorder/RUSTSEC-2021-0050.md:Previous versions have also been yanked from crates.io.
crates/spin/RUSTSEC-2019-0031.md:unaffected = [">= 0"] # workaround for `yanked = true` not removing the advisory
crates/sha2/RUSTSEC-2021-0100.md:The crate has since been yanked, but any users who upgraded to v0.9.7 should
crates/rustsec-example-crate/RUSTSEC-2019-0024.md:(Technically there is a third release, v0.0.0, which is yanked, but otherwise
```

_Note: Need to check RUSTSEC-2019-0031 what was the case with it and if something needs to be done_

