### PR TITLE
Add License CC-BY 4.0 Import exemption

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -13,7 +13,7 @@ repository, even for commercial purposes, without asking permission.
 Additional content from GitHub Security Advisory ("GHSA") database
 
 Additional content may be adapted from GHSA with attribution requirements, but
-no additional clauses like copyleft.
+with no additional clauses like copyleft.
 
 Any such license and attribution will be explicitly covered on an advisory by
 advisory basis directly within the applicable advisories.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
-All code and data in the RustSec advisory database repository is dedicated
-to the public domain:
+All code and data in the RustSec advisory database repository is dedicated to
+the public domain:
 
 https://creativecommons.org/publicdomain/zero/1.0/
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,8 +1,3 @@
-Unless otherwise explicitly mentioned in any individual advisories imported
-from other security advisory databases generally as CC-BY 4.0:
-
-https://creativecommons.org/licenses/by/4.0/
-
 All code and data in the RustSec advisory database repository is dedicated
 to the public domain:
 
@@ -14,3 +9,12 @@ the extent allowed by law.
 
 You can copy, modify, distribute, and retransmit any information in this
 repository, even for commercial purposes, without asking permission.
+
+Additional adapted content from GitHub Security Advisory ("GHSA") database
+
+CC-BY (or other) additional content may be adapted from GHSA that only applies
+to licenses with attribution requirements but no additional clauses like
+copyleft.
+
+Any such license and attribution will be explicitly covered advisory by advisory
+basis directly within the applicable advisories.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -10,11 +10,10 @@ the extent allowed by law.
 You can copy, modify, distribute, and retransmit any information in this
 repository, even for commercial purposes, without asking permission.
 
-Additional adapted content from GitHub Security Advisory ("GHSA") database
+Additional content from GitHub Security Advisory ("GHSA") database
 
-CC-BY (or other) additional content may be adapted from GHSA that only applies
-to licenses with attribution requirements but no additional clauses like
-copyleft.
+Additional content may be adapted from GHSA with only attribution requirements,
+but no additional clauses like copyleft.
 
-Any such license and attribution will be explicitly covered advisory by advisory
-basis directly within the applicable advisories.
+Any such license and attribution will be explicitly covered on an advisory by
+advisory basis directly within the applicable advisories.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -12,8 +12,8 @@ repository, even for commercial purposes, without asking permission.
 
 Additional content from GitHub Security Advisory ("GHSA") database
 
-Additional content may be adapted from GHSA with only attribution requirements,
-but no additional clauses like copyleft.
+Additional content may be adapted from GHSA with attribution requirements, but
+no additional clauses like copyleft.
 
 Any such license and attribution will be explicitly covered on an advisory by
 advisory basis directly within the applicable advisories.

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,10 @@
-All code and data in the RustSec advisory database repository is dedicated to
-the public domain:
+Unless otherwise explicitly mentioned in any individual advisories imported
+from other security advisory databases generally as CC-BY 4.0:
+
+https://creativecommons.org/licenses/by/4.0/
+
+All code and data in the RustSec advisory database repository is dedicated
+to the public domain:
 
 https://creativecommons.org/publicdomain/zero/1.0/
 


### PR DESCRIPTION
Allows importing advisories with attribution from GHSA

EDIT: This is so that it will be ready for the tooling https://github.com/rustsec/rustsec/pull/682