### PR TITLE
Add advisory for unsoundness in Hound < 3.5.1

### DIFF
--- a/crates/hound/RUSTSEC-0000-0000.md
+++ b/crates/hound/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "hound"
+date = "2023-09-25"
+url = "https://github.com/ruuda/hound/blob/9a962e1819102a33f0af2a2c60be6f0edcdfd7a8/changelog.md#351"
+references = ["https://github.com/ruuda/hound/pull/58"]
+informational = "unsound"
+
+[versions]
+patched = [">= 3.5.1"]
+unaffected = ["< 0.2.0"]
+```
+
+# `WavReader` and `WavWriter` write to uninitialized memory
+
+Affected versions wrote to uninitialized memory that was created through
+`Vec::with_capacity` followed by `Vec::set_len`. Hound did not read from nor
+expose this uninitialized memory, but this construct is unsound nonetheless.
+There is no evidence that the unsoundness has any security impact.
+
+The unsoundness was addressed by using a small zero-initialized buffer (in the
+case of `WavReader`), and through `mem::MaybeUninit` (for `WavWriter`).


### PR DESCRIPTION
See the diff for the description of the unsoundness.