### PR TITLE
CVE-2023-39914 in bcder.

### DIFF
--- a/crates/bcder/RUSTSEC-0000-0000.md
+++ b/crates/bcder/RUSTSEC-0000-0000.md
@@ -4,8 +4,6 @@ id = "RUSTSEC-0000-0000"
 package = "bcder"
 date = "2023-09-13"
 url = "https://nlnetlabs.nl/downloads/bcder/CVE-2023-39914.txt"
-# Valid categories: "code-execution", "crypto-failure", "denial-of-service", "file-disclosure"
-# "format-injection", "memory-corruption", "memory-exposure", "privilege-escalation"
 categories = ["denial-of-service"]
 keywords = ["example", "freeform", "keywords"]
 aliases = ["CVE-2023-39914"]

--- a/crates/bcder/RUSTSEC-0000-0000.md
+++ b/crates/bcder/RUSTSEC-0000-0000.md
@@ -3,19 +3,17 @@
 id = "RUSTSEC-0000-0000"
 package = "bcder"
 date = "2023-09-13"
-url = "https://github.com/NLnetLabs/bcder"
+url = "https://nlnetlabs.nl/downloads/bcder/CVE-2023-39914.txt"
 # Valid categories: "code-execution", "crypto-failure", "denial-of-service", "file-disclosure"
 # "format-injection", "memory-corruption", "memory-exposure", "privilege-escalation"
 categories = ["denial-of-service"]
 keywords = ["example", "freeform", "keywords"]
 aliases = ["CVE-2023-39914"]
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+references = ["https://github.com/NLnetLabs/bcder/pull/74"]
 
 [versions]
-patched = ["<= 0.7.2"]
-unaffected = [">= 0.7.3"]
-
-[affected]
+patched = [">= 0.7.3"]
 ```
 
 # BER/CER/DER decoder panics on invalid input

--- a/crates/bcder/RUSTSEC-0000-0000.md
+++ b/crates/bcder/RUSTSEC-0000-0000.md
@@ -1,0 +1,30 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "bcder"
+date = "2023-09-13"
+url = "https://github.com/NLnetLabs/bcder"
+# Valid categories: "code-execution", "crypto-failure", "denial-of-service", "file-disclosure"
+# "format-injection", "memory-corruption", "memory-exposure", "privilege-escalation"
+categories = ["denial-of-service"]
+keywords = ["example", "freeform", "keywords"]
+aliases = ["CVE-2023-39914"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+
+[versions]
+patched = ["<= 0.7.2"]
+unaffected = [">= 0.7.3"]
+
+[affected]
+```
+
+# BER/CER/DER decoder panics on invalid input
+
+Due to insufficient checking of input data, decoding certain data sequences
+can lead to _bcder_ panicking rather than returning an error. This can affect
+both the actual decoding stage as well as accessing content of types that
+utilized delayed decoding.
+
+bcder 0.7.3 fixes these issues by more thoroughly checking inputs and
+returning errors as expected.
+


### PR DESCRIPTION
The bcder crate has a number of issues resulting in panics when decoding invalid BER/CER/DER encoded data which may result in denial-of-service in applications using the crate.