### PR TITLE
Add unmaintained advisory for nphysics

### DIFF
--- a/crates/nphysics2d/RUSTSEC-0000-0000.md
+++ b/crates/nphysics2d/RUSTSEC-0000-0000.md
@@ -1,0 +1,15 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "nphysics2d"
+date = "2021-01-29"
+url = "https://github.com/dimforge/nphysics"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+# nphysics2d is unmaintained
+
+The maintainer has advised that this crate is passively-maintained and that it
+is being superseded by the [Rapier](https://github.com/dimforge/rapier) project.

--- a/crates/nphysics3d/RUSTSEC-0000-0000.md
+++ b/crates/nphysics3d/RUSTSEC-0000-0000.md
@@ -1,0 +1,15 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "nphysics3d"
+date = "2021-01-29"
+url = "https://github.com/dimforge/nphysics"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+# nphysics3d is unmaintained
+
+The maintainer has advised that this crate is passively-maintained and that it
+is being superseded by the [Rapier](https://github.com/dimforge/rapier) project.


### PR DESCRIPTION
There is no activity since July 2021 and the maintainer has advised that this crate is passively-maintained since January 2021.