### PR TITLE
add additional replacement for ansi_term

### DIFF
--- a/crates/ansi_term/RUSTSEC-2021-0139.md
+++ b/crates/ansi_term/RUSTSEC-2021-0139.md
@@ -27,6 +27,7 @@ Last release seems to have been three years ago.
  - [owo-colors](https://crates.io/crates/owo-colors)
  - [stylish](https://crates.io/crates/stylish)
  - [yansi](https://crates.io/crates/yansi)
+ - [ansiterm](https://crates.io/crates/ansiterm)
 
 ## Dependency Specific Migration(s)
 

--- a/crates/ansi_term/RUSTSEC-2021-0139.md
+++ b/crates/ansi_term/RUSTSEC-2021-0139.md
@@ -21,13 +21,13 @@ Last release seems to have been three years ago.
 
  The below list has not been vetted in any way and may or may not contain alternatives;
 
+ - [ansiterm](https://crates.io/crates/ansiterm)
  - [anstyle](https://github.com/epage/anstyle)
  - [console](https://crates.io/crates/console)
  - [nu-ansi-term](https://crates.io/crates/nu-ansi-term)
  - [owo-colors](https://crates.io/crates/owo-colors)
  - [stylish](https://crates.io/crates/stylish)
  - [yansi](https://crates.io/crates/yansi)
- - [ansiterm](https://crates.io/crates/ansiterm)
 
 ## Dependency Specific Migration(s)
 


### PR DESCRIPTION
add [rustadopt](https://github.com/rustadopt/ansiterm-rs) fork ( crates.io/crates/ansiterm ) as an alternative to ansi_term crate.

This is in use by us over at [Eza](https://github.com/eza-community/eza) and maintained by a few of the same people.