### PR TITLE
fix hyper patched version number

### DIFF
--- a/crates/hyper/RUSTSEC-2022-0022.md
+++ b/crates/hyper/RUSTSEC-2022-0022.md
@@ -7,7 +7,7 @@ informational = "unsound"
 url = "https://github.com/hyperium/hyper/pull/2545"
 
 [versions]
-patched = [">= 0.4.12"]
+patched = [">= 0.14.12"]
 ```
 
 # Parser creates invalid uninitialized value


### PR DESCRIPTION
That said, the known risks of miscompilation are actually completely mitigated by https://github.com/rust-lang/rust/pull/99182. So I wonder if we should remove the advisory?