### PR TITLE
Update RUSTSEC-2020-0071.md

### DIFF
--- a/crates/time/RUSTSEC-2020-0071.md
+++ b/crates/time/RUSTSEC-2020-0071.md
@@ -71,7 +71,7 @@ Users of time 0.1 do not have a patch and should upgrade to an unaffected versio
 
 ### Workarounds
 
-A possible workaround is to avoid using the default `oldtime` feature dependency of the `chrono` crate by disabling its `default-features` and manually specifying the required features instead.
+A possible workaround for crates affected through the transitive dependency in `chrono`, is to avoid using the default `oldtime` feature dependency of the `chrono` crate by disabling its default-features and manually specifying the required features instead.
 
 #### Examples:
 

--- a/crates/time/RUSTSEC-2020-0071.md
+++ b/crates/time/RUSTSEC-2020-0071.md
@@ -71,4 +71,26 @@ Users of time 0.1 do not have a patch and should upgrade to an unaffected versio
 
 ### Workarounds
 
-No workarounds are known.
+A possible workaround is to avoid using the default `oldtime` feature dependency of the `chrono` crate by disabling its `default-features` and manually specifying the required features instead.
+
+#### Examples:
+
+`Cargo.toml`:  
+
+```toml
+chrono = { version = "0.4", default-features = false, features = ["serde"] }
+```
+
+```toml
+chrono = { version = "0.4.22", default-features = false, features = ["clock"] }
+```
+
+Commandline:  
+
+```bash
+cargo add chrono --no-default-features -F clock
+```
+
+Sources:  
+ - https://github.com/chronotope/chrono/issues/602#issuecomment-1242149249  
+ - https://github.com/vityafx/serde-aux/issues/21  


### PR DESCRIPTION
I found this solution to work for me and I hope it is correct as cargo-audit stopped complaining about this vulnerability once this workaround is applied.