### PR TITLE
`out_reference::Out::from_raw` should be `unsafe`

### DIFF
--- a/crates/out-reference/RUSTSEC-0000-0000.md
+++ b/crates/out-reference/RUSTSEC-0000-0000.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "out-reference"
-date = "2020-03-04"
+date = "2021-01-20"
 url = "https://github.com/RustyYato/out-ref/issues/1"
 informational = "unsound"
 categories = ["memory-corruption"]

--- a/crates/out-reference/RUSTSEC-0000-0000.md
+++ b/crates/out-reference/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "out-reference"
+date = "2020-03-04"
+url = "https://github.com/RustyYato/out-ref/issues/1"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["unsound", "raw-pointer"]
+
+[versions]
+patched = [">=0.2.0"]
+unaffected = []
+
+[affected.functions]
+"out_reference::Out::from_raw" = [">=0.1.0, <0.2.0"]
+```
+
+# `out_reference::Out::from_raw` should be `unsafe`
+
+`Out::from_raw` in affected versions allows writing a value to invalid memory address without requiring `unsafe`.
+
+The unsoundness has been fixed by making `Out::from_raw` an unsafe function.

--- a/crates/out-reference/RUSTSEC-0000-0000.md
+++ b/crates/out-reference/RUSTSEC-0000-0000.md
@@ -9,15 +9,15 @@ categories = ["memory-corruption"]
 keywords = ["unsound", "raw-pointer"]
 
 [versions]
-patched = [">=0.2.0"]
-unaffected = []
+patched = [">= 0.2.0"]
+unaffected = ["< 0.1.0"]
 
 [affected.functions]
-"out_reference::Out::from_raw" = [">=0.1.0, <0.2.0"]
+"out_reference::Out::from_raw" = [">= 0.1.0, < 0.2.0"]
 ```
 
 # `out_reference::Out::from_raw` should be `unsafe`
 
 `Out::from_raw` in affected versions allows writing a value to invalid memory address without requiring `unsafe`.
 
-The unsoundness has been fixed by making `Out::from_raw` an unsafe function.
+The soundness issue has been addressed by making `Out::from_raw` an unsafe function.


### PR DESCRIPTION
Resolves #613 