### PR TITLE
Unaligned read in `users`

### DIFF
--- a/crates/users/RUSTSEC-0000-0000.md
+++ b/crates/users/RUSTSEC-0000-0000.md
@@ -1,0 +1,26 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "users"
+date = "2023-09-10"
+url = "https://github.com/ogham/rust-users/issues/55"
+informational = "unsound"
+keywords = ["unaligned-read"]
+
+[versions]
+patched = []
+```
+
+# Unaligned read of `*const *const c_char` pointer
+
+Affected versions dereference a potentially unaligned pointer. The pointer is
+commonly unaligned in practice, resulting in undefined behavior.
+
+In some build modes, this is observable as a panic followed by abort. In other
+build modes the UB may manifest in some other way, including the possibility of
+working correctly in some architectures.
+
+The crate is not currently maintained, so a patched version is not available.
+
+## Recommended alternatives
+- [`sysinfo`](https://crates.io/crates/sysinfo)


### PR DESCRIPTION
Closes https://github.com/rustsec/advisory-db/issues/1731.

I looked for an `unaffected` version. As far as I can tell, this bug has been present since the initial commit and initial version of this crate. The buggy code is introduced here:

- https://github.com/ogham/rust-users/commit/336223239a407069533b00c329ffe34454efa882#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R221-R245

and only slightly refactored by https://github.com/ogham/rust-users/commit/4c966938db5eb1528e8c26a0c1d5ac9747a6a67b.

The existing `unmaintained` advisory for this crate mentions `uzers` as an alternative:

https://github.com/rustsec/advisory-db/blob/d30ca831602ec928feaba99d7a04bb2a17643f73/crates/users/RUSTSEC-2023-0040.md#L17-L23

but I have not included that crate in this advisory because it has not fixed this bug either. https://github.com/rustadopt/uzers-rs/blob/v0.11.2/src/base.rs#L299-L313

A separate pair of advisors for `uzers` might be warranted if that fork is also unmaintained.