### PR TITLE
Report json as unmaintained

### DIFF
--- a/crates/json/RUSTSEC-0000-0000.md
+++ b/crates/json/RUSTSEC-0000-0000.md
@@ -17,7 +17,7 @@ Last release was almost 3 years ago.
 
 The maintainer is unresponsive with outstanding issues.
 
-These outstanding issues include [a soundness one](https://github.com/maciejhirsz/json-rust/issues/196).
+One of the outstanding issues include [a possible soundness issue](https://github.com/maciejhirsz/json-rust/issues/196).
 
 ## Possible Alternative(s)
 

--- a/crates/json/RUSTSEC-0000-0000.md
+++ b/crates/json/RUSTSEC-0000-0000.md
@@ -15,7 +15,9 @@ patched = []
 
 Last release was almost 3 years ago.
 
-The maintainer is unresponsive with outstanding issues, [a soundness one](https://github.com/maciejhirsz/json-rust/issues/196).
+The maintainer is unresponsive with outstanding issues.
+
+Outstanding issues includes [a soundness one](https://github.com/maciejhirsz/json-rust/issues/196).
 
 ## Possible Alternative(s)
 

--- a/crates/json/RUSTSEC-0000-0000.md
+++ b/crates/json/RUSTSEC-0000-0000.md
@@ -2,16 +2,20 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "json"
-date = "2023-01-18"
+date = "2022-02-01"
 url = "https://github.com/maciejhirsz/json-rust/issues/205"
+references = ["https://github.com/maciejhirsz/json-rust/issues/196"]
 informational = "unmaintained"
+
 [versions]
 patched = []
 ```
 
 # json is unmaintained
 
-The author is unresponsive in Github issues, and there are open issues regarding soundness.
+Last release was almost 3 years ago.
+
+The maintainer is unresponsive with outstanding issues, [a soundness one](https://github.com/maciejhirsz/json-rust/issues/196).
 
 ## Possible Alternative(s)
 

--- a/crates/json/RUSTSEC-0000-0000.md
+++ b/crates/json/RUSTSEC-0000-0000.md
@@ -17,7 +17,7 @@ Last release was almost 3 years ago.
 
 The maintainer is unresponsive with outstanding issues.
 
-Outstanding issues includes [a soundness one](https://github.com/maciejhirsz/json-rust/issues/196).
+These outstanding issues include [a soundness one](https://github.com/maciejhirsz/json-rust/issues/196).
 
 ## Possible Alternative(s)
 

--- a/crates/json/RUSTSEC-0000-0000.md
+++ b/crates/json/RUSTSEC-0000-0000.md
@@ -21,5 +21,6 @@ The maintainer is unresponsive with outstanding issues, [a soundness one](https:
 
 The below list has not been vetted in any way and may or may not contain alternatives;
 
-- [serde-json](https://github.com/serde-rs/json)
-- [json-deserializer](https://github.com/jorgecarleitao/json-deserializer/tree/main)
+- [serde_json](https://crates.io/crates/serde_json)
+- [json-deserializer](https://crates.io/crates/json-deserializer)
+- [simd-json](https://crates.io/crates/simd-json)

--- a/crates/json/RUSTSEC-0000-0000.md
+++ b/crates/json/RUSTSEC-0000-0000.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "json"
+date = "2023-01-18"
+url = "https://github.com/maciejhirsz/json-rust/issues/205"
+informational = "unmaintained"
+[versions]
+patched = []
+```
+
+# json is unmaintained
+
+The author is unresponsive in Github issues, and there are open issues regarding soundness.
+
+## Possible Alternative(s)
+
+The below list has not been vetted in any way and may or may not contain alternatives;
+
+- [serde-json](https://github.com/serde-rs/json)
+- [json-deserializer](https://github.com/jorgecarleitao/json-deserializer/tree/main)


### PR DESCRIPTION
A thread on Reddit yesterday led me to investigate a few different JSON crates in the ecosystem. One of the most popular ones beyond serde-json that reported fast benchmarks is [`json`](https://crates.io/crates/json). I investigated it and discovered [users have asked](https://github.com/maciejhirsz/json-rust/issues/205) if the project is abandoned without reponse. Given how popular this crate appears to be given the recent downloads, I felt an unmaintained advisory was warranted.

Scanning the issues list, I also found [this issue](https://github.com/maciejhirsz/json-rust/issues/196) that may introduce undefined behavior. This triggers a Miri error under the stacked borrows model, but I'm not sure if that's enough to warrant a mention in the advisory or not. 