### PR TITLE
Add advisory Tauri filesystem scope bypass

### DIFF
--- a/crates/tauri/RUSTSEC-0000-0000.md
+++ b/crates/tauri/RUSTSEC-0000-0000.md
@@ -9,8 +9,8 @@ aliases = ["CVE-2022-41874", "GHSA-q9wv-22m9-vhqh"]
 cvss = "CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:C/C:L/I:N/A:N"
 
 [versions]
-patched = [">= 1.0.7", ">= 1.1.2"]
-unaffected = ["< 1.0.0", "< 1.1.0"]
+patched = [">= 1.0.7, < 1.1.0", ">= 1.1.2"]
+unaffected = ["< 1.0.0"]
 ```
 
 # `tauri` filesystem scope partial bypass

--- a/crates/tauri/RUSTSEC-0000-0000.md
+++ b/crates/tauri/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tauri"
+date = "2022-09-19"
+url = "https://github.com/tauri-apps/tauri/issues/5234"
+categories = ["privilege-escalation"]
+aliases = ["CVE-2022-41874", "GHSA-q9wv-22m9-vhqh"]
+cvss = "CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:C/C:L/I:N/A:N"
+
+[versions]
+patched = [">= 1.0.7", ">= 1.1.2"]
+unaffected = ["< 1.0.0", "< 1.1.0"]
+```
+
+# `tauri` filesystem scope partial bypass
+
+A bug identified in [this](https://github.com/tauri-apps/tauri/issues/5234) issue allows a partial filesystem scope bypass if glob characters are used within file dialog or drag-and-drop functionalities.
+
+[This](https://github.com/tauri-apps/tauri/pull/5237) PR fixes the issue by escaping glob characters.


### PR DESCRIPTION
Closes #1485 

This advisory affects multiple ranges of versions (>= 1.0.0, < 1.0.7 and >= 1.1.0, < 1.1.2) so was not sure of the correct representation in the advisory format.

There is not an official cvss number on the CVE so I took liberties with the [Calculator](https://www.first.org/cvss/calculator/3.1#CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:C/C:L/I:N/A:N). I feel that it was a bit of guesswork on my part.