### PR TITLE
Sync advisories ids from GitHub

### DIFF
--- a/crates/bcder/RUSTSEC-2023-0062.md
+++ b/crates/bcder/RUSTSEC-2023-0062.md
@@ -6,7 +6,7 @@ date = "2023-09-13"
 url = "https://nlnetlabs.nl/downloads/bcder/CVE-2023-39914.txt"
 categories = ["denial-of-service"]
 keywords = ["example", "freeform", "keywords"]
-aliases = ["CVE-2023-39914"]
+aliases = ["CVE-2023-39914", "GHSA-6jmw-6mxw-w4jc"]
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 references = ["https://github.com/NLnetLabs/bcder/pull/74"]
 

--- a/crates/cocoon/RUSTSEC-2023-0068.md
+++ b/crates/cocoon/RUSTSEC-2023-0068.md
@@ -7,6 +7,7 @@ url = "https://github.com/fadeevab/cocoon/issues/22"
 categories = ["crypto-failure"]
 cvss = "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:C/C:L/I:L/A:N"
 keywords = ["nonce", "stream-cipher"]
+aliases = ["GHSA-6878-6wc2-pf5h"]
 
 [affected.functions]
 "cocoon::Cocoon::encrypt" = ["<= 0.3.3"]

--- a/crates/compu-brotli-sys/RUSTSEC-2021-0132.md
+++ b/crates/compu-brotli-sys/RUSTSEC-2021-0132.md
@@ -7,6 +7,7 @@ url = "https://github.com/google/brotli/releases/tag/v1.0.9"
 categories = ["memory-corruption"]
 keywords = ["integer-overflow"]
 aliases = ["CVE-2020-8927", "GHSA-5v8v-66v8-mwm7"]
+related = ["PYSEC-2020-29"]
 
 [affected]
 

--- a/crates/cranelift-codegen/RUSTSEC-2021-0067.md
+++ b/crates/cranelift-codegen/RUSTSEC-2021-0067.md
@@ -8,6 +8,7 @@ categories = ["code-execution", "memory-corruption", "memory-exposure"]
 keywords = ["miscompile", "sandbox", "wasm"]
 aliases = ["CVE-2021-32629", "GHSA-hpqh-2wqx-7qp5"]
 cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+related = ["PYSEC-2021-87"]
 
 [versions]
 patched = [">= 0.73.1"]

--- a/crates/failure/RUSTSEC-2020-0036.md
+++ b/crates/failure/RUSTSEC-2020-0036.md
@@ -5,7 +5,7 @@ package = "failure"
 date = "2020-05-02"
 informational = "unmaintained"
 url = "https://github.com/rust-lang-nursery/failure/pull/347"
-aliases = ["CVE-2020-25575", "GHSA-jq66-xh47-j9f3"]
+aliases = ["CVE-2019-25010", "CVE-2020-25575", "GHSA-jq66-xh47-j9f3", "GHSA-r98r-j25q-rmpr"]
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
 
 [versions]

--- a/crates/gix-transport/RUSTSEC-2023-0064.md
+++ b/crates/gix-transport/RUSTSEC-2023-0064.md
@@ -6,6 +6,7 @@ date = "2023-09-23"
 url = "https://github.com/Byron/gitoxide/pull/1032"
 references = ["https://secure.phabricator.com/T12961"]
 categories = ["code-execution"]
+aliases = ["GHSA-rrjw-j4m2-mf34"]
 [versions]
 patched = [">= 0.36.1"]
 ```

--- a/crates/inventory/RUSTSEC-2023-0057.md
+++ b/crates/inventory/RUSTSEC-2023-0057.md
@@ -6,6 +6,7 @@ date = "2023-09-10"
 url = "https://github.com/dtolnay/inventory/pull/43"
 informational = "unsound"
 keywords = ["life-before-main"]
+aliases = ["GHSA-ghc8-5cgm-5rpf"]
 
 [versions]
 patched = [">= 0.2.0"]

--- a/crates/inventory/RUSTSEC-2023-0058.md
+++ b/crates/inventory/RUSTSEC-2023-0058.md
@@ -7,6 +7,7 @@ url = "https://github.com/dtolnay/inventory/pull/42"
 informational = "unsound"
 categories = ["thread-safety"]
 keywords = ["life-before-main"]
+aliases = ["GHSA-36xm-35qq-795w"]
 
 [versions]
 patched = [">= 0.2.0"]

--- a/crates/lexical/RUSTSEC-2023-0055.md
+++ b/crates/lexical/RUSTSEC-2023-0055.md
@@ -5,6 +5,7 @@ package = "lexical"
 date = "2023-09-03"
 informational = "unsound"
 references = ["https://github.com/Alexhuszagh/rust-lexical/issues/102", "https://github.com/Alexhuszagh/rust-lexical/issues/101", "https://github.com/Alexhuszagh/rust-lexical/issues/95", "https://github.com/Alexhuszagh/rust-lexical/issues/104"]
+aliases = ["GHSA-c2hm-mjxv-89r4"]
 
 [versions]
 patched = []

--- a/crates/libwebp-sys/RUSTSEC-2023-0061.md
+++ b/crates/libwebp-sys/RUSTSEC-2023-0061.md
@@ -5,7 +5,7 @@ package = "libwebp-sys"
 date = "2023-09-12"
 categories = ["memory-corruption"]
 keywords = ["webp"]
-aliases = ["CVE-2023-5129", "CVE-2023-4863"]
+aliases = ["CVE-2023-4863", "CVE-2023-5129", "GHSA-j7hp-h8jx-5ppr"]
 
 [versions]
 patched = [">= 0.9.3"]

--- a/crates/libwebp-sys2/RUSTSEC-2023-0060.md
+++ b/crates/libwebp-sys2/RUSTSEC-2023-0060.md
@@ -5,7 +5,7 @@ package = "libwebp-sys2"
 date = "2023-09-12"
 categories = ["memory-corruption"]
 keywords = ["webp"]
-aliases = ["CVE-2023-5129", "CVE-2023-4863"]
+aliases = ["CVE-2023-4863", "CVE-2023-5129", "GHSA-j7hp-h8jx-5ppr"]
 
 [versions]
 patched = [">= 0.1.8"]

--- a/crates/openssl/RUSTSEC-2023-0072.md
+++ b/crates/openssl/RUSTSEC-2023-0072.md
@@ -6,6 +6,7 @@ date = "2023-11-23"
 url = "https://github.com/sfackler/rust-openssl/issues/2096"
 informational = "unsound"
 categories = ["memory-corruption"]
+aliases = ["GHSA-xphf-cx8h-7q9g"]
 
 [affected]
 functions = { "openssl::x509::store::X509StoreRef::objects" = ["< 0.10.60, >=0.10.29"] }

--- a/crates/pleaser/RUSTSEC-2023-0066.md
+++ b/crates/pleaser/RUSTSEC-2023-0066.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "RUSTSEC-2023-0066"
 package = "pleaser"
-aliases = ["CVE-2023-46277"]
+aliases = ["CVE-2023-46277", "GHSA-cgf8-h3fp-h956"]
 date = "2023-04-29"
 url = "https://gitlab.com/edneville/please/-/issues/13"
 categories = ["privilege-escalation"]

--- a/crates/quinn-proto/RUSTSEC-2023-0063.md
+++ b/crates/quinn-proto/RUSTSEC-2023-0063.md
@@ -6,7 +6,7 @@ date = "2023-09-21"
 url = "https://github.com/quinn-rs/quinn/pull/1667"
 categories = ["denial-of-service"]
 keywords = ["panic"]
-aliases = ["GHSA-q8wc-j5m9-27w3"]
+aliases = ["CVE-2023-42805", "GHSA-q8wc-j5m9-27w3"]
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 
 [versions]

--- a/crates/rsa/RUSTSEC-2023-0071.md
+++ b/crates/rsa/RUSTSEC-2023-0071.md
@@ -8,7 +8,7 @@ categories = ["crypto-failure"]
 url = "https://github.com/RustCrypto/RSA/issues/19#issuecomment-1822995643"
 references = ["https://people.redhat.com/~hkario/marvin/"]
 cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N"
-aliases = ["CVE-2023-49092", "GHSA-c38w-74pg-36hr"]
+aliases = ["CVE-2023-49092", "GHSA-4grx-2x9w-596c", "GHSA-c38w-74pg-36hr"]
 
 [versions]
 patched = []

--- a/crates/rsa/RUSTSEC-2023-0071.md
+++ b/crates/rsa/RUSTSEC-2023-0071.md
@@ -8,7 +8,7 @@ categories = ["crypto-failure"]
 url = "https://github.com/RustCrypto/RSA/issues/19#issuecomment-1822995643"
 references = ["https://people.redhat.com/~hkario/marvin/"]
 cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N"
-aliases = ["CVE-2023-49092", "GHSA-4grx-2x9w-596c", "GHSA-c38w-74pg-36hr"]
+aliases = ["CVE-2023-49092", "GHSA-c38w-74pg-36hr", "GHSA-4grx-2x9w-596c"]
 
 [versions]
 patched = []

--- a/crates/self_cell/RUSTSEC-2023-0070.md
+++ b/crates/self_cell/RUSTSEC-2023-0070.md
@@ -6,6 +6,7 @@ date = "2023-11-10"
 url = "https://github.com/Voultapher/self_cell/issues/49"
 categories = []
 keywords = ["unsound", "self_cell", "self-referential"]
+aliases = ["GHSA-48m6-wm5p-rr6h"]
 
 [versions]
 patched = [">= 0.10.3, < 1.0.0", ">= 1.0.2"]

--- a/crates/socket2/RUSTSEC-2020-0079.md
+++ b/crates/socket2/RUSTSEC-2020-0079.md
@@ -6,7 +6,7 @@ date = "2020-11-06"
 url = "https://github.com/rust-lang/socket2-rs/issues/119"
 keywords = ["memory", "layout", "cast"]
 informational = "unsound"
-aliases = ["CVE-2020-35920", "GHSA-458v-4hrf-g3m4"]
+aliases = ["CVE-2020-35919", "CVE-2020-35920", "GHSA-458v-4hrf-g3m4", "GHSA-c79c-gwph-gqfm"]
 cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
 
 [versions]

--- a/crates/users/RUSTSEC-2023-0059.md
+++ b/crates/users/RUSTSEC-2023-0059.md
@@ -6,6 +6,7 @@ date = "2023-09-10"
 url = "https://github.com/ogham/rust-users/issues/55"
 informational = "unsound"
 keywords = ["unaligned-read"]
+aliases = ["GHSA-jcr6-4frq-9gjj"]
 
 [versions]
 patched = []

--- a/crates/wasmtime/RUSTSEC-2021-0110.md
+++ b/crates/wasmtime/RUSTSEC-2021-0110.md
@@ -8,6 +8,7 @@ categories = ["memory-corruption", "memory-exposure"]
 keywords = ["use-after-free", "out-of-bounds read", "out-of-bounds write", "Wasm", "garbage collection"]
 aliases = ["CVE-2021-39216", "CVE-2021-39218", "CVE-2021-39219", "GHSA-4873-36h9-wv49", "GHSA-q879-9g95-56mx", "GHSA-v4cp-h94r-m7xf"]
 cvss = "CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:N/I:H/A:H"
+related = ["PYSEC-2021-320", "PYSEC-2021-321", "PYSEC-2021-322"]
 
 [versions]
 patched = [">= 0.30.0"]


### PR DESCRIPTION
Required a [few changes](https://github.com/rustsec/rustsec/pull/656/commits/f56fb9b2a3a8272100ca8f31bb434f8e5b2be858) in the sync command.

Not sure what to do with the PYSEC ids. The occurrences in this pull request look like actual aliases (i.e. they refer to the same vulnerability in upstream code), but it may not always be the case.