### PR TITLE
Withdraw RUSTSEC-2021-0147

### DIFF
--- a/crates/daemonize/RUSTSEC-2021-0147.md
+++ b/crates/daemonize/RUSTSEC-2021-0147.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-2021-0147"
 package = "daemonize"
 date = "2021-09-01"
+withdrawn = "2023-02-19"
 url = "https://github.com/knsd/daemonize/issues/46"
 informational = "unmaintained"
 


### PR DESCRIPTION
Withdraw the unmaintained advisory for `daemonize` requested in #1543.

On Feb 19 2023, the author started to maintain the `daemonize` crate again.
Version 0.5.0 has been released on Feb 25 2023.
Therefore, this crate in no longer unmaintained and advisory `RUSTSEC-2021-0147` should be withdrawn.