### PR TITLE
Add ntru unsoundness advisory

### DIFF
--- a/crates/ntru/RUSTSEC-0000-0000.md
+++ b/crates/ntru/RUSTSEC-0000-0000.md
@@ -12,8 +12,8 @@ informational = "unsound"
 patched = []
 
 [affected.functions]
-"ntru::types::PrivateKey::export" = [">= 0.4.3, < 0.5.6"]
-"ntru::types::PublicKey::export" = [">= 0.4.3, < 0.5.6"]
+"ntru::types::PrivateKey::export" = [">= 0.4.3"]
+"ntru::types::PublicKey::export" = [">= 0.4.3"]
 ```
 
 # Unsound FFI: Wrong API usage causes write past allocated area

--- a/crates/ntru/RUSTSEC-0000-0000.md
+++ b/crates/ntru/RUSTSEC-0000-0000.md
@@ -10,7 +10,6 @@ informational = "unsound"
 
 [versions]
 patched = []
-unaffected = []
 
 [affected.functions]
 "ntru::types::PrivateKey::export" = [">= 0.4.3, < 0.5.6"]

--- a/crates/ntru/RUSTSEC-0000-0000.md
+++ b/crates/ntru/RUSTSEC-0000-0000.md
@@ -1,0 +1,31 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "ntru"
+date = "2023-03-22"
+url = "https://github.com/FrinkGlobal/ntru-rs/issues/8"
+categories = ["memory-corruption"]
+keywords = ["ffi", "buffer overflow"]
+informational = "unsound"
+
+[versions]
+patched = []
+unaffected = []
+
+[affected.functions]
+"ntru::types::PrivateKey::export" = [">= 0.4.3, < 0.5.6"]
+"ntru::types::PublicKey::export" = [">= 0.4.3, < 0.5.6"]
+```
+
+# Unsound FFI: Wrong API usage causes write past allocated area
+
+The following usage causes undefined behavior.
+```rust
+let kp: ntru::types::KeyPair = …;
+kp.get_public().export(Default::default())
+```
+
+When compiled with debug assertions, the code above will trigger a `attempt to subtract with overflow` panic before UB occurs.
+Other mistakes (e.g. using `EncParams` from a different key) may always trigger UB.
+
+Likely, older versions of this crate are also affected, but have not been tested.


### PR DESCRIPTION
I suspect that this unsoundness can also result in a crypto-fail with just the right kind of wrong parameters, but that'd kind of be the users fault.

It also [seems like](https://github.com/FrinkGlobal/ntru-rs/issues/7) ntru is unmaintained. Should I submit a separate advisory / separate PR for that?