### PR TITLE
Add open redirect issue in hyper-staticfile

### DIFF
--- a/crates/hyper-staticfile/RUSTSEC-0000-0000.md
+++ b/crates/hyper-staticfile/RUSTSEC-0000-0000.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "hyper-staticfile"
+date = "2022-12-23"
+url = "https://github.com/stephank/hyper-staticfile/commit/f12cadc6666c6f555d29725f5bc45da2103f24ea"
+categories = ["format-injection"]
+keywords = ["open redirect", "http"]
+
+[versions]
+patched = ["^0.9.4", ">= 0.10.0-alpha.5"]
+```
+
+# Location header incorporates user input, allowing open redirect
+
+When `hyper-staticfile` performs a redirect for a directory request (e.g. a
+request for `/dir` that redirects to `/dir/`), the `Location` header value was
+derived from user input (the request path), simply appending a slash. The
+intent was to perform an origin-relative redirect, but specific inputs
+allowed performing a scheme-relative redirect instead.
+
+An attacker could craft a special URL that would appear to be for the correct
+domain, but immediately redirects to a malicious domain. Such a URL can benefit
+phishing attacks, for example an innocent looking link in an email.


### PR DESCRIPTION
This adds an advisory for an open redirect issue discovered in `hyper-staticfile`. Hopefully it's okay that this doesn't have a URL attached. There's no issue for this in the issue tracker; it was reported to us directly by a security partner analyzing an application using this crate.