### PR TITLE
Add unmaintained `parity-wasm`

### DIFF
--- a/crates/parity-wasm/RUSTSEC-0000-0000.md
+++ b/crates/parity-wasm/RUSTSEC-0000-0000.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "parity-wasm"
-date = "2022-01-10"
+date = "2022-10-01"
 url = "https://github.com/paritytech/parity-wasm/pull/334"
 informational = "unmaintained"
 

--- a/crates/parity-wasm/RUSTSEC-0000-0000.md
+++ b/crates/parity-wasm/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "parity-wasm"
+date = "2022-01-10"
+url = "https://github.com/paritytech/parity-wasm/pull/334"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Crate `parity-wasm` deprecated by the author
+
+[This PR](https://github.com/paritytech/parity-wasm/pull/334) explicitly deprecates `parity-wasm`.
+The author recommends switching to [wasm-tools](https://github.com/bytecodealliance/wasm-tools).


### PR DESCRIPTION
The crate was explicitly deprecated by the author. The repo is archived and there is a note on top of the readme: https://github.com/paritytech/parity-wasm