### PR TITLE
Remove reference mention from description

### DIFF
--- a/crates/time/RUSTSEC-2020-0071.md
+++ b/crates/time/RUSTSEC-2020-0071.md
@@ -72,7 +72,3 @@ Users of time 0.1 do not have a patch and should upgrade to an unaffected versio
 ### Workarounds
 
 No workarounds are known.
-
-### References
-
-time-rs/time#293


### PR DESCRIPTION
It is already the url of the advisory metadata, and the internal github link does not render outside of github.