### PR TITLE
Add unmaintained advisory for syslog crate

### DIFF
--- a/crates/syslog/RUSTSEC-0000-0000.md
+++ b/crates/syslog/RUSTSEC-0000-0000.md
@@ -10,7 +10,7 @@ informational = "unmaintained"
 patched = []
 ```
 
-The syslog crate is no longer maintained by it's current owner.
-
-The PR referenced above has had no response for a year a three months.
-I tried to contact the owner through Github and the email associated with their Github account.
+# The syslog crate is no longer maintained by it's current owner.
+# 
+# The PR referenced above has had no response for a year a three months.
+# I tried to contact the owner through Github and the email associated with their Github account.

--- a/crates/syslog/RUSTSEC-0000-0000.md
+++ b/crates/syslog/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "syslog"
+date = "2023-04-01"
+url = "https://github.com/Geal/rust-syslog/pull/64"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+The syslog crate is no longer maintained by it's current owner.
+
+The PR referenced above has had no response for a year a three months.
+I tried to contact the owner through Github and the email associated with their Github account.


### PR DESCRIPTION
The syslog crate is no longer maintained by it's current owner.

The PR referenced in the advisory has had no response for a year a three months.
I tried to contact the owner through Github and the email associated with their Github account.
 