### PR TITLE
Updating information about replacements for owning_ref

### DIFF
--- a/crates/owning_ref/RUSTSEC-2022-0040.md
+++ b/crates/owning_ref/RUSTSEC-2022-0040.md
@@ -19,4 +19,5 @@ patched = []
 - `OwningRefMut::as_owner` and `OwningRefMut::as_owner_mut` are [unsound](https://github.com/Kimundi/owning-ref-rs/issues/61) and may result in a use-after-free.
 - The crate [violates Rust's aliasing rules](https://github.com/Kimundi/owning-ref-rs/issues/49), which may cause miscompilations on recent compilers that emit the LLVM `noalias` attribute.
 
-No patched versions are available at this time. While a pull request with some fixes is outstanding, the maintainer appears to be unresponsive.
+`safer_owning_ref` is a replacement crate which fixes these issues.
+No patched versions of the original crate are available, and the maintainer is unresponsive.


### PR DESCRIPTION
I've just taken my original fix and pull request for `owning_Ref` and made it into a crate,
So now people using `owning_ref` can be directed to that as a possible replacement.