### PR TITLE
Remove CVE-2020-25575 from RUSTSEC-2019-0030 aliases

### DIFF
--- a/crates/streebog/RUSTSEC-2019-0030.md
+++ b/crates/streebog/RUSTSEC-2019-0030.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "RUSTSEC-2019-0030"
 package = "streebog"
-aliases = ["CVE-2019-25006", "CVE-2019-25007", "CVE-2020-25575", "GHSA-39wr-f4ff-xm6p", "GHSA-gf93-h79q-6jjv", "GHSA-jq66-xh47-j9f3"]
+aliases = ["CVE-2019-25006", "CVE-2019-25007", "GHSA-39wr-f4ff-xm6p", "GHSA-gf93-h79q-6jjv"]
 categories = ["crypto-failure"]
 date = "2019-10-06"
 url = "https://github.com/RustCrypto/hashes/pull/91"


### PR DESCRIPTION
RUSTSEC-2019-0030 lists CVE-2020-25575 & GHSA-jq66-xh47-j9f3 as aliases, but they don't seem to be related.

CC: https://github.com/github/advisory-database/pull/2907