### PR TITLE
Inventory 0.1 is unsound (allows std access before init of Rust runtime)

### DIFF
--- a/crates/inventory/RUSTSEC-0000-0000.md
+++ b/crates/inventory/RUSTSEC-0000-0000.md
@@ -1,0 +1,26 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "inventory"
+date = "2023-09-10"
+url = "https://github.com/dtolnay/inventory/pull/43"
+informational = "unsound"
+keywords = ["life-before-main"]
+
+[versions]
+patched = [">= 0.2.0"]
+```
+
+# Fails to prohibit standard library access prior to initialization of Rust standard library runtime
+
+Affected versions allow arbitrary caller-provided code to execute before the
+lifetime of `main`.
+
+If the caller-provided code accesses particular pieces of the standard library
+that require an initialized Rust runtime, such as `std::io` or `std::thread`,
+these may not behave as documented. Panics are likely; UB is possible.
+
+The flaw was corrected by enforcing that only code written within the
+`inventory` crate, which is guaranteed not to access runtime-dependent parts of
+the standard library, runs before `main`. Caller-provided code is restricted to
+running at compile time.


### PR DESCRIPTION
I am reporting this against `inventory` even though the affected unsafe code lives in the `ctor` crate. I believe the majority of usages of `ctor` use it soundly. In fact inventory 0.2, which uses the same version of ctor as inventory 0.1, uses it in a manner that is not affected by this bug.

- Relevant standard library issue: https://github.com/rust-lang/rust/issues/110708
- Relevant inventory PR: https://github.com/dtolnay/inventory/pull/43