### PR TITLE
Add unmaintained `multi_mut`

### DIFF
--- a/crates/multi_mut/RUSTSEC-0000-0000.md
+++ b/crates/multi_mut/RUSTSEC-0000-0000.md
@@ -5,7 +5,7 @@ package = "multi_mut"
 date = "2020-02-07"
 url = "https://github.com/golddranks/multi_mut/issues/1"
 references = ["https://github.com/rust-lang/rust/issues/39155", "https://www.reddit.com/r/rust/comments/5ofuun/multi_mut_multiple_mutable_references_to_hashmap/"]
-informational = "unmaintained"
+informational = "unsound"
 
 [versions]
 patched = []

--- a/crates/multi_mut/RUSTSEC-0000-0000.md
+++ b/crates/multi_mut/RUSTSEC-0000-0000.md
@@ -1,0 +1,28 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "multi_mut"
+date = "2020-02-07"
+url = "https://github.com/golddranks/multi_mut/issues/1"
+references = ["https://github.com/rust-lang/rust/issues/39155", "https://www.reddit.com/r/rust/comments/5ofuun/multi_mut_multiple_mutable_references_to_hashmap/"]
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+# multi_mut is Unmaintained
+
+Last release was about 6 years ago.
+
+There is an outstanding [soundness issue](https://github.com/golddranks/multi_mut/issues/1).
+
+The maintainer has not responded for two years to the existing soundness issue.
+
+Rust compiler has enabled errors relating to LLVM noalias rules and may not
+compile anymore where as the old compiler versions had turned these off.
+
+The maintainer has stated:
+
+> I will take no responsibility of undefined behaviour possibly caused by this crate.
+
+This crate may or may not be suitable for use anymore given the outstanding issues.


### PR DESCRIPTION
Fixes #1531 

It has no dependants so I think unmaintained can do it ?

Ping: https://github.com/rust-lang/rust/issues/39155