### PR TITLE
Add jzon as alternative recommendation for json

### DIFF
--- a/crates/json/RUSTSEC-2022-0081.md
+++ b/crates/json/RUSTSEC-2022-0081.md
@@ -23,6 +23,7 @@ One of the outstanding issues include [a possible soundness issue](https://githu
 
 The below list has not been vetted in any way and may or may not contain alternatives;
 
+- [jzon](https://crates.io/crates/jzon) maintained fork of json
 - [serde_json](https://crates.io/crates/serde_json)
 - [json-deserializer](https://crates.io/crates/json-deserializer)
 - [simd-json](https://crates.io/crates/simd-json)


### PR DESCRIPTION
Following up on #1536

I'm currently gathering people in a community that should specialize on adopting abandoned Rust projects and so `json` was brought to my attention. We forked it to https://github.com/rustadopt/jzon-rs/ and plan to maintain it there. We already reviewed and merged pull requests, polished things like the CI and are currently checking out reported issues. It is now also available in version v0.12.5 on crates.io, see https://crates.io/crates/jzon .

This change adds `jzon` to the recommended alternatives for `json`.