### PR TITLE
Add unmaintained `badge`

### DIFF
--- a/crates/badge/RUSTSEC-0000-0000.md
+++ b/crates/badge/RUSTSEC-0000-0000.md
@@ -20,8 +20,8 @@ anymore.
 
  The below list has not been vetted in any way and may or may not contain alternatives;
 
- - [badgers](https://crates.io/crates/badgers) (API compatible fork of the `badge` crate using `ab_glyph` as a replacement for `rusttype`)
  - [badge-maker](https://crates.io/crates/badge-maker)
  - [badgeland](https://crates.io/crates/badgeland)
- - [rsbadges](https://crates.io/crates/rsbadges) (used deprecated `rusttype`)
  - [badgen](https://crates.io/crates/badgen)
+ - [badgers](https://crates.io/crates/badgers) (API compatible fork of the `badge` crate using `ab_glyph` as a replacement for `rusttype`)
+ - [rsbadges](https://crates.io/crates/rsbadges) (used deprecated `rusttype`)

--- a/crates/badge/RUSTSEC-0000-0000.md
+++ b/crates/badge/RUSTSEC-0000-0000.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "badge"
-date = "2022-09-27"
+date = "2022-09-28"
 url = "https://github.com/rust-lang/docs.rs/issues/1813#issuecomment-1232875809"
 informational = "unmaintained"
 
@@ -21,6 +21,6 @@ anymore.
 
  The below list has not been vetted in any way and may or may not contain alternatives;
 
- - [badgers](https://crates.io/crates/ab_glyph) (fork of the `badge` crate using
+ - [badgers](https://crates.io/crates/badgers) (fork of the `badge` crate using
    `ab_glyph` as a replacement for `rusttype`)
 

--- a/crates/badge/RUSTSEC-0000-0000.md
+++ b/crates/badge/RUSTSEC-0000-0000.md
@@ -20,5 +20,8 @@ anymore.
 
  The below list has not been vetted in any way and may or may not contain alternatives;
 
- - [badgers](https://crates.io/crates/badgers) (fork of the `badge` crate using `ab_glyph` as a replacement for `rusttype`)
-
+ - [badgers](https://crates.io/crates/badgers) (API compatible fork of the `badge` crate using `ab_glyph` as a replacement for `rusttype`)
+ - [badge-maker](https://crates.io/crates/badge-maker)
+ - [badgeland](https://crates.io/crates/badgeland)
+ - [rsbadges](https://crates.io/crates/rsbadges) (used deprecated `rusttype`)
+ - [badgen](https://crates.io/crates/badgen)

--- a/crates/badge/RUSTSEC-0000-0000.md
+++ b/crates/badge/RUSTSEC-0000-0000.md
@@ -1,0 +1,26 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "badge"
+date = "2022-09-27"
+url = "https://github.com/rust-lang/docs.rs/issues/1813#issuecomment-1232875809"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+# badge is Unmaintained
+
+The maintainer has adviced this crate is deprecated and will not receive any
+maintenance.
+
+The crate depends on the deprecated `rusttype` crate and won't receive updates
+anymore.
+
+## Possible Alternative(s)
+
+ The below list has not been vetted in any way and may or may not contain alternatives;
+
+ - [badgers](https://crates.io/crates/ab_glyph) (fork of the `badge` crate using
+   `ab_glyph` as a replacement for `rusttype`)
+

--- a/crates/badge/RUSTSEC-0000-0000.md
+++ b/crates/badge/RUSTSEC-0000-0000.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "badge"
-date = "2022-09-28"
+date = "2022-08-31"
 url = "https://github.com/rust-lang/docs.rs/issues/1813#issuecomment-1232875809"
 informational = "unmaintained"
 

--- a/crates/badge/RUSTSEC-0000-0000.md
+++ b/crates/badge/RUSTSEC-0000-0000.md
@@ -11,8 +11,7 @@ patched = []
 ```
 # badge is Unmaintained
 
-The maintainer has adviced this crate is deprecated and will not receive any
-maintenance.
+The maintainer has adviced this crate is deprecated and will not receive any maintenance.
 
 The crate depends on the deprecated `rusttype` crate and won't receive updates
 anymore.
@@ -21,6 +20,5 @@ anymore.
 
  The below list has not been vetted in any way and may or may not contain alternatives;
 
- - [badgers](https://crates.io/crates/badgers) (fork of the `badge` crate using
-   `ab_glyph` as a replacement for `rusttype`)
+ - [badgers](https://crates.io/crates/badgers) (fork of the `badge` crate using `ab_glyph` as a replacement for `rusttype`)
 


### PR DESCRIPTION
Closes #1401

The `badge` crate is unmaintained and depends on the deprecated `rusttype` crate.

I created a fork `badgers` that replaced `rusttype` with `ab_glyph` and keeps the same public API.