### PR TITLE
async-nats MitM vulnerability

### DIFF
--- a/crates/async-nats/RUSTSEC-0000-0000.md
+++ b/crates/async-nats/RUSTSEC-0000-0000.md
@@ -15,11 +15,11 @@ patched = [">= 0.29.0"]
 
 The NATS official Rust clients are vulnerable to MitM when using TLS.
 
-The common name of the TLS certificate presented by the server is validated against the
-`host`name provided by the NATS server `INFO` message during the initial connection setup phase.
-Because the `INFO` parameters are sent as plaintext, a MitM proxy can replace the value of
-the `host` field to the common name of a valid certificate it controls, fooling the client into
-accepting it.
+The common name of the server's TLS certificate is validated against
+the `host`name provided by the server's plaintext `INFO` message
+during the initial connection setup phase. A MitM proxy can tamper with
+the `host` field's value by substituting it with the common name of a
+valid certificate it controls, fooling the client into accepting it.
 
 ## Reproduction steps
 
@@ -27,11 +27,11 @@ accepting it.
 2. The connection is intercepted by a MitM proxy
 3. The proxy makes a separate connection to the NATS server
 4. The NATS server replies with an `INFO` message
-5. The proxy reads the `INFO`, alters the `host` JSON field of it and passes
-   the altered `INFO` back to the client
+5. The proxy reads the `INFO`, alters the `host` JSON field and passes
+   the tampered `INFO` back to the client
 6. The proxy upgrades the client connection to TLS, presenting a certificate issued
    by a certificate authority present in the client's keychain.
    In the previous step the `host` was set to the common name of said certificate
 7. `rustls` accepts the certificate, having verified that the common name matches the
-   attacker-controlled value given to it
-9. The client has been fooled into accepting the attacker's certificate
+   attacker-controlled value it was given
+9. The client has been fooled by the MitM proxy into accepting the attacker-controlled certificate

--- a/crates/async-nats/RUSTSEC-0000-0000.md
+++ b/crates/async-nats/RUSTSEC-0000-0000.md
@@ -1,0 +1,31 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "async-nats"
+date = "2023-03-24"
+url = "https://github.com/nats-io/nats.rs/commit/817a7b942c462fa9d9938dcb62124173634132fb#diff-767d442397fcaaf2f83e8f924d4a70317a2ce4703a49964d6007707949cfa5f5L303-R304"
+categories = []
+keywords = ["tls", "mitm"]
+
+[versions]
+patched = [">= 0.29.0"]
+```
+
+# rustls integration vulnerable to MitM
+
+The NATS Rust clients are vulnerable to MitM when using TLS.
+
+The common name of the TLS certificate presented by the server is validated against the hostname provided by the NATS server INFO command during the initial connection setup phase.
+Because the INFO parameters are sent as plaintext, a MitM proxy can replace the value of the host field to the common name of a valid certificate it controls, fooling the client into accepting it.
+
+## Reproduction
+
+1. The NATS Rust client tries to establish a new connection
+2. The connection is intercepted by a MitM proxy
+3. The proxy makes a separate connection to the NATS server
+4. The NATS server replies with an INFO command
+5. The proxy intercepts the INFO command, alters the host JSON field of it and passes the altered INFO back to the client
+6. The proxy upgrades the client connection to TLS, presenting a certificate issued by a certificate authority present in the client's keychain. In the previous step the host field was set to the common name of said certificate.
+7. This step can be found in my POC inside src/bin/mitm.rs line 102
+8. The TLS library accepts the certificate, having verified that the common name matches the malicious value given to it
+9. Although the connection is technically using TLS, the proxy is still able to see all of the traffic going between the client and the NATS server because we fooled it into accepting our certificate.

--- a/crates/async-nats/RUSTSEC-0000-0000.md
+++ b/crates/async-nats/RUSTSEC-0000-0000.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-0000-0000"
 package = "async-nats"
 date = "2023-03-24"
 url = "https://github.com/nats-io/nats.rs/commit/817a7b942c462fa9d9938dcb62124173634132fb#diff-767d442397fcaaf2f83e8f924d4a70317a2ce4703a49964d6007707949cfa5f5L303-R304"
-categories = []
+categories = ["crypto-failure"]
 keywords = ["tls", "mitm"]
 
 [versions]

--- a/crates/async-nats/RUSTSEC-0000-0000.md
+++ b/crates/async-nats/RUSTSEC-0000-0000.md
@@ -28,10 +28,10 @@ accepting it.
 3. The proxy makes a separate connection to the NATS server
 4. The NATS server replies with an `INFO` message
 5. The proxy reads the `INFO`, alters the `host` JSON field of it and passes
-   the altered INFO back to the client
+   the altered `INFO` back to the client
 6. The proxy upgrades the client connection to TLS, presenting a certificate issued
    by a certificate authority present in the client's keychain.
-   In the previous step the `host` was set to the common name of said certificate.
+   In the previous step the `host` was set to the common name of said certificate
 7. `rustls` accepts the certificate, having verified that the common name matches the
    attacker-controlled value given to it
-9. We fooled the client into accepting **our** certificate
+9. The client has been fooled into accepting the attacker's certificate

--- a/crates/async-nats/RUSTSEC-0000-0000.md
+++ b/crates/async-nats/RUSTSEC-0000-0000.md
@@ -11,7 +11,7 @@ keywords = ["tls", "mitm"]
 patched = [">= 0.29.0"]
 ```
 
-# rustls integration vulnerable to MitM
+# TLS certificate common name validation bypass
 
 The NATS Rust clients are vulnerable to MitM when using TLS.
 

--- a/crates/async-nats/RUSTSEC-0000-0000.md
+++ b/crates/async-nats/RUSTSEC-0000-0000.md
@@ -13,19 +13,25 @@ patched = [">= 0.29.0"]
 
 # TLS certificate common name validation bypass
 
-The NATS Rust clients are vulnerable to MitM when using TLS.
+The NATS official Rust clients are vulnerable to MitM when using TLS.
 
-The common name of the TLS certificate presented by the server is validated against the hostname provided by the NATS server INFO command during the initial connection setup phase.
-Because the INFO parameters are sent as plaintext, a MitM proxy can replace the value of the host field to the common name of a valid certificate it controls, fooling the client into accepting it.
+The common name of the TLS certificate presented by the server is validated against the
+`host`name provided by the NATS server `INFO` message during the initial connection setup phase.
+Because the `INFO` parameters are sent as plaintext, a MitM proxy can replace the value of
+the `host` field to the common name of a valid certificate it controls, fooling the client into
+accepting it.
 
-## Reproduction
+## Reproduction steps
 
 1. The NATS Rust client tries to establish a new connection
 2. The connection is intercepted by a MitM proxy
 3. The proxy makes a separate connection to the NATS server
-4. The NATS server replies with an INFO command
-5. The proxy intercepts the INFO command, alters the host JSON field of it and passes the altered INFO back to the client
-6. The proxy upgrades the client connection to TLS, presenting a certificate issued by a certificate authority present in the client's keychain. In the previous step the host field was set to the common name of said certificate.
-7. This step can be found in my POC inside src/bin/mitm.rs line 102
-8. The TLS library accepts the certificate, having verified that the common name matches the malicious value given to it
-9. Although the connection is technically using TLS, the proxy is still able to see all of the traffic going between the client and the NATS server because we fooled it into accepting our certificate.
+4. The NATS server replies with an `INFO` message
+5. The proxy reads the `INFO`, alters the `host` JSON field of it and passes
+   the altered INFO back to the client
+6. The proxy upgrades the client connection to TLS, presenting a certificate issued
+   by a certificate authority present in the client's keychain.
+   In the previous step the `host` was set to the common name of said certificate.
+7. `rustls` accepts the certificate, having verified that the common name matches the
+   attacker-controlled value given to it
+9. We fooled the client into accepting **our** certificate


### PR DESCRIPTION
The following vulnerability has been reported by me to https://advisories.nats.io/ and fixed in `async-nats` 0.29. Once this is merged I'll copy-paste the vulnerability and also apply it to the `nats` crate, which presents the exact same issue.

~~I'm opening this as draft because there are some things I'd like to cleanup in the report which I don't have the time to do right now. For now I simply copy-pasted part of the report I also sent to Synadia.~~

~~I wasn't sure **which category to put this in**, as none seemed to apply.~~
All versions of `async-nats` are affected, while very early versions of the `nats` crate aren't because they don't support TLS.
If a CVE is requested by the Synadia Security Team I'll update the advisory with the CVE ID.