### PR TITLE
A follow-up after #1645

### DIFF
--- a/crates/wasmtime/RUSTSEC-2022-0076.md
+++ b/crates/wasmtime/RUSTSEC-2022-0076.md
@@ -13,11 +13,9 @@ aliases = ["CVE-2022-39392", "GHSA-44mr-8vmm-wjhg"]
 [versions]
 patched = [">= 1.0.2, < 2.0.0", ">= 2.0.2"]
 
-[affected]
-functions = {
-  "wasmtime::PoolingAllocationConfig::instance_memory_pages" = [">= 2.0.0, < 2.0.2"],
-  "wasmtime::Config::allocation_strategy" = ["< 1.0.2"]
- }
+[affected.functions]
+"wasmtime::PoolingAllocationConfig::instance_memory_pages" = [">= 2.0.0, < 2.0.2"]
+"wasmtime::Config::allocation_strategy" = ["< 1.0.2"]
 ```
 
 # Bug in Wasmtime implementation of pooling instance allocator

--- a/crates/wasmtime/RUSTSEC-2022-0076.md
+++ b/crates/wasmtime/RUSTSEC-2022-0076.md
@@ -14,7 +14,7 @@ aliases = ["CVE-2022-39392", "GHSA-44mr-8vmm-wjhg"]
 patched = [">= 1.0.2, < 2.0.0", ">= 2.0.2"]
 
 [affected]
-functions = { "wasmtime::PoolingAllocationConfig::instance_memory_pages" = ["< 1.0.2", "> 2.0.0, < 2.0.2"] }
+functions = { "wasmtime::PoolingAllocationConfig::instance_memory_pages" = ["> 2.0.0, < 2.0.2"] }
 ```
 
 # Bug in Wasmtime implementation of pooling instance allocator

--- a/crates/wasmtime/RUSTSEC-2022-0076.md
+++ b/crates/wasmtime/RUSTSEC-2022-0076.md
@@ -14,7 +14,10 @@ aliases = ["CVE-2022-39392", "GHSA-44mr-8vmm-wjhg"]
 patched = [">= 1.0.2, < 2.0.0", ">= 2.0.2"]
 
 [affected]
-functions = { "wasmtime::PoolingAllocationConfig::instance_memory_pages" = [">= 2.0.0, < 2.0.2"] }
+functions = {
+  "wasmtime::PoolingAllocationConfig::instance_memory_pages" = [">= 2.0.0, < 2.0.2"]
+  "wasmtime::Config::allocation_strategy" = ["< 1.0.2"]
+ }
 ```
 
 # Bug in Wasmtime implementation of pooling instance allocator

--- a/crates/wasmtime/RUSTSEC-2022-0076.md
+++ b/crates/wasmtime/RUSTSEC-2022-0076.md
@@ -14,7 +14,7 @@ aliases = ["CVE-2022-39392", "GHSA-44mr-8vmm-wjhg"]
 patched = [">= 1.0.2, < 2.0.0", ">= 2.0.2"]
 
 [affected]
-functions = { "wasmtime::PoolingAllocationConfig::instance_memory_pages" = ["> 2.0.0, < 2.0.2"] }
+functions = { "wasmtime::PoolingAllocationConfig::instance_memory_pages" = [">= 2.0.0, < 2.0.2"] }
 ```
 
 # Bug in Wasmtime implementation of pooling instance allocator

--- a/crates/wasmtime/RUSTSEC-2022-0076.md
+++ b/crates/wasmtime/RUSTSEC-2022-0076.md
@@ -15,7 +15,7 @@ patched = [">= 1.0.2, < 2.0.0", ">= 2.0.2"]
 
 [affected]
 functions = {
-  "wasmtime::PoolingAllocationConfig::instance_memory_pages" = [">= 2.0.0, < 2.0.2"]
+  "wasmtime::PoolingAllocationConfig::instance_memory_pages" = [">= 2.0.0, < 2.0.2"],
   "wasmtime::Config::allocation_strategy" = ["< 1.0.2"]
  }
 ```


### PR DESCRIPTION
This is technically required for correctness, as v1 doesn't have this fn at all.