### PR TITLE
Added console to RUSTSEC-2021-0139

### DIFF
--- a/crates/ansi_term/RUSTSEC-2021-0139.md
+++ b/crates/ansi_term/RUSTSEC-2021-0139.md
@@ -23,5 +23,6 @@ Last release seems to have been three years ago.
  The below list has not been vetted in any way and may or may not contain alternatives;
 
  - [anstyle](https://github.com/epage/anstyle)
+ - [console](https://crates.io/crates/console)
  - [nu-ansi-term](https://crates.io/crates/nu-ansi-term)
  - [yansi](https://crates.io/crates/yansi)


### PR DESCRIPTION
I got a notification for this and noticed that I can replace a use with `console` here.