### PR TITLE
Add advisory for warp#937

### DIFF
--- a/crates/warp/RUSTSEC-0000-0000.md
+++ b/crates/warp/RUSTSEC-0000-0000.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "warp"
+date = "2023-01-28"
+url = "https://github.com/seanmonstar/warp/issues/937"
+categories = ["file-disclosure"]
+keywords = ["directory traversal", "http"]
+
+[affected]
+os = ["windows"]
+
+[versions]
+patched = [">= 0.3.3"]
+```
+
+# Improper validation of Windows paths could lead to directory traversal attack
+
+Path resolution in `warp::filters::fs::dir` didn't correctly validate Windows paths
+meaning paths like `/foo/bar/c:/windows/web/screen/img101.png` would be allowed
+and respond with the contents of `c:/windows/web/screen/img101.png`. Thus users
+could potentially read files anywhere on the filesystem.
+
+This only impacts Windows. Linux and other unix likes are not impacted by this.

--- a/crates/warp/RUSTSEC-0000-0000.md
+++ b/crates/warp/RUSTSEC-0000-0000.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "warp"
-date = "2023-01-28"
+date = "2022-01-14"
 url = "https://github.com/seanmonstar/warp/issues/937"
 categories = ["file-disclosure"]
 keywords = ["directory traversal", "http"]


### PR DESCRIPTION
Fixes #1524. I put the date as 2023, since that is the creation date of this advisory. However, this security issue was filed back in 2022. Let me know if I should change the dates. 