### PR TITLE
CI: Remove redundant linter noise

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -26,4 +26,4 @@ jobs:
         fi
 
     - name: Lint advisories
-      run: rustsec-admin lint --skip-namecheck rustdecimal
+      run: rustsec-admin lint --skip-namecheck rustdecimal | egrep -v "Linted ok:"


### PR DESCRIPTION
It seems to take long time to print 500+ lines @ 1m 35s when we could just print the failures and total checked:
https://github.com/rustsec/advisory-db/actions/runs/4519170146/jobs/7959502197#step:5:1

Testing if this is the case and if this help to get to bottom of it.