### PR TITLE
Add tokio `io::ReadHalf<T>::unsplit` unsound

### DIFF
--- a/crates/tokio/RUSTSEC-0000-0000.md
+++ b/crates/tokio/RUSTSEC-0000-0000.md
@@ -29,5 +29,5 @@ soundness issue.
 Thanks to zachs18 reporting the issue to Tokio team responsibly and taiki-e
 and carllerche appropriately responding and fixing the soundness bug.
 
-Tokio before 0.2.0 used `futures` 0.1 that did not have `Pin` thus is not
-affected by the bug - Thank you xfix.
+Tokio before 0.2.0 used `futures` 0.1 that did not have `Pin`, so it is not
+affected by this issue.

--- a/crates/tokio/RUSTSEC-0000-0000.md
+++ b/crates/tokio/RUSTSEC-0000-0000.md
@@ -26,8 +26,8 @@ the surrounding code.
 The `tokio` feature `io-util` is also required to be enabled to trigger this
 soundness issue.
 
-Thanks to @zachs18 reporting the issue to Tokio team responsibly and @taiki-e
-and @carllerche appropriately responding and fixing the soundness bug.
+Thanks to zachs18 reporting the issue to Tokio team responsibly and taiki-e
+and carllerche appropriately responding and fixing the soundness bug.
 
 Tokio before 0.2.0 used `futures` 0.1 that did not have `Pin` thus is not
-affected by the bug - Thank you @xfix.
+affected by the bug - Thank you xfix.

--- a/crates/tokio/RUSTSEC-0000-0000.md
+++ b/crates/tokio/RUSTSEC-0000-0000.md
@@ -1,0 +1,33 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tokio"
+date = "2023-01-11"
+url = "https://github.com/tokio-rs/tokio/issues/5372"
+categories = ["memory-exposure"]
+informational = "unsound"
+
+[versions]
+patched = [">= 1.18.5, < 1.19.0", ">= 1.20.4, < 1.21.0", ">= 1.24.2"]
+unaffected = ["< 0.2.0"]
+```
+
+# `tokio::io::ReadHalf<T>::unsplit` is Unsound
+
+`tokio::io::ReadHalf<T>::unsplit` can violate the `Pin` contract
+
+The soundness issue is described in the [tokio/issues#5372](https://github.com/tokio-rs/tokio/issues/5372)
+
+Specific set of conditions needed to trigger an issue (a !Unpin type in ReadHalf)
+is unusual, combined with the difficulty of making any arbitrary use-after-free
+exploitable in Rust without doing a lot of careful alignment of data types in
+the surrounding code.
+
+The `tokio` feature `io-util` is also required to be enabled to trigger this
+soundness issue.
+
+Thanks to @zachs18 reporting the issue to Tokio team responsibly and @taiki-e
+and @carllerche appropriately responding and fixing the soundness bug.
+
+Tokio before 0.2.0 used `futures` 0.1 that did not have `Pin` thus is not
+affected by the bug - Thank you @xfix.


### PR DESCRIPTION
Closes #1532 

Cc/ @zachs18 @carllerche - this `informational = "unsound"`

So not a full advisory but anyways