### PR TITLE
Mention `structopt` advice under `ansi_term`

### DIFF
--- a/crates/ansi_term/RUSTSEC-2021-0139.md
+++ b/crates/ansi_term/RUSTSEC-2021-0139.md
@@ -29,4 +29,4 @@ Last release seems to have been three years ago.
 
 ## Dependency Specific Migration(s)
 
- - [structopt, clap2](https://github.com/TeXitoi/structopt/issues/525)
+ - [structopt, clap2](https://github.com/clap-rs/clap/discussions/4172)

--- a/crates/ansi_term/RUSTSEC-2021-0139.md
+++ b/crates/ansi_term/RUSTSEC-2021-0139.md
@@ -11,8 +11,7 @@ patched = []
 ```
 # ansi_term is Unmaintained
 
-The maintainer has adviced this crate is deprecated and will not
-receive any maintenance.
+The maintainer has adviced that this crate is deprecated and will not receive any maintenance.
 
 The crate does not seem to have much dependencies and may or may not be ok to use as-is.
 
@@ -27,3 +26,11 @@ Last release seems to have been three years ago.
  - [nu-ansi-term](https://crates.io/crates/nu-ansi-term)
  - [owo-colors](https://crates.io/crates/owo-colors)
  - [yansi](https://crates.io/crates/yansi)
+
+## structopt - Major Dependency
+
+Crates such as `structopt` may rely on `clap2` that relies on `ansi_term`
+
+Where as superceded `clap3` provides `structopt` see discussion:
+
+ - https://github.com/TeXitoi/structopt/issues/525

--- a/crates/ansi_term/RUSTSEC-2021-0139.md
+++ b/crates/ansi_term/RUSTSEC-2021-0139.md
@@ -27,10 +27,6 @@ Last release seems to have been three years ago.
  - [owo-colors](https://crates.io/crates/owo-colors)
  - [yansi](https://crates.io/crates/yansi)
 
-## structopt - Major Dependency
+## Dependency Specific Migration(s)
 
-Crates such as `structopt` may rely on `clap2` that relies on `ansi_term`
-
-Where as superceded `clap3` provides `structopt` see discussion:
-
- - https://github.com/TeXitoi/structopt/issues/525
+ - [structopt, clap2](https://github.com/TeXitoi/structopt/issues/525)


### PR DESCRIPTION
Linking structopt/clap2 specific actionable advice: https://github.com/clap-rs/clap/discussions/4172 under `ansi_term`

Not sure if this is feasible but see what others think :woman_shrugging: 

As seen here:

- https://github.com/clap-rs/clap/discussions/4172
- https://github.com/TeXitoi/structopt/issues/525
- https://github.com/mrl5/vulner/issues/59#issuecomment-1221388712
- https://docs.rs/structopt/latest/structopt/#maintenance

I've asked @epage and @TeXitoi whether it would be also feasible to advice informational under `structopt` to optionally move to `clap` v3 but it will be @TeXitoi's sole decision if they wish to do that - the crate should be still fine to use as-is I think though.