### PR TITLE
Update RUSTSEC-2020-0071.md

### DIFF
--- a/crates/time/RUSTSEC-2020-0071.md
+++ b/crates/time/RUSTSEC-2020-0071.md
@@ -71,7 +71,7 @@ Users of time 0.1 do not have a patch and should upgrade to an unaffected versio
 
 ### Workarounds
 
-A possible workaround for crates affected through the transitive dependency in `chrono`, is to avoid using the default `oldtime` feature dependency of the `chrono` crate by disabling its default-features and manually specifying the required features instead.
+A possible workaround for crates affected through the transitive dependency in `chrono`, is to avoid using the default `oldtime` feature dependency of the `chrono` crate by disabling its `default-features` and manually specifying the required features instead.
 
 #### Examples:
 
@@ -92,5 +92,5 @@ cargo add chrono --no-default-features -F clock
 ```
 
 Sources:  
- - https://github.com/chronotope/chrono/issues/602#issuecomment-1242149249  
- - https://github.com/vityafx/serde-aux/issues/21  
+ - [chronotope/chrono#602 (comment)](https://github.com/chronotope/chrono/issues/602#issuecomment-1242149249)  
+ - [vityafx/serde-aux#21](https://github.com/vityafx/serde-aux/issues/21)  


### PR DESCRIPTION
The sources links were published without a hyperlink at: https://rustsec.org/advisories/RUSTSEC-2020-0071

This update is using explicit markdown hyperlinks in hopes that it will be rendered and published correctly.