### PR TITLE
snow: Unauthenticated Nonce Increment

### DIFF
--- a/crates/snow/RUSTSEC-0000-0000.md
+++ b/crates/snow/RUSTSEC-0000-0000.md
@@ -1,0 +1,28 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "snow"
+date = "2024-01-23"
+url = "https://github.com/mcginty/snow/security/advisories/GHSA-7g9j-g5jg-3vv3"
+categories = ["denial-of-service"]
+keywords = ["noise", "nonce", "state"]
+
+[versions]
+patched = [">= 0.9.5"]
+```
+
+# Unauthenticated Nonce Increment in snow
+
+There was a logic bug where unauthenticated payloads could still cause a nonce
+increment in snow's internal state. For an attacker with privileges to inject
+packets into the channel over which the Noise session operates, this could
+allow a denial-of-service attack which could prevent message delivery by
+sending garbage data.
+
+Note that this only affects those who are using the stateful TransportState,
+not those using StatelessTransportState.
+
+This has been patched in version 0.9.5, and all users are recommended to
+update.
+
+


### PR DESCRIPTION
Main report: https://github.com/mcginty/snow/security/advisories/GHSA-7g9j-g5jg-3vv3

In short: A logic bug was missed that allowed an internal nonce to be incremented even when a received payload was not successfully decrypted, opening up the possibility of an easy denial-of-service attack for those who have the ability to inject data into the channel that is used for Noise.