### PR TITLE
Make rustsec-example-crate v0.0.0 unaffected to allow testing yanked checks

### DIFF
--- a/crates/rustsec-example-crate/RUSTSEC-2019-0024.md
+++ b/crates/rustsec-example-crate/RUSTSEC-2019-0024.md
@@ -7,6 +7,7 @@ url = "https://github.com/RustSec/advisory-db/issues/158"
 
 [versions]
 patched = [">= 1.0.0"]
+unaffected = ["< 0.0.1"]
 ```
 
 # Test advisory with associated example crate
@@ -17,13 +18,12 @@ against an example crate, it is otherwise considered by the Advisory Database
 itself to be a normal security advisory.
 
 It's filed against `rustsec-example-crate`, an otherwise completely empty crate
-with no functionality or code, which has two releases:
+with no functionality or code, which has three releases:
 
+- [v0.0.0] - *unaffected* by this advisory (but *yanked* from crates.io)
 - [v0.0.1] - *vulnerable* according to this advisory
 - [v1.0.0] - *patched* by this advisory
 
-(Technically there is a third release, v0.0.0, which is yanked, but otherwise
-identical to the v0.0.1 release)
-
+[v0.0.0]: https://crates.io/crates/rustsec-example-crate/0.0.0
 [v0.0.1]: https://crates.io/crates/rustsec-example-crate/0.0.1
 [v1.0.0]: https://crates.io/crates/rustsec-example-crate/1.0.0


### PR DESCRIPTION
Needed for writing an automated test for https://github.com/rustsec/rustsec/issues/747