### PR TITLE
Add unmaintained `twoway`

### DIFF
--- a/crates/twoway/RUSTSEC-0000-0000.md
+++ b/crates/twoway/RUSTSEC-0000-0000.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "twoway"
-date = "2022-10-12"
+date = "2021-05-20"
 url = "https://github.com/bluss/twoway"
 references = ["https://github.com/bluss/twoway/commit/e99b3c718df1117ad7f54c33f6540c8f46cc17dd"]
 informational = "unmaintained"
@@ -10,8 +10,7 @@ categories = ["algorithms", "no-std"]
 keywords = ["string", "byte", "find", "memmem", "substring-search"]
 
 [versions]
-
-[affected]
+patched = []
 ```
 
 # Crate `twoway` deprecated by the author

--- a/crates/twoway/RUSTSEC-0000-0000.md
+++ b/crates/twoway/RUSTSEC-0000-0000.md
@@ -6,8 +6,6 @@ date = "2021-05-20"
 url = "https://github.com/bluss/twoway"
 references = ["https://github.com/bluss/twoway/commit/e99b3c718df1117ad7f54c33f6540c8f46cc17dd"]
 informational = "unmaintained"
-categories = ["algorithms", "no-std"]
-keywords = ["string", "byte", "find", "memmem", "substring-search"]
 
 [versions]
 patched = []

--- a/crates/twoway/RUSTSEC-0000-0000.md
+++ b/crates/twoway/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "twoway"
+date = "2022-10-12"
+url = "https://github.com/bluss/twoway"
+references = ["https://github.com/bluss/twoway/commit/e99b3c718df1117ad7f54c33f6540c8f46cc17dd"]
+informational = "unmaintained"
+categories = ["algorithms", "no-std"]
+keywords = ["string", "byte", "find", "memmem", "substring-search"]
+
+[versions]
+
+[affected]
+```
+
+# Crate `twoway` deprecated by the author
+
+The commit [`e99b3c7`](https://github.com/bluss/twoway/commit/e99b3c718df1117ad7f54c33f6540c8f46cc17dd) releasing version 0.2.2 explicitely deprecates `twoway` in favour of [`memchr`](https://crates.io/crates/memchr) crate.


### PR DESCRIPTION
The author deprecated the crate himself, but it's part of many web related crates, mostly related to `form/multipart` handling.