### PR TITLE
Add uzers as alternative recommendation for users

### DIFF
--- a/crates/users/RUSTSEC-2023-0040.md
+++ b/crates/users/RUSTSEC-2023-0040.md
@@ -15,7 +15,9 @@ patched = []
 The `users` crate hasn't seen any action since 2020-10-08. The developer seems [MIA] since.
 
 ## Recommended alternatives
+- [`uzers`]
 - [`sysinfo`]
 
 [MIA]: https://github.com/ogham/rust-users/issues/54
+[`uzers`]: https://crates.io/crates/uzers
 [`sysinfo`]: https://crates.io/crates/sysinfo


### PR DESCRIPTION
Following up on #1701

We use `users` in https://github.com/eza-community/eza so I decided to fork `users` to https://github.com/gierens/uzers-rs . I reviewed merged existing pull requests and plan to maintain it there. It's also on crates.io in version v0.11.1, see https://crates.io/crates/uzers 

This change adds `uzers` to the recommended alternatives for `users`.