### PR TITLE
Add advisory for stack buffer overflow with whoami

### DIFF
--- a/crates/whoami/RUSTSEC-0000-0000.md
+++ b/crates/whoami/RUSTSEC-0000-0000.md
@@ -1,0 +1,33 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "whoami"
+date = "2024-02-28"
+url = "https://github.com/ardaku/whoami/issues/91"
+informational = "unsound"
+categories = ["denial-of-service", "memory-corruption"]
+keywords = ["buffer-overflow", "stack-buffer-overflow", "cwe-121"]
+license = "CC0-1.0"
+
+[affected]
+# Solaris is also probably affected, as are other Unix OSes that aren't any of:
+# linux, macos, freebsd, dragonfly, bitrig, openbsd, netbsd
+os = ["illumos"]
+functions = { "whoami::username" = ["< 1.5.0"] }
+
+[versions]
+patched = [">= 1.5.0"]
+```
+
+# Stack buffer overflow with whoami on illumos
+
+With older versions of the whoami crate, calling the `username` function leads to an immediate stack
+buffer overflow on illumos. Denial of service and data corruption have both been observed in the
+wild, and the issue is possibly exploitable as well.
+
+This also affects any other Unix platforms that aren't any of: `linux`, `macos`, `freebsd`,
+`dragonfly`, `bitrig`, `openbsd`, `netbsd`.
+
+This issue has been addressed in whoami 1.5.0.
+
+For more information, see [this GitHub issue](https://github.com/ardaku/whoami/issues/91).

--- a/crates/whoami/RUSTSEC-0000-0000.md
+++ b/crates/whoami/RUSTSEC-0000-0000.md
@@ -4,7 +4,6 @@ id = "RUSTSEC-0000-0000"
 package = "whoami"
 date = "2024-02-28"
 url = "https://github.com/ardaku/whoami/issues/91"
-informational = "unsound"
 categories = ["denial-of-service", "memory-corruption"]
 keywords = ["buffer-overflow", "stack-buffer-overflow", "cwe-121"]
 license = "CC0-1.0"

--- a/crates/whoami/RUSTSEC-0000-0000.md
+++ b/crates/whoami/RUSTSEC-0000-0000.md
@@ -6,23 +6,22 @@ date = "2024-02-28"
 url = "https://github.com/ardaku/whoami/issues/91"
 categories = ["denial-of-service", "memory-corruption"]
 keywords = ["buffer-overflow", "stack-buffer-overflow", "cwe-121"]
-license = "CC0-1.0"
 
 [affected]
-# Solaris is also probably affected, as are other Unix OSes that aren't any of:
+# Other Unix OSes that aren't any of these may be affected as well:
 # linux, macos, freebsd, dragonfly, bitrig, openbsd, netbsd
-os = ["illumos"]
+os = ["illumos", "solaris"]
 functions = { "whoami::username" = ["< 1.5.0"] }
 
 [versions]
 patched = [">= 1.5.0"]
 ```
 
-# Stack buffer overflow with whoami on illumos
+# Stack buffer overflow with whoami on illumos and Solaris
 
 With older versions of the whoami crate, calling the `username` function leads to an immediate stack
-buffer overflow on illumos. Denial of service and data corruption have both been observed in the
-wild, and the issue is possibly exploitable as well.
+buffer overflow on illumos and Solaris. Denial of service and data corruption have both been
+observed in the wild, and the issue is possibly exploitable as well.
 
 This also affects any other Unix platforms that aren't any of: `linux`, `macos`, `freebsd`,
 `dragonfly`, `bitrig`, `openbsd`, `netbsd`.


### PR DESCRIPTION
See:

* https://github.com/ardaku/whoami/issues/91
* https://github.com/ardaku/whoami/issues/97

Questions:

* Some other Unix platforms may also be affected. It's hard to enumerate a full list here, but happy to add them as they come to mind for people.