### PR TITLE
Update RUSTSEC-2022-0076.md with v1 patch

### DIFF
--- a/crates/wasmtime/RUSTSEC-2022-0076.md
+++ b/crates/wasmtime/RUSTSEC-2022-0076.md
@@ -14,7 +14,7 @@ aliases = ["CVE-2022-39392", "GHSA-44mr-8vmm-wjhg"]
 patched = [">= 1.0.2, < 2.0.0", ">= 2.0.2"]
 
 [affected]
-functions = { "wasmtime::PoolingAllocationConfig::instance_memory_pages" = [">= 1.0.2, < 2.0.0", "< 2.0.2"] }
+functions = { "wasmtime::PoolingAllocationConfig::instance_memory_pages" = ["< 1.0.2", "> 2.0.0, < 2.0.2"] }
 ```
 
 # Bug in Wasmtime implementation of pooling instance allocator

--- a/crates/wasmtime/RUSTSEC-2022-0076.md
+++ b/crates/wasmtime/RUSTSEC-2022-0076.md
@@ -11,10 +11,10 @@ cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N"
 aliases = ["CVE-2022-39392", "GHSA-44mr-8vmm-wjhg"]
 
 [versions]
-patched = [">= 2.0.2", ">= 1.0.2"]
+patched = [">= 1.0.2, < 2.0.0", ">= 2.0.2"]
 
 [affected]
-functions = { "wasmtime::PoolingAllocationConfig::instance_memory_pages" = ["< 2.0.2"] }
+functions = { "wasmtime::PoolingAllocationConfig::instance_memory_pages" = [">= 1.0.2, < 2.0.0", "< 2.0.2"] }
 ```
 
 # Bug in Wasmtime implementation of pooling instance allocator

--- a/crates/wasmtime/RUSTSEC-2022-0076.md
+++ b/crates/wasmtime/RUSTSEC-2022-0076.md
@@ -11,7 +11,7 @@ cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N"
 aliases = ["CVE-2022-39392", "GHSA-44mr-8vmm-wjhg"]
 
 [versions]
-patched = [">= 2.0.2"]
+patched = [">= 2.0.2", ">= 1.0.2"]
 
 [affected]
 functions = { "wasmtime::PoolingAllocationConfig::instance_memory_pages" = ["< 2.0.2"] }


### PR DESCRIPTION
The details page at https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-44mr-8vmm-wjhg says the v1 also has a patched release.