### PR TITLE
RUSTSEC-2022-0049: recategorize as memory-exposure

### DIFF
--- a/crates/iana-time-zone/RUSTSEC-2022-0049.md
+++ b/crates/iana-time-zone/RUSTSEC-2022-0049.md
@@ -5,7 +5,7 @@ package = "iana-time-zone"
 date = "2022-08-15"
 url = "https://github.com/strawlab/iana-time-zone/pull/54"
 references = ["https://github.com/strawlab/iana-time-zone/pull/50#discussion_r945353515"]
-categories = ["memory-corruption"]
+categories = ["memory-exposure"]
 informational = "unsound"
 
 [affected]


### PR DESCRIPTION
Because of the bug random data was read, but still written into a sane buffer.