### PR TITLE
Suggest kuchikiki as an alternative to kuchiki

### DIFF
--- a/crates/kuchiki/RUSTSEC-2023-0019.md
+++ b/crates/kuchiki/RUSTSEC-2023-0019.md
@@ -18,5 +18,6 @@ The `kuchiki` repo was marked as archived in [this](https://github.com/kuchiki-r
 
 Possible alternatives may include:
 
+- [kuchikiki](https://crates.io/crates/kuchikiki)
 - [html5ever](https://crates.io/crates/html5ever)
 - [xml-rs](https://crates.io/crates/xml-rs)


### PR DESCRIPTION
The `kuchiki` crate has been marked unmaintained. We're continuing to support a fork under then name `kuchikiki` which we intend to remain semver-compatible with our former upstream.

Suggest this as an alternative in RUSTSEC-2023-0019 since it is a direct replacement; the other alternatives involve significant porting effort.