### PR TITLE
Remove `yanked` 2

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.cargo/bin
-        key: rustsec-admin-v0.8.1
+        key: rustsec-admin-v0.8.1p
 
     - name: Install rustsec-admin
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,11 +12,11 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Cache cargo bin
-      uses: actions/cache@v1
-      with:
-        path: ~/.cargo/bin
-        key: rustsec-admin-v0.8.1
+#    - name: Cache cargo bin
+#      uses: actions/cache@v1
+#      with:
+#        path: ~/.cargo/bin
+#        key: rustsec-admin-v0.8.1
 
     - name: Install rustsec-admin
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,11 +12,11 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-#    - name: Cache cargo bin
-#      uses: actions/cache@v1
-#      with:
-#        path: ~/.cargo/bin
-#        key: rustsec-admin-v0.8.1
+    - name: Cache cargo bin
+      uses: actions/cache@v1
+      with:
+        path: ~/.cargo/bin
+        key: rustsec-admin-v0.8.1
 
     - name: Install rustsec-admin
       run: |

--- a/crates/directories/RUSTSEC-2020-0054.md
+++ b/crates/directories/RUSTSEC-2020-0054.md
@@ -5,7 +5,6 @@ package = "directories"
 date = "2020-10-16"
 informational = "unmaintained"
 url = "https://github.com/dirs-dev/directories-rs"
-yanked = true
 withdrawn = "2021-04-19"
 
 [versions]

--- a/crates/dirs/RUSTSEC-2020-0053.md
+++ b/crates/dirs/RUSTSEC-2020-0053.md
@@ -5,7 +5,6 @@ package = "dirs"
 date = "2020-10-16"
 informational = "unmaintained"
 url = "https://github.com/dirs-dev/dirs-rs"
-yanked = true
 withdrawn = "2021-04-19"
 
 [versions]

--- a/crates/libpulse-binding/RUSTSEC-2020-0055.md
+++ b/crates/libpulse-binding/RUSTSEC-2020-0055.md
@@ -4,7 +4,6 @@ id = "RUSTSEC-2020-0055"
 package = "libpulse-binding"
 date = "2020-10-21"
 url = "https://rustsec.org/advisories/RUSTSEC-2018-0020.html"
-yanked = true
 withdrawn = "2020-10-22"
 
 [versions]

--- a/crates/spin/RUSTSEC-2019-0031.md
+++ b/crates/spin/RUSTSEC-2019-0031.md
@@ -5,7 +5,6 @@ package = "spin"
 date = "2019-11-21"
 informational = "unmaintained"
 url = "https://github.com/mvdnes/spin-rs/commit/7516c80"
-yanked = true
 withdrawn = "2020-10-08"
 
 [versions]

--- a/crates/tower-http/RUSTSEC-2021-0135.md
+++ b/crates/tower-http/RUSTSEC-2021-0135.md
@@ -7,7 +7,6 @@ url = "https://github.com/tower-rs/tower-http/pull/204"
 categories = ["file-disclosure"]
 keywords = ["directory traversal", "http"]
 withdrawn = "2022-08-14" # fixing date to 2022-01-21 see rustsec/advisory-db#1165
-yanked = true
 
 [affected]
 os = ["windows"]


### PR DESCRIPTION
EDIT: Cache was the problem but there was different problem when I re-tested without cache - needs bump: https://github.com/rustsec/rustsec/pull/642

Some weird GH action cache thing / feature with pending / paraller PRs so Re-created this.

Following-Up from:
https://github.com/rustsec/advisory-db/pull/1362

After:
```
$ grep -R yanked *
crates/crossbeam-utils/RUSTSEC-2022-0041.md:Affected 0.8.x releases have been yanked.
crates/reorder/RUSTSEC-2021-0050.md:Previous versions have also been yanked from crates.io.
crates/spin/RUSTSEC-2019-0031.md:unaffected = [">= 0"] # workaround for `yanked = true` not removing the advisory
crates/sha2/RUSTSEC-2021-0100.md:The crate has since been yanked, but any users who upgraded to v0.9.7 should
crates/rustsec-example-crate/RUSTSEC-2019-0024.md:(Technically there is a third release, v0.0.0, which is yanked, but otherwise
```