### PR TITLE
Add unsound `rmp-serde`

### DIFF
--- a/crates/rmp-serde/RUSTSEC-0000-0000.md
+++ b/crates/rmp-serde/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rmp-serde"
+date = "2022-04-13"
+url = "https://github.com/3Hren/msgpack-rust/issues/305"
+categories = ["memory-corruption"]
+informational = "unsound"
+
+[versions]
+patched = [">= 1.1.1"]
+```
+
+# `rmp-serde` `Raw` and `RawRef` unsound
+
+It was found that `Raw::from_utf8` expects valid UTF-8. If invalid UTF-8 is received it can cause the process to crash.


### PR DESCRIPTION
Closes #1426 

Adds advisory for unsound behaviour of `rmp-serde < 1.1.1`.