### PR TITLE
Add non-informational crayon advisory

### DIFF
--- a/crates/crayon/RUSTSEC-0000-0000.md
+++ b/crates/crayon/RUSTSEC-0000-0000.md
@@ -1,0 +1,40 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "crayon"
+date = "2024-02-27"
+url = "https://github.com/shawnscode/crayon/issues/109"
+categories = ["memory-corruption"]
+keywords = ["std::mem::uninitialized", "address-sanitizer"]
+
+[versions]
+patched = []
+unaffected = ["< 0.6.0"]
+[affected]
+functions = { "crayon::utils::object_pool::ObjectPool<H,T>::free" = [">=0.6.0"] }
+```
+
+# ObjectPool creates uninitialized memory when freeing objects
+
+As of version 0.6.0, the ObjectPool explicitly creates an uninitialized instance of its
+type parameter when it attempts to free an object, and swaps it into the storage. This
+causes instant undefined behavior due to reading the uninitialized memory in order to
+write it to the pool storage.
+
+Extremely basic usage of the crate can trigger this issue, e.g. this code from a doctest:
+
+```rust
+use crayon::prelude::*;
+application::oneshot().unwrap();
+
+let mut params = MeshParams::default();
+
+let mesh = video::create_mesh(params, None).unwrap();
+
+// Deletes the mesh object.
+video::delete_mesh(mesh); // <-- UB
+```
+
+Upstream silenced the Clippy warning, instead of removing the use of mem::uninitialized.
+
+Discovered via https://asan.saethlin.dev/ub?crate=crayon&version=0.7.1

--- a/crates/crayon/RUSTSEC-0000-0000.md
+++ b/crates/crayon/RUSTSEC-0000-0000.md
@@ -35,6 +35,6 @@ let mesh = video::create_mesh(params, None).unwrap();
 video::delete_mesh(mesh); // <-- UB
 ```
 
-Upstream silenced the Clippy warning, instead of removing the use of mem::uninitialized.
+The Clippy warning for this code was silenced in commit c2fde19caf6149d91faa504263f0bc5cafc35de5.
 
 Discovered via https://asan.saethlin.dev/ub?crate=crayon&version=0.7.1


### PR DESCRIPTION
The crate already has an informational advisory, and this is clearly a separate issue despite affecting the same code.

Discovered via https://asan.saethlin.dev/ub?crate=crayon&version=0.7.1 . I considered removing `informational=unsound` on the previous advisory, but the issue it describes can be worked around with careful usage, while this issue is unconditional UB in extremely basic usage of the crate.

The crate does not appear to have any reverse dependents on crates.io except its own libraries, so the utility of this advisory is questionable, but clearly someone attempted to use it or else the previous advisory would not have been created.