### PR TITLE
🦺 Advisory for unmaintained crate, `users`

### DIFF
--- a/crates/users/RUSTSEC-0000-0000.md
+++ b/crates/users/RUSTSEC-0000-0000.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "users"
+date = "2023-06-01"
+url = "https://github.com/ogham/rust-users/issues/54"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `users` crate is unmaintained
+
+The `users` crate hasn't seen any action since 2020-10-08. The developer seems [MIA] since.
+
+## Recommended alternatives
+- [`sysinfo`]
+
+[MIA]: https://github.com/ogham/rust-users/issues/54
+[`sysinfo`]: https://crates.io/crates/sysinfo


### PR DESCRIPTION
The `users` crate hasn't seen any action since 2020-10-08. The developer seems [MIA] since.

I failed to find a direct replacement that's maintained but [`sysinfo`] crate provides the same
functionality since the last release.

[MIA]: https://github.com/ogham/rust-users/issues/54
[`sysinfo`]: https://crates.io/crates/sysinfo