### PR TITLE
Add unmaintained `buf_redux`

### DIFF
--- a/crates/buf_redux/RUSTSEC-0000-0000.md
+++ b/crates/buf_redux/RUSTSEC-0000-0000.md
@@ -22,12 +22,11 @@ The safety-undocumented unsafe in the crate may or may not be safe to use.
 
 The crate also has a current future incompatibility warning [buf_redux/23](https://github.com/abonander/buf_redux/issues/23).
 
-No direct fork exist.
-
 ## Possible Alternatives
 
 The below may or may not provide alternative(s)
 
 - Rust alloc / std vec::Vec, collections::VecDeque
+- [buffer-redux](https://crates.io/crates/buffer-redux) - fork
 - [bytes](https://crates.io/crates/bytes)
 - [crates.io search for 'buffer'](https://crates.io/keywords/buffer)

--- a/crates/buf_redux/RUSTSEC-0000-0000.md
+++ b/crates/buf_redux/RUSTSEC-0000-0000.md
@@ -1,0 +1,15 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "buf_redux"
+date = "2023-02-14"
+url = "https://github.com/abonander/buf_redux/issues/22"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# buf_redux is unmaintained
+
+Maintainer has archived the GitHub repository. No known alternatives exists.

--- a/crates/buf_redux/RUSTSEC-0000-0000.md
+++ b/crates/buf_redux/RUSTSEC-0000-0000.md
@@ -28,6 +28,6 @@ No direct fork exist.
 
 The below may or may not provide alternative(s)
 
-- Rust core / std vec::Vec, collections::VecDeque
+- Rust alloc / std vec::Vec, collections::VecDeque
 - [bytes](https://crates.io/crates/bytes)
 - [crates.io search for 'buffer'](https://crates.io/keywords/buffer)

--- a/crates/buf_redux/RUSTSEC-0000-0000.md
+++ b/crates/buf_redux/RUSTSEC-0000-0000.md
@@ -16,7 +16,7 @@ Last release was over three years ago.
 
 The maintainer(s) have been unreachable to respond to any issues that may or may not include security issues.
 
-The repository is now archived and there is no security policy in place to contact the maintainer otherwise.
+The repository is now archived and there is no security policy in place to contact the maintainer(s) otherwise.
 
 The safety-undocumented unsafe in the crate may or may not be safe to use.
 

--- a/crates/buf_redux/RUSTSEC-0000-0000.md
+++ b/crates/buf_redux/RUSTSEC-0000-0000.md
@@ -14,9 +14,9 @@ patched = []
 
 Last release was over three years ago.
 
-Maintainer has been unreachable to respond to any issues that may or may not include security issues.
+The maintainer(s) have been unreachable to respond to any issues that may or may not include security issues.
 
-The repository is archived and there is no security policy in place to contact the maintainer otherwise.
+The repository is now archived and there is no security policy in place to contact the maintainer otherwise.
 
 The safety-undocumented unsafe in the crate may or may not be safe to use.
 

--- a/crates/buf_redux/RUSTSEC-0000-0000.md
+++ b/crates/buf_redux/RUSTSEC-0000-0000.md
@@ -2,14 +2,30 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "buf_redux"
-date = "2023-02-14"
-url = "https://github.com/abonander/buf_redux/issues/22"
+date = "2023-01-24"
+url = "https://github.com/abonander/buf_redux/issues"
 informational = "unmaintained"
 
 [versions]
 patched = []
 ```
 
-# buf_redux is unmaintained
+# buf_redux is Unmaintained
 
-Maintainer has archived the GitHub repository. No known alternatives exists.
+Last release was over three years ago.
+
+Maintainer has archived the GitHub repository and is unreachable to respond to any issues that may or may not include security related issues.
+
+The safety-undocumented unsafe in the crate may or may not be safe to use.
+
+The crate also has a current future incompatibility warning [buf_redux/23](https://github.com/abonander/buf_redux/issues/23).
+
+No direct fork exist.
+
+## Possible Alternatives
+
+The below list have not been vetted in any way and may or may not provide alternative(s)
+
+- Rust core / std vec::Vec, collections::VecDeque
+- [bytes](https://crates.io/crates/bytes)
+- [crates.io search for 'buffer'](https://crates.io/keywords/buffer)

--- a/crates/buf_redux/RUSTSEC-0000-0000.md
+++ b/crates/buf_redux/RUSTSEC-0000-0000.md
@@ -16,7 +16,7 @@ Last release was over three years ago.
 
 Maintainer has been unreachable to respond to any issues that may or may not include security issues.
 
-The repository is arhcived and there is no security policy in place to contact the maintainer otherwise.
+The repository is archived and there is no security policy in place to contact the maintainer otherwise.
 
 The safety-undocumented unsafe in the crate may or may not be safe to use.
 

--- a/crates/buf_redux/RUSTSEC-0000-0000.md
+++ b/crates/buf_redux/RUSTSEC-0000-0000.md
@@ -14,7 +14,9 @@ patched = []
 
 Last release was over three years ago.
 
-Maintainer has archived the GitHub repository and is unreachable to respond to any issues that may or may not include security related issues.
+Maintainer has been unreachable to respond to any issues that may or may not include security issues.
+
+The repository is arhcived and there is no security policy in place to contact the maintainer otherwise.
 
 The safety-undocumented unsafe in the crate may or may not be safe to use.
 
@@ -24,7 +26,7 @@ No direct fork exist.
 
 ## Possible Alternatives
 
-The below list have not been vetted in any way and may or may not provide alternative(s)
+The below may or may not provide alternative(s)
 
 - Rust core / std vec::Vec, collections::VecDeque
 - [bytes](https://crates.io/crates/bytes)


### PR DESCRIPTION
buf_redux is crate by @abonander who has archived bunch of his Rust crates in GitHub including this one.

No reaction to any open pull request or issues since 2019 in the repository. Last crates.io release also from 2019.

My question about maintenance status has been unanswered so far https://github.com/abonander/buf_redux/issues/22

And there's also future incompatibility warning https://github.com/abonander/buf_redux/issues/23.

Fixes #1602