### PR TITLE
Add patch version to borsh-rs advisory

### DIFF
--- a/crates/borsh/RUSTSEC-2023-0033.md
+++ b/crates/borsh/RUSTSEC-2023-0033.md
@@ -11,7 +11,7 @@ aliases = ["GHSA-fjx5-qpf4-xjf2"]
 
 [affected]
 [versions]
-patched = []
+patched = [">= 1.0.0-alpha.1"]
 ```
 
 # Parsing borsh messages with ZST which are not-copy/clone is unsound


### PR DESCRIPTION
This was patched in [1.0.0-alpha.1](https://github.com/near/borsh-rs/compare/borsh-v0.11.0...borsh-v1.0.0-alpha.1) on 2023-08-07.

I'm not sure if the `alpha.1` is compatible with semver. If not then we have to wait until the stable release of borsh-rs. I did not find guidance on this.