### PR TITLE
update GHA syntax for deprecation

### DIFF
--- a/.github/workflows/assign-ids.yml
+++ b/.github/workflows/assign-ids.yml
@@ -27,7 +27,7 @@ jobs:
       id: assign
       run: |
         message=$(rustsec-admin assign-id --github-actions-output)
-        echo "::set-output name=commit_message::${message}"
+        echo "commit_message=${message}" >> $GITHUB_OUTPUT
 
     - name: Create duplicate ID assignment guard
       run: |


### PR DESCRIPTION
see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/