### PR TITLE
Update RUSTSEC-2021-0145.md with stable IsTerminal

### DIFF
--- a/crates/atty/RUSTSEC-2021-0145.md
+++ b/crates/atty/RUSTSEC-2021-0145.md
@@ -33,5 +33,6 @@ Last release of `atty` was almost 3 years ago.
 
 The below list has not been vetted in any way and may or may not contain alternatives;
 
- - [is-terminal](https://crates.io/crates/is-terminal)
- - std::io::IsTerminal *nightly-only experimental*
+ - [std::io::IsTerminal](https://doc.rust-lang.org/stable/std/io/trait.IsTerminal.html) - Stable since Rust 1.70.0
+ - [is-terminal](https://crates.io/crates/is-terminal) - Standalone crate supporting Rust older than 1.70.0
+


### PR DESCRIPTION
Since `IsTerminal` is now stable, this CVE can recommend that first. It should at least not lie about it being nightly only any longer.