### PR TITLE
RUSTSEC-2023-0071.md: use `###` section headers

### DIFF
--- a/crates/rsa/RUSTSEC-2023-0071.md
+++ b/crates/rsa/RUSTSEC-2023-0071.md
@@ -16,16 +16,16 @@ patched = []
 
 # Marvin Attack: potential key recovery through timing sidechannels
 
-## Impact
+### Impact
 Due to a non-constant-time implementation, information about the private key is leaked through timing information which is observable over the network. An attacker may be able to use that information to recover the key.
 
-## Patches
+### Patches
 No patch is yet available, however work is underway to migrate to a fully constant-time implementation.
 
-## Workarounds
+### Workarounds
 The only currently available workaround is to avoid using the `rsa` crate in settings where attackers are able to observe timing information, e.g. local use on a non-compromised computer is fine.
 
-## References
+### References
 This vulnerability was discovered as part of the "[Marvin Attack]", which revealed several implementations of RSA including OpenSSL had not properly mitigated timing sidechannel attacks.
 
 [Marvin Attack]: https://people.redhat.com/~hkario/marvin/


### PR DESCRIPTION
The `##` headers are huge when rendered on rustsec.org