### PR TITLE
Add "unmaintained" advisories for all old Gitoxide crates.

### DIFF
--- a/crates/git-actor/RUSTSEC-0000-0000.md
+++ b/crates/git-actor/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-actor"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-actor to continue receiving updates.

--- a/crates/git-attributes/RUSTSEC-0000-0000.md
+++ b/crates/git-attributes/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-attributes"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-attributes to continue receiving updates.

--- a/crates/git-bitmap/RUSTSEC-0000-0000.md
+++ b/crates/git-bitmap/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-bitmap"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-bitmap to continue receiving updates.

--- a/crates/git-chunk/RUSTSEC-0000-0000.md
+++ b/crates/git-chunk/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-chunk"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-chunk to continue receiving updates.

--- a/crates/git-command/RUSTSEC-0000-0000.md
+++ b/crates/git-command/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-command"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-command to continue receiving updates.

--- a/crates/git-commitgraph/RUSTSEC-0000-0000.md
+++ b/crates/git-commitgraph/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-commitgraph"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-commitgraph to continue receiving updates.

--- a/crates/git-config-value/RUSTSEC-0000-0000.md
+++ b/crates/git-config-value/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-config-value"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-config-value to continue receiving updates.

--- a/crates/git-config/RUSTSEC-0000-0000.md
+++ b/crates/git-config/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-config"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-config to continue receiving updates.

--- a/crates/git-credentials/RUSTSEC-0000-0000.md
+++ b/crates/git-credentials/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-credentials"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-credentials to continue receiving updates.

--- a/crates/git-date/RUSTSEC-0000-0000.md
+++ b/crates/git-date/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-date"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-date to continue receiving updates.

--- a/crates/git-diff/RUSTSEC-0000-0000.md
+++ b/crates/git-diff/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-diff"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-diff to continue receiving updates.

--- a/crates/git-discover/RUSTSEC-0000-0000.md
+++ b/crates/git-discover/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-discover"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-discover to continue receiving updates.

--- a/crates/git-features/RUSTSEC-0000-0000.md
+++ b/crates/git-features/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-features"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-features to continue receiving updates.

--- a/crates/git-fetchhead/RUSTSEC-0000-0000.md
+++ b/crates/git-fetchhead/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-fetchhead"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-fetchhead to continue receiving updates.

--- a/crates/git-filter/RUSTSEC-0000-0000.md
+++ b/crates/git-filter/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-filter"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-filter to continue receiving updates.

--- a/crates/git-glob/RUSTSEC-0000-0000.md
+++ b/crates/git-glob/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-glob"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-glob to continue receiving updates.

--- a/crates/git-hash/RUSTSEC-0000-0000.md
+++ b/crates/git-hash/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-hash"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-hash to continue receiving updates.

--- a/crates/git-hashtable/RUSTSEC-0000-0000.md
+++ b/crates/git-hashtable/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-hashtable"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-hashtable to continue receiving updates.

--- a/crates/git-index/RUSTSEC-0000-0000.md
+++ b/crates/git-index/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-index"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-index to continue receiving updates.

--- a/crates/git-lfs/RUSTSEC-0000-0000.md
+++ b/crates/git-lfs/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-lfs"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-lfs to continue receiving updates.

--- a/crates/git-lock/RUSTSEC-0000-0000.md
+++ b/crates/git-lock/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-lock"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-lock to continue receiving updates.

--- a/crates/git-mailmap/RUSTSEC-0000-0000.md
+++ b/crates/git-mailmap/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-mailmap"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-mailmap to continue receiving updates.

--- a/crates/git-note/RUSTSEC-0000-0000.md
+++ b/crates/git-note/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-note"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-note to continue receiving updates.

--- a/crates/git-object/RUSTSEC-0000-0000.md
+++ b/crates/git-object/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-object"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-object to continue receiving updates.

--- a/crates/git-odb/RUSTSEC-0000-0000.md
+++ b/crates/git-odb/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-odb"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-odb to continue receiving updates.

--- a/crates/git-pack/RUSTSEC-0000-0000.md
+++ b/crates/git-pack/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-pack"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-pack to continue receiving updates.

--- a/crates/git-packetline/RUSTSEC-0000-0000.md
+++ b/crates/git-packetline/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-packetline"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-packetline to continue receiving updates.

--- a/crates/git-path/RUSTSEC-0000-0000.md
+++ b/crates/git-path/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-path"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-path to continue receiving updates.

--- a/crates/git-pathspec/RUSTSEC-0000-0000.md
+++ b/crates/git-pathspec/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-pathspec"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-pathspec to continue receiving updates.

--- a/crates/git-prompt/RUSTSEC-0000-0000.md
+++ b/crates/git-prompt/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-prompt"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-prompt to continue receiving updates.

--- a/crates/git-protocol/RUSTSEC-0000-0000.md
+++ b/crates/git-protocol/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-protocol"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-protocol to continue receiving updates.

--- a/crates/git-quote/RUSTSEC-0000-0000.md
+++ b/crates/git-quote/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-quote"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-quote to continue receiving updates.

--- a/crates/git-rebase/RUSTSEC-0000-0000.md
+++ b/crates/git-rebase/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-rebase"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-rebase to continue receiving updates.

--- a/crates/git-ref/RUSTSEC-0000-0000.md
+++ b/crates/git-ref/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-ref"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-ref to continue receiving updates.

--- a/crates/git-refspec/RUSTSEC-0000-0000.md
+++ b/crates/git-refspec/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-refspec"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-refspec to continue receiving updates.

--- a/crates/git-revision/RUSTSEC-0000-0000.md
+++ b/crates/git-revision/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-revision"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-revision to continue receiving updates.

--- a/crates/git-sec/RUSTSEC-0000-0000.md
+++ b/crates/git-sec/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-sec"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-sec to continue receiving updates.

--- a/crates/git-sequencer/RUSTSEC-0000-0000.md
+++ b/crates/git-sequencer/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-sequencer"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-sequencer to continue receiving updates.

--- a/crates/git-submodule/RUSTSEC-0000-0000.md
+++ b/crates/git-submodule/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-submodule"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-submodule to continue receiving updates.

--- a/crates/git-tempfile/RUSTSEC-0000-0000.md
+++ b/crates/git-tempfile/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-tempfile"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-tempfile to continue receiving updates.

--- a/crates/git-tix/RUSTSEC-0000-0000.md
+++ b/crates/git-tix/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-tix"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-tix to continue receiving updates.

--- a/crates/git-transport/RUSTSEC-0000-0000.md
+++ b/crates/git-transport/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-transport"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-transport to continue receiving updates.

--- a/crates/git-traverse/RUSTSEC-0000-0000.md
+++ b/crates/git-traverse/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-traverse"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-traverse to continue receiving updates.

--- a/crates/git-url/RUSTSEC-0000-0000.md
+++ b/crates/git-url/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-url"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-url to continue receiving updates.

--- a/crates/git-validate/RUSTSEC-0000-0000.md
+++ b/crates/git-validate/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-validate"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-validate to continue receiving updates.

--- a/crates/git-worktree/RUSTSEC-0000-0000.md
+++ b/crates/git-worktree/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git-worktree"
+date = "2023-03-14"
+url = "https://github.com/Byron/gitoxide/pull/741"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Gitoxide has renamed its crates.
+
+All crates in the gitoxide project have been renamed from git-<crate> to
+gix-<crate>. The git- prefixed crates are no longer being updated. Switch
+to using gix-worktree to continue receiving updates.


### PR DESCRIPTION
Gitoxide mass renamed its crates from git-<crate> to gix-<crate>, and the old crate names are no longer receiving updates. Create advisories for all of them with messages pointing to the new crates.