### PR TITLE
Add sqlite advisory

### DIFF
--- a/crates/libsqlite3-sys/RUSTSEC-0000-0000.md
+++ b/crates/libsqlite3-sys/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libsqlite3-sys"
+date = "2022-08-03"
+url = "https://nvd.nist.gov/vuln/detail/CVE-2022-35737"
+categories = ["denial-of-service", "code-execution"]
+aliases = ["CVE-2022-35737"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+
+[versions]
+patched = [">= 0.25.1"]
+```
+
+# `libsqlite3-sys` via C SQLite CVE-2022-35737
+
+It was sometimes possible for SQLite versions >= 1.0.12, < 3.39.2 to allow an array-bounds overflow when large string were input into SQLite's `printf` function.
+
+As `libsqlite3-sys` bundles SQLite, it is susceptible to the vulnerability. `libsqlite3-sys` was updated to bundle the patched version of SQLite [here](https://github.com/rusqlite/rusqlite/releases/tag/sys0.25.1).


### PR DESCRIPTION
Closes #1446 

One thing I noticed is that the NIST link to the CVE does not exist (see [here](https://nvd.nist.gov/vuln/detail/CVE-2022-35737)), but I could find it on the Wayback machine (see [here](https://web.archive.org/web/20221027155821/https://nvd.nist.gov/vuln/detail/CVE-2022-35737)). So not sure if the CVE is still valid.