### PR TITLE
Add hyper-staticfile file disclosure on Windows

### DIFF
--- a/crates/hyper-staticfile/RUSTSEC-0000-0000.md
+++ b/crates/hyper-staticfile/RUSTSEC-0000-0000.md
@@ -11,7 +11,7 @@ keywords = ["directory traversal", "http"]
 os = ["windows"]
 
 [versions]
-patched = [">= 0.9.2", ">= 0.10.0-alpha.2"]
+patched = ["^0.9.2", ">= 0.10.0-alpha.2"]
 ```
 
 # Improper validation of Windows paths could lead to directory traversal attack

--- a/crates/hyper-staticfile/RUSTSEC-0000-0000.md
+++ b/crates/hyper-staticfile/RUSTSEC-0000-0000.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "hyper-staticfile"
+date = "2022-11-30"
+url = "https://github.com/stephank/hyper-staticfile/issues/35"
+categories = ["file-disclosure"]
+keywords = ["directory traversal", "http"]
+
+[affected]
+os = ["windows"]
+
+[versions]
+patched = [">= 0.9.2", ">= 0.10.0-alpha.2"]
+```
+
+# Improper validation of Windows paths could lead to directory traversal attack
+
+Path resolution in `hyper-staticfile` didn't correctly validate Windows paths
+meaning paths like `/foo/bar/c:/windows/web/screen/img101.png` would be allowed
+and respond with the contents of `c:/windows/web/screen/img101.png`. Thus users
+could potentially read files anywhere on the filesystem.
+
+This only impacts Windows. Linux and other unix likes are not impacted by this.


### PR DESCRIPTION
This adds an advisory for https://github.com/stephank/hyper-staticfile/issues/35.

The contents are heavily based on an existing `tower-http` advisory: https://github.com/rustsec/advisory-db/blob/a66a3049c98395410a2afadf0382882b0a04d8b1/crates/tower-http/RUSTSEC-2022-0043.md