### PR TITLE
Add unmaintained advisory report for filesystem-rs

### DIFF
--- a/crates/filesystem/RUSTSEC-0000-0000.md
+++ b/crates/filesystem/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "filesystem"
+date = "2024-01-25"
+url = "https://github.com/iredelmeier/filesystem-rs/pull/29"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# filesystem-rs may be implicitly unmaintained
+
+The last release was over 5 years ago, and the last commit was over 4 years ago.
+
+The maintainer(s) have not responded to a pull request to update dependencies that are themselves unmaintained, and which poses the question of maintenance.


### PR DESCRIPTION
The `filesystem` crate (repo URL <https://github.com/iredelmeier/filesystem-rs>) appears to be implicitly unmaintained. The main branch has not been updated for 4+ years, and [this pull request](<https://github.com/iredelmeier/filesystem-rs/pull/29>) from 10 months ago to fix unmaintained dependencies has not been addressed; [this comment](<https://github.com/iredelmeier/filesystem-rs/pull/29#issuecomment-1493898927>) within that PR poses the question of maintenance. 