### PR TITLE
CVE-2023-4863 in vendored libwebp

### DIFF
--- a/crates/libwebp-sys/RUSTSEC-0000-0000.md
+++ b/crates/libwebp-sys/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libwebp-sys"
+date = "2023-09-12"
+categories = ["memory-corruption"]
+keywords = ["webp"]
+aliases = ["CVE-2023-4863"]
+
+[versions]
+patched = [">= 0.9.3"]
+```
+
+# libwebp: OOB write in BuildHuffmanTable
+
+[Google](https://chromereleases.googleblog.com/2023/09/stable-channel-update-for-desktop_11.html) and [Mozilla](https://www.mozilla.org/en-US/security/advisories/mfsa2023-40/) have released security advisories for RCE due to heap overflow in libwebp. Google warns the vulnerability has been exploited in the wild.
+
+libwebp needs to be updated to include a patch for "OOB write in BuildHuffmanTable".

--- a/crates/libwebp-sys2/RUSTSEC-0000-0000.md
+++ b/crates/libwebp-sys2/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libwebp-sys2"
+date = "2023-09-12"
+categories = ["memory-corruption"]
+keywords = ["webp"]
+aliases = ["CVE-2023-4863"]
+
+[versions]
+patched = [">= 0.1.8"]
+```
+
+# libwebp: OOB write in BuildHuffmanTable
+
+[Google](https://chromereleases.googleblog.com/2023/09/stable-channel-update-for-desktop_11.html) and [Mozilla](https://www.mozilla.org/en-US/security/advisories/mfsa2023-40/) have released security advisories for RCE due to heap overflow in libwebp. Google warns the vulnerability has been exploited in the wild.
+
+libwebp needs to be updated to include a patch for "OOB write in BuildHuffmanTable".


### PR DESCRIPTION
libwebp has an exploitable heap buffer overflow. There are two Rust sys crate that have bundled the vulnerable version of libwebp. Both sys crates are patched now.
