### PR TITLE
Add unmaintained crate advisory for `alloc-cortex-m`

### DIFF
--- a/crates/alloc-cortex-m/RUSTSEC-0000-0000.md
+++ b/crates/alloc-cortex-m/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "alloc-cortex-m"
+date = "2022-12-21"
+informational = "unmaintained"
+url = "https://github.com/rust-embedded/embedded-alloc/pull/56"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# crate has been renamed to `embedded-alloc`
+
+This crate has been renamed from `alloc-cortex-m` to `embedded-alloc`.
+
+The new repository location is:
+
+<https://github.com/rust-embedded/embedded-alloc>


### PR DESCRIPTION
Has been renamed to `embedded-alloc`.