### PR TITLE
Add patched info for RUSTSEC-2022-0079 (elf_rs)

### DIFF
--- a/crates/elf_rs/RUSTSEC-2022-0079.md
+++ b/crates/elf_rs/RUSTSEC-2022-0079.md
@@ -8,7 +8,7 @@ categories = ["memory-corruption"]
 keywords = ["elf", "header"]
 
 [versions]
-patched = []
+patched = [">= 0.3.0"]
 
 [affected]
 ```


### PR DESCRIPTION
The issue was confirmed to be fixed in v0.3.0 by the person who reported the issue: https://github.com/vincenthouyi/elf_rs/issues/11#issuecomment-1384624749