### PR TITLE
Add unmaintained `typemap`

### DIFF
--- a/crates/typemap/RUSTSEC-0000-0000.md
+++ b/crates/typemap/RUSTSEC-0000-0000.md
@@ -14,6 +14,8 @@ patched = []
 
 The maintainer seems unreachable.
 
+The crate may or may not be usable as-is despite no maintenance.
+
 The last release seems to have been seven years ago.
 
 ## Possible Alternative(s)

--- a/crates/typemap/RUSTSEC-0000-0000.md
+++ b/crates/typemap/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "typemap"
+date = "2019-04-06"
+url = "https://github.com/reem/rust-typemap/issues/45"
+references = ["https://github.com/rustsec/advisory-db/issues/1088"]
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+# typemap is Unmaintained
+
+The maintainer seems unreachable.
+
+The last release seems to have been seven years ago.
+
+## Possible Alternative(s)
+
+ The below list has not been vetted in any way and may or may not contain alternatives;
+
+ - [ttmap](https://crates.io/crates/ttmap)


### PR DESCRIPTION
https://github.com/reem/rust-typemap/issues/45, https://github.com/rustsec/advisory-db/pull/1390, https://github.com/rustsec/advisory-db/issues/1088

@DoumanAsh would you mind reviewing this advisory ?

I know it was few years ago you started working on ttmap but seems it's been kept up to date ? last release 8 months ago

_ttmap - 2,638 downloads all time
typemap - 3,874,814 downloads all time, ~4k a day_

Also @philip-peterson mind reviewing as this is associated crate