### PR TITLE
Add pointers to Rust-lang security policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Rust-lang Project Security Policy
+    url: https://www.rust-lang.org/policies/security
+    about: Please report issues about rustc and cargo to security@rust-lang.org.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,11 @@ be responsibly publicly disclosed via RustSec by submitting an advisory
 to RustSec with the included actionable information e.g. a patched version
 of the said crate.
 
+## Crates without Security Policies
+
+If the crate or the repository does not have any associated security policy
+please see the authors field and try e-mailing them first.
+
 ## Unresponsive Maintainers
 
 If the maintainer(s) is / are unresponsive then this can be also reported given

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,26 @@
-# Reporting Vulnerabilities
+# Contributing to RustSec
+
+Public disclosure via RustSec happens after the maintainer(s) have been made
+responsibly aware of any potential vulnerabilities on their published crate.
+
+## Crate Security Policies
+
+Please see any security policies of given crate / repository first for more
+information on how to responsibly report any potential security vulnerabilities
+first to the maintainers of any given crate / repository.
+
+If and when the maintainer has either acknowledged, then this can
+be responsibly publicly disclosed via RustSec by submitting an advisory
+to RustSec with the included actionable information e.g. a patched version
+of the said crate.
+
+## Unresponsive Maintainers
+
+If the maintainer(s) is / are unresponsive then this can be also reported given
+if the vulnerability has been first appropriately reported to the maintainer(s)
+and where the maintainer(s) have been given a chance to respond first.
+
+## Reporting Vulnerabilities
 
 To add an advisory to the RustSec database, open a [Pull Request] against
 [this](https://github.com/RustSec/advisory-db) repository containing the new advisory:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,8 @@
 Public disclosure via RustSec happens after the maintainer(s) have been made
 responsibly aware of any potential vulnerabilities on their published crate.
 
+If any help is required with this, please e-mail maintainers@rustsec.org
+
 ## Crate Security Policies
 
 Please see any security policies of given crate / repository first for more

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@
 ![Maintained: Q2 2022][maintained-image]
 [![Project Chat][chat-image]][chat-link]
 
-**NOTE**: Security Issues related to rustc, cargo and related to Rust-lang
-repositories are handled elsewhere - please see the [Rust-lang Security Policy](https://www.rust-lang.org/policies/security).
+**NOTE**: Security Issues related to Rust-lang project itself including
+malicious crates/users in crates.io, docs.rs, rustc, cargo or otherwise related
+to Rust-lang repositories and it's infrastructure are handled elsewhere, please
+see the [Rust-lang Security Policy](https://www.rust-lang.org/policies/security) for this.
 
 The RustSec Advisory Database is a repository of security advisories filed
 against Rust crates published via https://crates.io. A human-readable version

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 ![Maintained: Q2 2022][maintained-image]
 [![Project Chat][chat-image]][chat-link]
 
+**NOTE**: Security Issues related to rustc, cargo and related to Rust-lang
+repositories are handled elsewhere - please see the [Rust-lang Security Policy](https://www.rust-lang.org/policies/security).
+
 The RustSec Advisory Database is a repository of security advisories filed
 against Rust crates published via https://crates.io. A human-readable version
 of the advisory database can be found at https://rustsec.org/advisories/.

--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ and reporting (send PRs to add yours):
 ## Reporting Vulnerabilities
 
 Before reporting a vulnerability, please consult the security policy of any
-given crate / repository before disclosing publicly via RustSec to allow
-responsible disclosure to the responsible maintainers first.
+given crate / repository (if any) first before disclosing publicly via RustSec
+to allow responsible disclosure to the responsible maintainers first.
 
-As an example security issues related to Rust-lang project itself including
+As an example, security issues related to Rust-lang project itself including
 malicious crates/users in crates.io, docs.rs, rustc, cargo or otherwise related
-to Rust-lang repositories and it's infrastructure are handled elsewhere, please
-see the [Rust-lang Security Policy](https://www.rust-lang.org/policies/security) for this.
+to Rust-lang repositories and it's infrastructure, please see the
+[Rust-lang Security Policy](https://www.rust-lang.org/policies/security) for this.
 
 To report a new vulnerability to RustSec, open a pull request using the template
 below. See [CONTRIBUTING.md] for more information.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,6 @@
 ![Maintained: Q2 2022][maintained-image]
 [![Project Chat][chat-image]][chat-link]
 
-**NOTE**: Security Issues related to Rust-lang project itself including
-malicious crates/users in crates.io, docs.rs, rustc, cargo or otherwise related
-to Rust-lang repositories and it's infrastructure are handled elsewhere, please
-see the [Rust-lang Security Policy](https://www.rust-lang.org/policies/security) for this.
-
 The RustSec Advisory Database is a repository of security advisories filed
 against Rust crates published via https://crates.io. A human-readable version
 of the advisory database can be found at https://rustsec.org/advisories/.
@@ -31,8 +26,17 @@ and reporting (send PRs to add yours):
 
 ## Reporting Vulnerabilities
 
-To report a new vulnerability, open a pull request using the template below.
-See [CONTRIBUTING.md] for more information.
+Before reporting a vulnerability, please consult the security policy of any
+given crate / repository before disclosing publicly via RustSec to allow
+responsible disclosure to the responsible maintainers first.
+
+As an example security issues related to Rust-lang project itself including
+malicious crates/users in crates.io, docs.rs, rustc, cargo or otherwise related
+to Rust-lang repositories and it's infrastructure are handled elsewhere, please
+see the [Rust-lang Security Policy](https://www.rust-lang.org/policies/security) for this.
+
+To report a new vulnerability to RustSec, open a pull request using the template
+below. See [CONTRIBUTING.md] for more information.
 
 <a href="https://github.com/RustSec/advisory-db/blob/main/CONTRIBUTING.md">
   <img alt="Report Vulnerability" width="250px" height="60px" src="https://rustsec.org/img/report-vuln-button.svg">


### PR DESCRIPTION
- Issue template to point to the Security policy
- Top level note in README to point to the Security policy