### PR TITLE
RUSTSEC-2023-0059: add "uzers" fork as alternative for "users"

### DIFF
--- a/crates/users/RUSTSEC-2023-0059.md
+++ b/crates/users/RUSTSEC-2023-0059.md
@@ -23,4 +23,5 @@ working correctly in some architectures.
 The crate is not currently maintained, so a patched version is not available.
 
 ## Recommended alternatives
+- [`uzers`](https://crates.io/crates/uzers) (an actively maintained fork of the `users` crate)
 - [`sysinfo`](https://crates.io/crates/sysinfo)


### PR DESCRIPTION
see https://github.com/rustsec/advisory-db/pull/1778#issuecomment-1716122937

`uzers` was already listed as an alternative on the slightly older "unmaintained" advisory (RUSTSEC-2023-0040), but it is missing from the new one (unaligned pointer reads).