### PR TITLE
Update RUSTSEC-2020-0097.md

### DIFF
--- a/crates/xcb/RUSTSEC-2020-0097.md
+++ b/crates/xcb/RUSTSEC-2020-0097.md
@@ -5,12 +5,12 @@ package = "xcb"
 aliases = ["CVE-2020-36205"]
 cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 date = "2020-12-10"
-url = "https://github.com/rtbo/rust-xcb/issues/93"
+url = "https://github.com/rust-x-bindings/rust-xcb/issues/93"
 categories = ["memory-corruption", "thread-safety"]
 informational = "unsound"
 
 [versions]
-patched = []
+patched = [">= 1.0"]
 ```
 
 # Soundness issue with base::Error


### PR DESCRIPTION
This issue has been patched in versions >=v1.0 (see [comment]).

[comment]: https://github.com/rust-x-bindings/rust-xcb/issues/93#issuecomment-966921127