### PR TITLE
lz4-sys: Forward CVE-2021-3520

### DIFF
--- a/crates/lz4-sys/RUSTSEC-0000-0000.md
+++ b/crates/lz4-sys/RUSTSEC-0000-0000.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "lz4-sys"
+date = "2022-08-25"
+url = "https://github.com/lz4/lz4/pull/972"
+categories = ["memory-corruption"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+keywords = ["integer-overflow", "out-of-bounds"]
+related = ["CVE-2021-3520"]
+
+[versions]
+patched = [">= 1.9.4"]
+```
+
+# Memory corruption in liblz4
+
+lz4-sys up to v1.9.3 bundles a version of liblz4 that is vulnerable to
+[CVE-2021-3520](https://nvd.nist.gov/vuln/detail/CVE-2021-3520).
+
+Attackers could craft a payload that triggers an integer overflow upon
+decompression, causing an out-of-bounds write.
+
+The flaw has been corrected in version v1.9.4 of liblz4, which is included
+in lz4-sys 1.9.4.


### PR DESCRIPTION
Forwarding CVE-2021-3520. lz4-sys 1.9.4 has not yet been released.