### PR TITLE
Mark crate `cosmwasm` as unmaintained

### DIFF
--- a/crates/cosmwasm/RUSTSEC-0000-0000.md
+++ b/crates/cosmwasm/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "cosmwasm"
+date = "2024-01-20"
+url = "https://github.com/CosmWasm/cosmwasm/issues/1430"
+informational = "unmaintained"
+categories = []
+license = "CC0-1.0"
+
+[versions]
+patched = []
+```
+
+# `cosmwasm` is unmaintained
+
+The crate `cosmwasm` is [not used anymore] since spring 2020.
+The functionality was split in multiple different crates, such as the standard library `cosmwasm-std` and the virtual machine `cosmwasm-vm`. An overview can be found in the [cosmwasm repository].
+
+If you have this crate in your dependency tree, this is very likely by mistake and should be corrected.
+
+[not used anymore]: https://github.com/CosmWasm/cosmwasm/issues/1430
+[cosmwasm repository]: https://github.com/CosmWasm/cosmwasm


### PR DESCRIPTION
Hi! I'm one of the original maintainers of the cosmwasm crate. This is unmaintained for a long time for for some reason, it is still downloaded. Would be great to be able to mark it as unmaintained.