### PR TITLE
Update CVSS score and aliases of RUSTSEC-2023-0071

### DIFF
--- a/crates/rsa/RUSTSEC-2023-0071.md
+++ b/crates/rsa/RUSTSEC-2023-0071.md
@@ -7,8 +7,8 @@ keywords = ["cryptography"]
 categories = ["crypto-failure"]
 url = "https://github.com/RustCrypto/RSA/issues/19#issuecomment-1822995643"
 references = ["https://people.redhat.com/~hkario/marvin/"]
-cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N"
-aliases = ["CVE-2023-49092", "GHSA-c38w-74pg-36hr"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
+aliases = ["CVE-2023-49092", "GHSA-c38w-74pg-36hr", "GHSA-4grx-2x9w-596c"]
 
 [versions]
 patched = []


### PR DESCRIPTION
CVSS score has been updated by the package maintainer:
- https://github.com/github/advisory-database/pull/3030
- https://github.com/advisories/GHSA-c38w-74pg-36hr

Moreover, there is a duplicate [GHSA-4grx-2x9w-596c](https://github.com/advisories/GHSA-4grx-2x9w-596c) which should be mentioned as alias.