### PR TITLE
Add `alloc_no_stdlib`

### DIFF
--- a/crates/alloc_no_stdlib/RUSTSEC-0000-0000.md
+++ b/crates/alloc_no_stdlib/RUSTSEC-0000-0000.md
@@ -1,0 +1,37 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+
+package = "aalloc-no-stdlib"
+
+date = "2022-11-09"
+
+url = "https://github.com/dropbox/rust-alloc-no-stdlib/issues/12"
+
+informational = "unsound"
+
+categories = ["memory-exposure"]
+
+keywords = ["uninitialized", "information-leak", "memory-exposure"]
+
+[affected]
+
+[versions]
+patched = []
+```
+
+# alloc_no_stdlib gives out references to uninitialized data to library users
+
+The following code demonstrates this library giving out a slice of uninitialized memory as its allocation 
+
+```rust
+let mut malloc_global_buffer =
+	unsafe { define_allocator_memory_pool!(4096, u8, [0; 200 * 1024 * 1024], malloc) };
+let mut ags =
+	MallocAllocatedFreelist4096::<u8>::new_allocator(&mut malloc_global_buffer.data, bzero);
+let mut uninit = ags.alloc_cell(4);
+let uninit_slice = uninit.as_mut();
+let boom = uninit_slice[0]; // reading uninitized data from the allocation
+```
+
+This is dangerous because it would allow information disclosure by reading data that was previously allocated where the memory pool currently is, as well as causing UB and a risk of miscompilation.

--- a/crates/alloc_no_stdlib/RUSTSEC-0000-0000.md
+++ b/crates/alloc_no_stdlib/RUSTSEC-0000-0000.md
@@ -33,3 +33,5 @@ let boom = uninit_slice[0]; // reading uninitized data from the allocation
 ```
 
 This is dangerous because it would allow information disclosure by reading data that was previously allocated where the memory pool currently is, as well as causing UB and a risk of miscompilation.
+
+It has had an issue open regarding this unsoundness for almost a year with no actions taken, and the crate appears somewhat unmaintained also.

--- a/crates/alloc_no_stdlib/RUSTSEC-0000-0000.md
+++ b/crates/alloc_no_stdlib/RUSTSEC-0000-0000.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-0000-0000"
 
 package = "alloc-no-stdlib"
 
-date = "2022-11-09"
+date = "2022-01-31"
 
 url = "https://github.com/dropbox/rust-alloc-no-stdlib/issues/12"
 

--- a/crates/alloc_no_stdlib/RUSTSEC-0000-0000.md
+++ b/crates/alloc_no_stdlib/RUSTSEC-0000-0000.md
@@ -1,17 +1,11 @@
 ```toml
 [advisory]
 id = "RUSTSEC-0000-0000"
-
 package = "alloc-no-stdlib"
-
 date = "2022-01-31"
-
 url = "https://github.com/dropbox/rust-alloc-no-stdlib/issues/12"
-
 informational = "unsound"
-
 categories = ["memory-exposure"]
-
 keywords = ["uninitialized", "information-leak", "memory-exposure"]
 
 [versions]

--- a/crates/alloc_no_stdlib/RUSTSEC-0000-0000.md
+++ b/crates/alloc_no_stdlib/RUSTSEC-0000-0000.md
@@ -14,8 +14,6 @@ categories = ["memory-exposure"]
 
 keywords = ["uninitialized", "information-leak", "memory-exposure"]
 
-[affected]
-
 [versions]
 patched = []
 ```

--- a/crates/alloc_no_stdlib/RUSTSEC-0000-0000.md
+++ b/crates/alloc_no_stdlib/RUSTSEC-0000-0000.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 
-package = "aalloc-no-stdlib"
+package = "alloc-no-stdlib"
 
 date = "2022-11-09"
 


### PR DESCRIPTION
alloc_no_stdlib contains a memory disclosure vulnerability (reading uninitialized memory)