### PR TITLE
Add shadowsocks misaligned read advisory

### DIFF
--- a/crates/shadowsocks/RUSTSEC-2023-0000.md
+++ b/crates/shadowsocks/RUSTSEC-2023-0000.md
@@ -1,0 +1,42 @@
+```toml
+[advisory]
+id = "RUSTSEC-2023-0000"
+package = "shadowsocks"
+date = "2023-07-05"
+url = "https://shadowsocks.org/"
+categories = ["denial-of-service"]
+keywords = []
+
+[versions]
+patched = [">= 1.15.4"]
+
+
+[affected]
+arch = ["x86_64", "aarch64"]
+os = ["linux", "macos"]
+```
+
+# `shadowsocks` misaligned reads.
+The current release of `shadowsocks` (`1.15.3` as of writing) has a bug that causes a segmentation
+fault due to a misaligned read when reading a SOCKS header.
+
+I do not know when this behavior was introduced. The code itself used to work just fine with older
+stable Rust compilers (`.1.68`), but recent stable versions have exposed the misaligned reads,
+possibly due to more aggressive use of SIMD instructions. The crux of the issue is attempting to read
+16 bit values at uneven offsets from a unsigned byte slice. This behavior has been verified in
+aarch64 on macOS and x86_64 on Linux, but I see no reason it wouldn't fail on Windows too.
+
+The offending code itself is all found in `shadowsocks::relay::socks5::Address::read_from`, as can
+be seen [on GitHub]. The bug can be verified by just running a `cargo test -p shadowsocks --test
+tcp` with the `v1.15.3` [release].
+
+Currently, the bug is already fixed in the main branch (`32de79eeb7f3b0867ee415b16f5ead0df8a750ef`
+at time of writing) in [commit] (`c2877c10b589f8123840741c6ce1d553b33892ae`), but it has not been
+backported on top of the latest released crate.
+
+
+
+
+[on GitHub]: https://github.com/shadowsocks/shadowsocks-rust/blob/v1.15.3/crates/shadowsocks/src/relay/socks5.rs#L258-L329
+[commit]: https://github.com/shadowsocks/shadowsocks-rust/commit/c2877c10b589f8123840741c6ce1d553b33892ae
+[release]: https://github.com/shadowsocks/shadowsocks-rust/releases/tag/v1.15.3


### PR DESCRIPTION
We found that on the latest stable compiler, the `shadowsocks` crate is reliably panicking under normal conditions due to a misaligned read, thus we've thought it'd be best to write up a potential advisory.