### PR TITLE
Add unmaintained advisory for ncollide

### DIFF
--- a/crates/ncollide2d/RUSTSEC-0000-0000.md
+++ b/crates/ncollide2d/RUSTSEC-0000-0000.md
@@ -1,0 +1,15 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "ncollide2d"
+date = "2021-01-29"
+url = "https://github.com/dimforge/ncollide"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+# ncollide2d is unmaintained
+
+The maintainer has advised that this crate is passively-maintained and that it
+is being superseded by the [Parry](https://github.com/dimforge/parry) project.

--- a/crates/ncollide3d/RUSTSEC-0000-0000.md
+++ b/crates/ncollide3d/RUSTSEC-0000-0000.md
@@ -1,0 +1,15 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "ncollide3d"
+date = "2021-01-29"
+url = "https://github.com/dimforge/ncollide"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+# ncollide3d is unmaintained
+
+The maintainer has advised that this crate is passively-maintained and that it
+is being superseded by the [Parry](https://github.com/dimforge/parry) project.


### PR DESCRIPTION
There is no activity since March 2022 and the maintainer has advised that this crate is passively-maintained since January 2021.