### PR TITLE
Add unmaintained `daemonize`

### DIFF
--- a/crates/daemonize/RUSTSEC-0000-0000.md
+++ b/crates/daemonize/RUSTSEC-0000-0000.md
@@ -1,0 +1,28 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "daemonize"
+date = "2021-09-01"
+url = "https://github.com/knsd/daemonize/issues/46"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `daemonize` is Unmaintained
+
+An [issue](https://github.com/knsd/daemonize/issues/46) inquiring as to possible updates has gone unanswered by the maintainer.
+
+## Continued use
+
+The crate has only two dependencies so may or may not be suitable for use as-is.
+
+## Possible Alternatives
+
+The below list has not been vetted in any way and may or may not contain alternatives:
+
+- [daemonize-me](https://crates.io/crates/daemonize-me)
+- [tetsy-daemonize](https://crates.io/crates/tetsy-daemonize)
+- [parity-daemonize](https://crates.io/crates/parity-daemonize)
+- [daemonizer](https://crates.io/crates/daemonizer)

--- a/crates/daemonize/RUSTSEC-0000-0000.md
+++ b/crates/daemonize/RUSTSEC-0000-0000.md
@@ -24,5 +24,3 @@ The below list has not been vetted in any way and may or may not contain alterna
 
 - [daemonize-me](https://crates.io/crates/daemonize-me)
 - [tetsy-daemonize](https://crates.io/crates/tetsy-daemonize)
-- [parity-daemonize](https://crates.io/crates/parity-daemonize)
-- [daemonizer](https://crates.io/crates/daemonizer)

--- a/crates/daemonize/RUSTSEC-0000-0000.md
+++ b/crates/daemonize/RUSTSEC-0000-0000.md
@@ -12,11 +12,11 @@ patched = []
 
 # `daemonize` is Unmaintained
 
+Last release was over four years ago.
+
+The crate contains undocumented unsafe behind safe fns.
+
 An [issue](https://github.com/knsd/daemonize/issues/46) inquiring as to possible updates has gone unanswered by the maintainer.
-
-## Continued use
-
-The crate has only two dependencies so may or may not be suitable for use as-is.
 
 ## Possible Alternatives
 


### PR DESCRIPTION
Closes #1543

Adds a unmaintained advisory for `daemonize`.

When looking for possible alternatives there are not really any suitable options that immediately jump out at me. Most of them have comparably much lower usage or also seem to be unmaintained.