### PR TITLE
Remove mapr as alternativ from RUSTSEC-2020-0077

### DIFF
--- a/crates/memmap/RUSTSEC-2020-0077.md
+++ b/crates/memmap/RUSTSEC-2020-0077.md
@@ -17,6 +17,5 @@ The author of the `memmap` crate is unresponsive.
 
 Maintained alternatives:
 
-- [`mapr`](https://github.com/filecoin-project/mapr)
 - [`memmap2`](https://github.com/RazrFalcon/memmap2-rs)
 


### PR DESCRIPTION
With the merge of https://github.com/RazrFalcon/memmap2-rs/pull/52 into `memmap2`,
all changes from `mapr` are ported upstream. Hence `memmap2` is now the single best
alternative.