### PR TITLE
Add unmaintained `dlopen_derive` advisory

### DIFF
--- a/crates/dlopen_derive/RUSTSEC-0000-0000.md
+++ b/crates/dlopen_derive/RUSTSEC-0000-0000.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "dlopen_derive"
+date = "2023-07-30"
+url = "https://github.com/szymonwieloch/rust-dlopen/issues/47"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `dlopen_derive` is unmaintained
+
+`dlopen_derive` hasn't been updated since June 9, 2019.
+
+`dlopen_derive` depends on [`quote = "0.6.12"`] and [`syn = "0.15.34"`]. Versions `1.0.0` of these dependencies were published on August 13, 2019. The `0.*` versions haven't received updates since.
+
+## Recommended alternatives
+
+- [`dlopen2_derive`]
+
+[`dlopen2_derive`]: https://github.com/OpenByteDev/dlopen2
+[`quote = "0.6.12"`]: https://github.com/dtolnay/quote/releases/tag/0.6.12
+[`syn = "0.15.34"`]: https://github.com/dtolnay/syn/releases/tag/0.15.34

--- a/crates/dlopen_derive/RUSTSEC-0000-0000.md
+++ b/crates/dlopen_derive/RUSTSEC-0000-0000.md
@@ -16,9 +16,11 @@ patched = []
 
 `dlopen_derive` depends on [`quote = "0.6.12"`] and [`syn = "0.15.34"`]. Versions `1.0.0` of these dependencies were published on August 13, 2019. The `0.*` versions haven't received updates since.
 
+Note that `dlopen` is an unmaintained crate from the same repository as `dlopen_derive`. However, migrating away from `dlopen_derive` implies migrating away from `dlopen`, as well.
+
 ## Recommended alternatives
 
-- [`dlopen2_derive`]
+- [`dlopen2_derive`] (and `dlopen2`)
 
 [`dlopen2_derive`]: https://github.com/OpenByteDev/dlopen2
 [`quote = "0.6.12"`]: https://github.com/dtolnay/quote/releases/tag/0.6.12


### PR DESCRIPTION
`dlopen_derive` hasn't been updated since June 9, 2019.

`dlopen_derive` depends on [`quote = "0.6.12"`] and [`syn = "0.15.34"`]. Versions `1.0.0` of these dependencies were published on August 13, 2019. The `0.*` versions haven't received updates since.

## Recommended alternatives

- [`dlopen2_derive`]

[`dlopen2_derive`]: https://github.com/OpenByteDev/dlopen2
[`quote = "0.6.12"`]: https://github.com/dtolnay/quote/releases/tag/0.6.12
[`syn = "0.15.34"`]: https://github.com/dtolnay/syn/releases/tag/0.15.34