### PR TITLE
Added unsound `spin`

### DIFF
--- a/crates/spin/RUSTSEC-0000-0000.md
+++ b/crates/spin/RUSTSEC-0000-0000.md
@@ -5,7 +5,6 @@ package = "spin"
 date = "2023-03-31"
 informational = "unsound"
 url = "https://github.com/mvdnes/spin-rs/issues/148"
-withdrawn = "2020-10-08"
 
 [versions]
 patched = [">= 0.9.8"]

--- a/crates/spin/RUSTSEC-0000-0000.md
+++ b/crates/spin/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "spin"
+date = "2023-03-31"
+informational = "unsound"
+url = "https://github.com/mvdnes/spin-rs/issues/148"
+withdrawn = "2020-10-08"
+
+[versions]
+patched = [">= 0.9.8"]
+unaffected = ["< 0.9.3"]
+```
+
+# Initialisation failure in `Once::try_call_once` can lead to undefined behaviour for other initialisers
+
+`Once::try_call_once` is unsound if invoked more than once concurrently and any call fails to initialise successfully.


### PR DESCRIPTION
This should only be merged when the fix in https://github.com/mvdnes/spin-rs/pull/149 has merged and a new version (`0.9.8`) is released.