### PR TITLE
Update RUSTSEC-2022-0075.md

### DIFF
--- a/crates/wasmtime/RUSTSEC-2022-0075.md
+++ b/crates/wasmtime/RUSTSEC-2022-0075.md
@@ -10,7 +10,7 @@ keywords = ["use-after-free", "Wasm", "garbage collection"]
 aliases = ["CVE-2022-39393", "GHSA-wh6w-3828-g9qf"]
 
 [versions]
-patched = [">= 2.0.2", ">= 1.0.2"]
+patched = [">= 2.0.2", "^1.0.2"]
 ```
 
 # Bug in pooling instance allocator

--- a/crates/wasmtime/RUSTSEC-2022-0075.md
+++ b/crates/wasmtime/RUSTSEC-2022-0075.md
@@ -10,7 +10,7 @@ keywords = ["use-after-free", "Wasm", "garbage collection"]
 aliases = ["CVE-2022-39393", "GHSA-wh6w-3828-g9qf"]
 
 [versions]
-patched = [">= 2.0.2"]
+patched = [">= 2.0.2", ">= 1.0.2"]
 ```
 
 # Bug in pooling instance allocator

--- a/crates/wasmtime/RUSTSEC-2022-0075.md
+++ b/crates/wasmtime/RUSTSEC-2022-0075.md
@@ -10,7 +10,7 @@ keywords = ["use-after-free", "Wasm", "garbage collection"]
 aliases = ["CVE-2022-39393", "GHSA-wh6w-3828-g9qf"]
 
 [versions]
-patched = [">= 2.0.2", "^1.0.2"]
+patched = [">= 1.0.2, < 2.0.0", ">= 2.0.2"]
 ```
 
 # Bug in pooling instance allocator


### PR DESCRIPTION
https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-wh6w-3828-g9qf specifies 1.0.2 as patched.