### PR TITLE
Add unmaintained advisory for diesel-adapter

### DIFF
--- a/crates/diesel-adapter/RUSTSEC-0000-0000.md
+++ b/crates/diesel-adapter/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "diesel-adapter"
+date = "2023-03-08"
+informational = "unmaintained"
+url = "https://github.com/casbin-rs/diesel-adapter/issues/75"
+references = ["https://github.com/casbin-rs/diesel-adapter/issues/70"]
+
+[versions]
+patched = []
+```
+
+# diesel-adapter is Unmaintained
+
+Last release was more than 2 years ago and has much older dependencies with open CVEs and no one to actively address and update the software.
+
+Current outstanding issues include vulnerable dependencies that all together may mean that security issues may not be addressed now or in the future.
+
+## Possible Alternative(s)
+
+There are currently no known alternatives.


### PR DESCRIPTION
`diesel-adapter` has some dependencies with CVEs open it, and an attempt to update things from a crate consumer shows that (a) there really isn't anyone assigned to maintenance of the crate, e.g. issue fixes are requested from the community rather than having someone able to response, and (b) the source has a broken CI that can't realistically be addressed from a few drive-by patches.