### PR TITLE
Add unmaintained ftp crate

### DIFF
--- a/crates/ftp/RUSTSEC-0000-0000.md
+++ b/crates/ftp/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "ftp"
+date = "2023-02-20"
+url = "https://github.com/mattnenterprise/rust-ftp/pull/92"
+references = ["https://github.com/mattnenterprise/rust-ftp/issues/91", "https://github.com/mattnenterprise/rust-ftp/issues/84"]
+informational = "unmaintained"
+categories = ["crypto-failure"]
+keywords = ["ssl", "wont-build"]
+[versions]
+patched = []
+```
+
+# ftp is unmaintained, use suppaftp instead
+
+The [`ftp`](https://crates.io/crates/ftp) crate is not maintained any more;
+use [`suppaftp`](https://crates.io/crates/suppaftp) instead.

--- a/crates/ftp/RUSTSEC-0000-0000.md
+++ b/crates/ftp/RUSTSEC-0000-0000.md
@@ -6,7 +6,6 @@ date = "2023-02-20"
 url = "https://github.com/mattnenterprise/rust-ftp/pull/92"
 references = ["https://github.com/mattnenterprise/rust-ftp/issues/91", "https://github.com/mattnenterprise/rust-ftp/issues/84"]
 informational = "unmaintained"
-categories = ["crypto-failure"]
 keywords = ["ssl", "wont-build"]
 [versions]
 patched = []


### PR DESCRIPTION
Report for unmaintained `ftp` crate. Use `suppaftp` instead