### PR TITLE
Add unsound `const-cstr`

### DIFF
--- a/crates/const-cstr/RUSTSEC-0000-0000.md
+++ b/crates/const-cstr/RUSTSEC-0000-0000.md
@@ -36,5 +36,5 @@ This is however unlikely but the the crate should not be used for untrusted data
 
 The below may or may not provide alternative(s)
 
-- [const_cstr::cstr!](https://docs.rs/const-str/latest/const_str/macro.cstr.html)
-- [cstr::cstr!](https://docs.rs/cstr/latest/cstr)
+- [const_str::cstr!](https://docs.rs/const-str/latest/const_str/macro.cstr.html)
+- [cstr::cstr!](https://crates.io/crates/cstr)

--- a/crates/const-cstr/RUSTSEC-0000-0000.md
+++ b/crates/const-cstr/RUSTSEC-0000-0000.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "const-cstr"
-date = "2023-02-14"
+date = "2023-03-12"
 url = "https://github.com/abonander/const-cstr"
 informational = "unsound"
 

--- a/crates/const-cstr/RUSTSEC-0000-0000.md
+++ b/crates/const-cstr/RUSTSEC-0000-0000.md
@@ -4,12 +4,37 @@ id = "RUSTSEC-0000-0000"
 package = "const-cstr"
 date = "2023-02-14"
 url = "https://github.com/abonander/const-cstr"
-informational = "unmaintained"
+informational = "unsound"
 
 [versions]
 patched = []
 ```
 
-# const-cstr is unmaintained
+# const-cstr is Unmaintained
 
-Maintainer has archived the GitHub repository. No known alternatives exists.
+Last release was about five years ago.
+
+The maintainer(s) have been unreachable to respond to any issues that may or may not include security issues.
+
+The repository is now archived and there is no security policy in place to contact the maintainer(s) otherwise.
+
+No direct fork exist.
+
+# const-cstr is Unsound
+
+The crate violates the safety contract of [ffi::CStr::from_bytes_with_nul_unchecked](https://doc.rust-lang.org/std/ffi/struct.CStr.html#method.from_bytes_with_nul_unchecked) used in `ConstCStr::as_cstr`
+
+No interior nul bytes checking is done either by the constructor or the canonical macro to create the `ConstCStr`
+
+# const-cstr Panic
+
+Additionally the crate may cause runtime panics if statically compiled and ran with any untrusted data that is not nul-terminated.
+
+This is however unlikely but the the crate should not be used for untrusted data in context where panic may create a DoS vector.
+
+## Possible Alternatives
+
+The below may or may not provide alternative(s)
+
+- [const_cstr::cstr!](https://docs.rs/const-str/latest/const_str/macro.cstr.html)
+- [cstr::cstr!](https://docs.rs/cstr/latest/cstr)

--- a/crates/const-cstr/RUSTSEC-0000-0000.md
+++ b/crates/const-cstr/RUSTSEC-0000-0000.md
@@ -1,0 +1,15 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "const-cstr"
+date = "2023-02-14"
+url = "https://github.com/abonander/const-cstr"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# const-cstr is unmaintained
+
+Maintainer has archived the GitHub repository. No known alternatives exists.


### PR DESCRIPTION
const-cstr is crate by @abonander who has archived bunch of his Rust crates in GitHub.

See communication attempts on other crates:
 * https://github.com/rustsec/advisory-db/issues/1602
 * https://github.com/rustsec/advisory-db/issues/1438

