### PR TITLE
Add unmaintained advisory report for conrod and conrod_core

### DIFF
--- a/crates/conrod/RUSTSEC-0000-0000.md
+++ b/crates/conrod/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "conrod"
+date = "2024-01-26"
+url = "https://crates.io/crates/conrod"
+informational = "unmaintained"
+[versions]
+patched = []
+```
+
+# `conrod` is unmaintained
+
+The crate `conrod` has been [deprecated] since version 0.62.0 released in December 2018. The functionality was split across multiple different crates, with the core functionality being transferred to `conrod_core`. An overview can be found in the [conrod repository].
+
+If you have this crate in your dependency tree, this is very likely by mistake and should be corrected.
+
+[deprecated]: https://crates.io/crates/conrod/
+[conrod repository]: https://github.com/PistonDevelopers/conrod

--- a/crates/conrod_core/RUSTSEC-0000-0000.md
+++ b/crates/conrod_core/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "conrod_core"
+date = "2024-01-26"
+url = "https://github.com/PistonDevelopers/conrod/issues/1454"
+informational = "unmaintained"
+[versions]
+patched = []
+```
+
+# `conrod_core` is unmaintained
+
+The `conrod_core` crate is no longer maintained.
+
+The author suggests [`egui`](https://crates.io/crates/egui) as a potential alternative.


### PR DESCRIPTION
The `conrod` crate is explicitly unmaintained. Core functionality was transferred to `conrod_core` and backend functionality split across a number of separate crates such as `conrod_wgpu` around December 2018.

The entire conrod project became explicitly unmaintained in January 2022 when the developer stepped away from the project (https://github.com/PistonDevelopers/conrod/issues/1454).