### PR TITLE
Add unmaintained `unsafe-any` 

### DIFF
--- a/crates/unsafe-any/RUSTSEC-0000-0000.md
+++ b/crates/unsafe-any/RUSTSEC-0000-0000.md
@@ -1,0 +1,26 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "unsafe-any"
+date = "2019-04-06"
+url = "https://github.com/reem/rust-typemap/issues/45"
+references = ["https://github.com/rustsec/advisory-db/issues/1088"]
+informational = "unmaintained"
+[versions]
+patched = []
+```
+# unsafe-any is Unmaintained
+
+The maintainer seems unreachable.
+
+Associated crates `typemap` and `traitobject` are also unmaintained.
+
+These crates may or may not be usable as-is despite no maintenance.
+
+The last release seems to have been over five years ago.
+
+## Possible Alternative(s)
+
+ The below list has not been vetted in any way and may or may not contain alternatives;
+
+ - .. TBD


### PR DESCRIPTION
TBD alternatives

Would have to ideally file this together with:

- `traitobject` - https://github.com/rustsec/advisory-db/pull/1390
- `typemap` - https://github.com/rustsec/advisory-db/pull/1406

