### PR TITLE
Add unmaintained `mapr`

### DIFF
--- a/crates/mapr/RUSTSEC-0000-0000.md
+++ b/crates/mapr/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "mapr"
+date = "2022-08-24"
+url = "https://github.com/rustsec/advisory-db/pull/1381"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+# mapr is Unmaintained
+
+The `mapr` fork has been merged back into upstream fork `memmap2`.
+
+The maintainer(s) have adviced `mapr` is deprecated and will not
+receive any maintenance in favor of using `memmap2`.
+
+## Possible Alternative(s)
+
+ The below list has not been vetted in any way and may or may not contain alternatives;
+
+ - [`memmap2`](https://github.com/RazrFalcon/memmap2-rs)


### PR DESCRIPTION
Follow-up from: https://github.com/rustsec/advisory-db/pull/1381