### PR TITLE
serialport-rs memory leak advisory

### DIFF
--- a/crates/serialport/RUSTSEC-0000-0000.md
+++ b/crates/serialport/RUSTSEC-0000-0000.md
@@ -8,14 +8,12 @@ date = "2023-06-14"
 
 url = "https://github.com/serialport/serialport-rs/pull/98"
 
-categories = ["memory-corruption"]
+categories = ["denial-of-service"]
 
 keywords = ["memory", "leak"]
 
 [affected]
-arch = ["aarch64-apple-darwin", "i686-apple-darwin"]
-
-os = ["MacOS"]
+os = ["macos"]
 
 [versions]
 patched = [">= 4.2.1"]

--- a/crates/serialport/RUSTSEC-0000-0000.md
+++ b/crates/serialport/RUSTSEC-0000-0000.md
@@ -1,0 +1,30 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+
+package = "serialport"
+
+date = "2023-06-14"
+
+url = "https://github.com/serialport/serialport-rs/pull/98"
+
+categories = ["memory-corruption"]
+
+keywords = ["memory", "leak"]
+
+[affected]
+arch = ["aarch64-apple-darwin", "i686-apple-darwin"]
+
+os = ["MacOS"]
+
+[versions]
+patched = [">= 4.2.1"]
+```
+
+# Memory leaks on macOS 
+
+There were a number of memory leaks when enumerating serial ports on macOS, particularly when performing the "available_ports" method.
+
+Version 4.2.0 has been yanked. However, previous versions are likely to also contain the memory leak bugs where macOS is supported.
+
+It is recommended to update as soon as possible if serialport-rs is being used on macOS.


### PR DESCRIPTION
A memory leak had been found with serialport-rs, which has now been corrected.