### PR TITLE
Add unmaintained `rusoto_credential`

### DIFF
--- a/crates/rusoto_credential/RUSTSEC-0000-0000.md
+++ b/crates/rusoto_credential/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rusoto_credential"
+date = "2022-04-24"
+url = "https://github.com/rusoto/rusoto/issues/1651"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Rusoto is unmaintained
+
+The maintainers of Rusoto advise that all its crates are deprecated. This includes the common crates `rusoto_core`, `rusoto_signature`, `rusoto_credential`, and service crates such as `rusoto_s3` and `rusoto_ec2`.
+
+Users should migrate to the [AWS SDK for Rust](https://github.com/awslabs/aws-sdk-rust), which is maintained by AWS.


### PR DESCRIPTION
Hi. I'm ostensibly one of the maintainers of Rusoto, here to report its lack of maintenance.

[Rusoto has been deprecated for a while](https://github.com/rusoto/rusoto/issues/1651#issuecomment-1108012975); this is a more formalized notice of such to help churn downstream automation to make it clear that users need to migrate to aws-sdk-rust.

This is a somewhat unique case for the RustSec advisory DB, I think. The Rusoto project is made up of a little over 200 separate crates, but every crate in the tree either is or depends on `rusoto_credential`. Most users don't directly depend on `rusoto_credential` though, so I feel that listing an advisory for only that crate is a bit confusing, but hopefully downstream systems show the full description for context.