### PR TITLE
Bump rustsec-admin to deprecate `yanked`

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,12 +16,12 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cargo/bin
-        key: rustsec-admin-v0.8.0
+        key: rustsec-admin-v0.8.1
 
     - name: Install rustsec-admin
       run: |
         if [ ! -f $HOME/.cargo/bin/rustsec-admin ]; then
-            cargo install rustsec-admin --vers 0.8.0
+            cargo install rustsec-admin --vers 0.8.1
         fi
 
     - name: Lint advisories


### PR DESCRIPTION
Unblocks #1362 

By bumping rustsec-admin which ensures cache gets flushed and links with rustsec 0.26.1

Giving effect to this: https://github.com/rustsec/rustsec/pull/631
And this: https://github.com/rustsec/advisory-db/pull/1355

Cheers