### PR TITLE
Add unmaintained advisory for safemem

### DIFF
--- a/crates/safemem/RUSTSEC-0000-0000.md
+++ b/crates/safemem/RUSTSEC-0000-0000.md
@@ -1,0 +1,15 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "safemem"
+date = "2023-02-14"
+url = "https://github.com/abonander/safemem"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# safemem is unmaintained
+
+Maintainer has archived the GitHub repository. No known alternatives exists.

--- a/crates/safemem/RUSTSEC-0000-0000.md
+++ b/crates/safemem/RUSTSEC-0000-0000.md
@@ -12,4 +12,12 @@ patched = []
 
 # safemem is unmaintained
 
+Last release was over three years ago.
+
+The maintainer(s) have been unreachable to respond to any issues that may or may not include security issues.
+
+The repository is now archived and there is no security policy in place to contact the maintainer(s) otherwise.
+
+## Possible Alternatives
+
 Maintainer has archived the GitHub repository. No known alternatives exists.

--- a/crates/safemem/RUSTSEC-0000-0000.md
+++ b/crates/safemem/RUSTSEC-0000-0000.md
@@ -12,12 +12,4 @@ patched = []
 
 # safemem is unmaintained
 
-Last release was over three years ago.
-
-The maintainer(s) have been unreachable to respond to any issues that may or may not include security issues.
-
-The repository is now archived and there is no security policy in place to contact the maintainer(s) otherwise.
-
-## Possible Alternatives
-
-Maintainer has archived the GitHub repository. No known alternatives exists.
+The latest crates.io release was in 2019. The repository has been archived by the author.


### PR DESCRIPTION
safemem is crate by @abonander who has archived bunch of his Rust crates in GitHub.

See communication attempts on other crates:
 * https://github.com/rustsec/advisory-db/issues/1602
 * https://github.com/rustsec/advisory-db/issues/1438

