### PR TITLE
Add notice to gix-transport crate

### DIFF
--- a/crates/gix-transport/RUSTSEC-0000-0000.md
+++ b/crates/gix-transport/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "gix-transport"
+date = "2023-09-23"
+url = "https://github.com/Byron/gitoxide/pull/1032"
+references = ["https://secure.phabricator.com/T12961"]
+categories = ["code-execution"]
+[versions]
+patched = [">= 0.36.1"]
+```
+
+# gix-transport code execution vulnerability
+
+The `gix-transport` crate prior to the patched version 0.36.1 would allow attackers to
+use malicious ssh clone URLs to pass arbitrary arguments to the `ssh` program, leading
+to arbitrary code execution.
+
+PoC: `gix clone 'ssh://-oProxyCommand=open$IFS-aCalculator/foo'`
+
+This will launch a calculator on OSX.
+
+See https://secure.phabricator.com/T12961 for more details on similar vulnerabilities in `git`.

--- a/crates/gix-transport/RUSTSEC-0000-0000.md
+++ b/crates/gix-transport/RUSTSEC-0000-0000.md
@@ -21,3 +21,5 @@ PoC: `gix clone 'ssh://-oProxyCommand=open$IFS-aCalculator/foo'`
 This will launch a calculator on OSX.
 
 See https://secure.phabricator.com/T12961 for more details on similar vulnerabilities in `git`.
+
+Thanks for [vin01](https://github.com/vin01) for disclosing the issue.


### PR DESCRIPTION
Reproducer with `gix` (CLI) v0.29

* `gix clone 'ssh://-oProxyCommand=open$IFS-aCalculator/foo'`
    - This will launch a calculator on OSX.

Fixed in `gix` (CLI) v0.30.

See https://secure.phabricator.com/T12961 for more details.

This issue was discovered by @vin01 whom I thank for their diligence!