### PR TITLE
Add patched version to RUSTSEC-2023-0029

### DIFF
--- a/crates/nats/RUSTSEC-2023-0029.md
+++ b/crates/nats/RUSTSEC-2023-0029.md
@@ -8,17 +8,13 @@ keywords = ["tls", "mitm"]
 aliases = ["GHSA-wvc4-j7g5-4f79"]
 
 [versions]
-patched = []
+patched = [">=0.24.1"]
 unaffected = ["< 0.9.0"]
 ```
 
 # TLS certificate common name validation bypass
 
 The NATS official Rust clients are vulnerable to MitM when using TLS.
-
-A fix for the `nats` crate hasn't been released yet. Since the `nats` crate
-is going to be deprecated anyway, consider switching to `async-nats` `>= 0.29`
-which already fixed this vulnerability.
 
 The common name of the server's TLS certificate is validated against
 the `host`name provided by the server's plaintext `INFO` message


### PR DESCRIPTION
Depends on the release of https://github.com/nats-io/nats.rs/pull/1157