### PR TITLE
Add crypto-failure category to snow advisory

### DIFF
--- a/crates/snow/RUSTSEC-2024-0011.md
+++ b/crates/snow/RUSTSEC-2024-0011.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2024-0011"
 package = "snow"
 date = "2024-01-23"
 url = "https://github.com/mcginty/snow/security/advisories/GHSA-7g9j-g5jg-3vv3"
-categories = ["denial-of-service"]
+categories = ["crypto-failure", "denial-of-service"]
 keywords = ["noise", "nonce", "state"]
 aliases = ["GHSA-7g9j-g5jg-3vv3"]
 


### PR DESCRIPTION
Denial of service through messing with nonces is also a crypto-failure.