### PR TITLE
Add wyz as unmaintained

### DIFF
--- a/crates/wyz/RUSTSEC-0000-0000.md
+++ b/crates/wyz/RUSTSEC-0000-0000.md
@@ -1,3 +1,4 @@
+```toml
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "wyz"
@@ -8,6 +9,7 @@ informational = "unmaintained"
 [versions]
 patched = []
 unaffected = []
+```
 
 # wyz is unmaintained with obscured source code
 

--- a/wyz/RUSTSEC-0000-0000.md
+++ b/wyz/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wyz"
+date = "2022-10-27"
+references = ["https://github.com/bitvecto-rs/bitvec/issues/195"]
+informational = "unmaintained"
+
+[versions]
+patched = []
+unaffected = []
+
+# wyz is unmaintained with obscured source code
+
+wyz, as published to crates.io, has version 0.5.0. Its GitHub repository only version 0.4.0 available, obscuring its source code.
+
+Additionally, wyz has a dependency of traitobject in its tree, which was assigned RUSTSEC-2020-0027. This has not been acknowledged for over a month, with the last update to wyz being over a year and a half ago.


### PR DESCRIPTION
https://github.com/myrrlyn/wyz/issues/8 for the issue cited in the advisory.

I also just created https://github.com/myrrlyn/wyz/issues/9 requesting 0.5.0 be published, which may be responded to and may invalidate part of this advisory. I do not appreciate crates having repositories which do not contain their code however.

Sorry if this is malformed. I did see most unmaintained notices seem to follow a boilerplate, and wasn't sure exactly how to handle this. The obscured code section felt notable.