### PR TITLE
Add unmaintained advisory for `generational-arena`

### DIFF
--- a/crates/generational-arena/RUSTSEC-0000-0000.md
+++ b/crates/generational-arena/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "generational-arena"
+date = "2024-02-11"
+url = "https://github.com/fitzgen/generational-arena/issues/55"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `generational-arena` is unmaintained
+The `generational-arena` crate's repository has been archived and is no longer maintained.
+
+## Alternatives
+ - [slotmap](https://crates.io/crates/slotmap)


### PR DESCRIPTION
Closes #1883

I included the url for the unanswered maintenance issue, even though this advisory is prompted by the archival of that repository. Let me know if I should just omit that field or if I need to be more descriptive.