### PR TITLE
Fix typo in `claim` advisory.

### DIFF
--- a/crates/claim/RUSTSEC-2022-0077.md
+++ b/crates/claim/RUSTSEC-2022-0077.md
@@ -16,7 +16,7 @@ The last release was in February 2021, almost two years ago.
 
 The maintainer has been unresponsive regarding this crate for over a year.
 
-A pending issue with `claim`'s dependencies has made the crate [difficul to use](https://github.com/svartalf/rust-claim/issues/9)
+A pending issue with `claim`'s dependencies has made the crate [difficult to use](https://github.com/svartalf/rust-claim/issues/9).
 
 ## Possible Alternative(s)
 


### PR DESCRIPTION
Added in the missing letter. Also added a period at the end of the sentence :)