### PR TITLE
Add advisory for h2: resource exhaustion vulnerability may lead to DoS

### DIFF
--- a/crates/h2/RUSTSEC-0000-0000.md
+++ b/crates/h2/RUSTSEC-0000-0000.md
@@ -13,6 +13,8 @@ patched = [">= 0.3.17"]
 
 # h2 causes stream stacking, may cause Denial of Service (DoS)
 
-h2 causes stream stacking, may cause Denial of Service. Please see [GitHub Security Advisory entry](https://github.com/advisories/GHSA-f8vr-r385-rh5r) for more info.
+If an attacker is able to flood the network with pairs of `HEADERS`/`RST_STREAM` frames, such that the `h2` application is not able to accept them faster than the bytes are received, the pending accept queue can grow in memory usage. Being able to do this consistently can result in excessive memory use, and eventually trigger Out Of Memory.
+
+Please see the [GitHub Security Advisory entry](https://github.com/advisories/GHSA-f8vr-r385-rh5r) for more info.
 
 This flaw is corrected in [hyperium/h2#668](https://github.com/hyperium/h2/pull/668), which restricts remote reset stream count by default.

--- a/crates/h2/RUSTSEC-0000-0000.md
+++ b/crates/h2/RUSTSEC-0000-0000.md
@@ -13,6 +13,6 @@ patched = [">= 0.3.17"]
 
 # h2 causes stream stacking, may cause Denial of Service (DoS)
 
-h2 causes stream stacking, may cause Denial of Service.
+h2 causes stream stacking, may cause Denial of Service. Please see [GitHub Security Advisory entry](https://github.com/advisories/GHSA-f8vr-r385-rh5r) for more info.
 
 This flaw is corrected in [hyperium/h2#668](https://github.com/hyperium/h2/pull/668), which restricts remote reset stream count by default.

--- a/crates/h2/RUSTSEC-0000-0000.md
+++ b/crates/h2/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "h2"
+date = "2023-04-14"
+url = "https://github.com/hyperium/hyper/issues/2877"
+categories = ["denial-of-service"]
+keywords = ["http", "http2", "h2"]
+aliases = ["CVE-2023-26964", "GHSA-f8vr-r385-rh5r"]
+[versions]
+patched = [">= 0.3.17"]
+```
+
+# h2 causes stream stacking, may cause Denial of Service (DoS)
+
+h2 causes stream stacking, may cause Denial of Service.
+
+This flaw is corrected in [hyperium/h2#668](https://github.com/hyperium/h2/pull/668), which restricts remote reset stream count by default.

--- a/crates/h2/RUSTSEC-0000-0000.md
+++ b/crates/h2/RUSTSEC-0000-0000.md
@@ -15,6 +15,4 @@ patched = [">= 0.3.17"]
 
 If an attacker is able to flood the network with pairs of `HEADERS`/`RST_STREAM` frames, such that the `h2` application is not able to accept them faster than the bytes are received, the pending accept queue can grow in memory usage. Being able to do this consistently can result in excessive memory use, and eventually trigger Out Of Memory.
 
-Please see the [GitHub Security Advisory entry](https://github.com/advisories/GHSA-f8vr-r385-rh5r) for more info.
-
 This flaw is corrected in [hyperium/h2#668](https://github.com/hyperium/h2/pull/668), which restricts remote reset stream count by default.

--- a/crates/h2/RUSTSEC-0000-0000.md
+++ b/crates/h2/RUSTSEC-0000-0000.md
@@ -11,7 +11,7 @@ aliases = ["CVE-2023-26964", "GHSA-f8vr-r385-rh5r"]
 patched = [">= 0.3.17"]
 ```
 
-# h2 causes stream stacking, may cause Denial of Service (DoS)
+# Resource exhaustion vulnerability in h2 may lead to Denial of Service (DoS)
 
 If an attacker is able to flood the network with pairs of `HEADERS`/`RST_STREAM` frames, such that the `h2` application is not able to accept them faster than the bytes are received, the pending accept queue can grow in memory usage. Being able to do this consistently can result in excessive memory use, and eventually trigger Out Of Memory.
 


### PR DESCRIPTION
(should not be merged as is at writing this comment, see following comment)