### PR TITLE
Update RUSTSEC-2021-0122

### DIFF
--- a/crates/flatbuffers/RUSTSEC-2021-0122.md
+++ b/crates/flatbuffers/RUSTSEC-2021-0122.md
@@ -7,7 +7,7 @@ date = "2021-10-31"
 url = "https://github.com/google/flatbuffers/issues/6627"
 
 [versions]
-patched = []
+patched = [">= 22.9.29"]
 ```
 
 # Generated code can read and write out of bounds in safe code


### PR DESCRIPTION
flatbuffers 22.9.29 contains https://github.com/google/flatbuffers/pull/7518 which fixes this advisory