### PR TITLE
Report claim as unmaintained.

### DIFF
--- a/crates/claim/RUSTSEC-0000-0000.md
+++ b/crates/claim/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "claim"
+date = "2023-01-12"
+url = "https://github.com/svartalf/rust-claim/issues/12"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `claim` is Unmaintained
+
+The maintainer has been unresponsive regarding this crate for over a year. An issue with `claim`'s dependencies has made the crate nearly unusable when used in conjunction with the majority of the ecosystem (see https://github.com/svartalf/rust-claim/issues/9), and fixes for this issue have been left unanswered.
+
+As the crate is most commonly used as a `dev-dependency`, most affected crates are using it as a dependency directly.
+
+The last release was in February 2021, almost two years ago.
+
+## Alternative
+
+[`claims`](https://crates.io/crates/claims), a fork of the `claim` crate, is a maintained alternative. Pull requests that were pending for `claim` have been merged into `claims` and new versions have been released accordingly on crates.io.

--- a/crates/claim/RUSTSEC-0000-0000.md
+++ b/crates/claim/RUSTSEC-0000-0000.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "claim"
-date = "2023-01-12"
+date = "2022-12-04"
 url = "https://github.com/svartalf/rust-claim/issues/12"
 informational = "unmaintained"
 
@@ -12,12 +12,14 @@ patched = []
 
 # `claim` is Unmaintained
 
-The maintainer has been unresponsive regarding this crate for over a year. An issue with `claim`'s dependencies has made the crate nearly unusable when used in conjunction with the majority of the ecosystem (see https://github.com/svartalf/rust-claim/issues/9), and fixes for this issue have been left unanswered.
-
-As the crate is most commonly used as a `dev-dependency`, most affected crates are using it as a dependency directly.
-
 The last release was in February 2021, almost two years ago.
 
-## Alternative
+The maintainer has been unresponsive regarding this crate for over a year.
 
-[`claims`](https://crates.io/crates/claims), a fork of the `claim` crate, is a maintained alternative. Pull requests that were pending for `claim` have been merged into `claims` and new versions have been released accordingly on crates.io.
+A pending issue with `claim`'s dependencies has made the crate [difficul to use](https://github.com/svartalf/rust-claim/issues/9)
+
+## Possible Alternative(s)
+
+The below list has not been vetted in any way and may or may not contain alternatives;
+
+- [`claims`](https://crates.io/crates/claims), a direct fork of the `claim` crate


### PR DESCRIPTION
As discussed in https://github.com/svartalf/rust-claim/issues/12, and originally requested in #1479. See also the discussion in https://github.com/svartalf/rust-claim/issues/9, which led to the eventual forking of the crate.

I wrote a bit here about the issue surrounding the crate's dependency issues which have needed fixing, as well as the maintained fork, `claims`.