### PR TITLE
Sync advisories ids from GitHub

### DIFF
--- a/crates/ed25519-dalek/RUSTSEC-2022-0093.md
+++ b/crates/ed25519-dalek/RUSTSEC-2022-0093.md
@@ -5,6 +5,7 @@ package = "ed25519-dalek"
 date = "2022-06-11"
 categories = ["crypto-failure"]
 url = "https://github.com/MystenLabs/ed25519-unsafe-libs"
+aliases = ["GHSA-w5vr-6qhr-36cc"]
 
 [versions]
 patched = [">= 2"]

--- a/crates/mail-internals/RUSTSEC-2023-0054.md
+++ b/crates/mail-internals/RUSTSEC-2023-0054.md
@@ -6,6 +6,7 @@ date = "2023-08-07"
 url = "https://git.sr.ht/~nabijaczleweli/mail-internals.crate/commit/05443c864b204e7f1512caf2d53e8cce4dd340fc"
 categories = ["memory-corruption"]
 keywords = ["mail", "mail-api"]
+aliases = ["GHSA-rcx8-48pc-v9q8"]
 
 [affected]
 functions = { "mail_internals::utils::vec_insert_bytes" = [">= 0.2.0"] }

--- a/crates/rustdecimal/RUSTSEC-2022-0042.md
+++ b/crates/rustdecimal/RUSTSEC-2022-0042.md
@@ -6,7 +6,7 @@ date = "2022-05-10"
 url = "https://groups.google.com/g/rustlang-security-announcements/c/5DVtC8pgJLw?pli=1"
 categories = ["code-execution"]
 keywords = ["typosquatting"]
-aliases = ["GHSA-7pwq-f4pq-78gm"]
+aliases = ["GHSA-7pwq-f4pq-78gm", "MAL-2022-1"]
 [versions]
 patched = []
 ```

--- a/crates/rustls-webpki/RUSTSEC-2023-0053.md
+++ b/crates/rustls-webpki/RUSTSEC-2023-0053.md
@@ -7,10 +7,10 @@ categories = ["denial-of-service"]
 keywords = ["certificate", "path building", "x509"]
 cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 related = ["CVE-2018-16875"]
+aliases = ["GHSA-fh2r-99q2-6mmg"]
 
 [versions]
 patched = [">= 0.100.2, < 0.101.0", ">= 0.101.4"]
-
 ```
 
 # rustls-webpki: CPU denial of service in certificate path building

--- a/crates/webpki/RUSTSEC-2023-0052.md
+++ b/crates/webpki/RUSTSEC-2023-0052.md
@@ -7,6 +7,7 @@ categories = ["denial-of-service"]
 keywords = ["certificate", "path building", "x509"]
 cvss = "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 related = ["CVE-2018-16875"]
+aliases = ["GHSA-8qv2-5vq6-g2g7"]
 
 [versions]
 patched = []


### PR DESCRIPTION
Side note: advisories parsing is currently broken in the [sync command](https://github.com/rustsec/rustsec/pull/656) due to https://github.com/github/advisory-database/issues/2665 (added local workarounds to get it working though.