### PR TITLE
Update info about CVE-2023-5129

### DIFF
--- a/crates/libwebp-sys/RUSTSEC-2023-0061.md
+++ b/crates/libwebp-sys/RUSTSEC-2023-0061.md
@@ -5,7 +5,7 @@ package = "libwebp-sys"
 date = "2023-09-12"
 categories = ["memory-corruption"]
 keywords = ["webp"]
-aliases = ["CVE-2023-4863"]
+aliases = ["CVE-2023-5129", "CVE-2023-4863"]
 
 [versions]
 patched = [">= 0.9.3"]
@@ -15,4 +15,4 @@ patched = [">= 0.9.3"]
 
 [Google](https://chromereleases.googleblog.com/2023/09/stable-channel-update-for-desktop_11.html) and [Mozilla](https://www.mozilla.org/en-US/security/advisories/mfsa2023-40/) have released security advisories for RCE due to heap overflow in libwebp. Google warns the vulnerability has been exploited in the wild.
 
-libwebp needs to be updated to include a patch for "OOB write in BuildHuffmanTable".
+libwebp needs to be updated to 1.3.2 to include a patch for "OOB write in BuildHuffmanTable".

--- a/crates/libwebp-sys2/RUSTSEC-2023-0060.md
+++ b/crates/libwebp-sys2/RUSTSEC-2023-0060.md
@@ -5,7 +5,7 @@ package = "libwebp-sys2"
 date = "2023-09-12"
 categories = ["memory-corruption"]
 keywords = ["webp"]
-aliases = ["CVE-2023-4863"]
+aliases = ["CVE-2023-5129", "CVE-2023-4863"]
 
 [versions]
 patched = [">= 0.1.8"]
@@ -15,4 +15,4 @@ patched = [">= 0.1.8"]
 
 [Google](https://chromereleases.googleblog.com/2023/09/stable-channel-update-for-desktop_11.html) and [Mozilla](https://www.mozilla.org/en-US/security/advisories/mfsa2023-40/) have released security advisories for RCE due to heap overflow in libwebp. Google warns the vulnerability has been exploited in the wild.
 
-libwebp needs to be updated to include a patch for "OOB write in BuildHuffmanTable".
+libwebp needs to be updated to 1.3.2 to include a patch for "OOB write in BuildHuffmanTable".


### PR DESCRIPTION
There is finally a CVE specifically for libwebp that doesn't suggest it's a Chrome-only problem.