### PR TITLE
Patched slock

### DIFF
--- a/crates/slock/RUSTSEC-2020-0135.md
+++ b/crates/slock/RUSTSEC-2020-0135.md
@@ -9,7 +9,7 @@ aliases = ["CVE-2020-36455"]
 cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]
-patched = []
+patched = [">= 0.2.0"]
 ```
 
 # Slock<T> allows sending non-Send types across thread boundaries


### PR DESCRIPTION
The [slock](https://crates.io/crates/slock) crate no longer has the issue described in the advisory