### PR TITLE
Create advisory for tungstenite DoS

### DIFF
--- a/crates/tungstenite/RUSTSEC-0000-0000.md
+++ b/crates/tungstenite/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tungstenite"
+date = "2023-09-25"
+url = "https://github.com/snapview/tungstenite-rs/issues/376"
+categories = ["denial-of-service"]
+keywords = []
+aliases = ["CVE-2023-43669", "GHSA-9mcr-873m-xcxp"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+
+[versions]
+patched = [">= 0.20.1"]
+```
+
+# Tungstenite allows remote attackers to cause a denial of service
+
+The Tungstenite crate through 0.20.0 for Rust allows remote attackers to cause
+a denial of service (minutes of CPU consumption) via an excessive length of an
+HTTP header in a client handshake. The length affects both how many times a parse
+is attempted (e.g., thousands of times) and the average amount of data for each
+parse attempt (e.g., millions of bytes).

--- a/crates/tungstenite/RUSTSEC-0000-0000.md
+++ b/crates/tungstenite/RUSTSEC-0000-0000.md
@@ -5,7 +5,6 @@ package = "tungstenite"
 date = "2023-09-25"
 url = "https://github.com/snapview/tungstenite-rs/issues/376"
 categories = ["denial-of-service"]
-keywords = []
 aliases = ["CVE-2023-43669", "GHSA-9mcr-873m-xcxp"]
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 


### PR DESCRIPTION
@daniel-abramov @agalakhov please have a look. I noticed this via GitHub's vulnerability reporting system, but would be nice to have this in the RustSec advisory database, too (because it triggers tools like cargo-audit and cargo-deny).