### PR TITLE
Update webpki RUSTSEC-2023-0052 advisory.

### DIFF
--- a/crates/webpki/RUSTSEC-2023-0052.md
+++ b/crates/webpki/RUSTSEC-2023-0052.md
@@ -10,7 +10,7 @@ related = ["CVE-2018-16875"]
 aliases = ["GHSA-8qv2-5vq6-g2g7"]
 
 [versions]
-patched = []
+patched = [">= 0.22.1"]
 ```
 
 # webpki: CPU denial of service in certificate path building
@@ -24,6 +24,3 @@ Both TLS clients and TLS servers that accept client certificate are affected.
 This was previously reported in
 <https://github.com/briansmith/webpki/issues/69> and re-reported recently
 by Luke Malinowski.
-
-`rustls-webpki` is a fork of this crate which contains a fix for this issue
-and is actively maintained.


### PR DESCRIPTION
* Indicate release version that the fix landed in.
* Remove unnecessary noise from the text.