### PR TITLE
update RUSTSEC-2024-0020 with additional information

### DIFF
--- a/crates/whoami/RUSTSEC-2024-0020.md
+++ b/crates/whoami/RUSTSEC-2024-0020.md
@@ -8,9 +8,8 @@ categories = ["denial-of-service", "memory-corruption"]
 keywords = ["buffer-overflow", "stack-buffer-overflow", "cwe-121"]
 
 [affected]
-# Other Unix OSes that aren't any of these may be affected as well:
-# linux, macos, freebsd, dragonfly, bitrig, openbsd, netbsd
-os = ["illumos", "solaris"]
+# Other Unix OSes that aren't Linux or macOS are affected as well.
+os = ["illumos", "solaris", "bitrig", "dragonfly", "freebsd", "netbsd", "openbsd"]
 
 [affected.functions]
 "whoami::username" = ["< 1.5.0"]

--- a/crates/whoami/RUSTSEC-2024-0020.md
+++ b/crates/whoami/RUSTSEC-2024-0020.md
@@ -13,10 +13,10 @@ keywords = ["buffer-overflow", "stack-buffer-overflow", "cwe-121"]
 os = ["illumos", "solaris"]
 
 [affected.functions]
-"whoami::username" = "< 1.5.0"
-"whoami::realname" = "< 1.5.0"
-"whoami::username_os" = "< 1.5.0"
-"whoami::realname_os" = "< 1.5.0"
+"whoami::username" = ["< 1.5.0"]
+"whoami::realname" = ["< 1.5.0"]
+"whoami::username_os" = ["< 1.5.0"]
+"whoami::realname_os" = ["< 1.5.0"]
 
 [versions]
 patched = [">= 1.5.0"]

--- a/crates/whoami/RUSTSEC-2024-0020.md
+++ b/crates/whoami/RUSTSEC-2024-0020.md
@@ -11,20 +11,43 @@ keywords = ["buffer-overflow", "stack-buffer-overflow", "cwe-121"]
 # Other Unix OSes that aren't any of these may be affected as well:
 # linux, macos, freebsd, dragonfly, bitrig, openbsd, netbsd
 os = ["illumos", "solaris"]
-functions = { "whoami::username" = ["< 1.5.0"] }
+
+[affected.functions]
+"whoami::username" = "< 1.5.0"
+"whoami::realname" = "< 1.5.0"
+"whoami::username_os" = "< 1.5.0"
+"whoami::realname_os" = "< 1.5.0"
 
 [versions]
 patched = [">= 1.5.0"]
+unaffected = ["< 0.5.3"]
 ```
 
-# Stack buffer overflow with whoami on illumos and Solaris
+# Stack buffer overflow with whoami on several Unix platforms
 
-With older versions of the whoami crate, calling the `username` function leads to an immediate stack
-buffer overflow on illumos and Solaris. Denial of service and data corruption have both been
-observed in the wild, and the issue is possibly exploitable as well.
+With versions of the whoami crate >= 0.5.3 and < 1.5.0, calling any of these functions leads to an
+immediate stack buffer overflow on illumos and Solaris:
 
-This also affects any other Unix platforms that aren't any of: `linux`, `macos`, `freebsd`,
-`dragonfly`, `bitrig`, `openbsd`, `netbsd`.
+- `whoami::username`
+- `whoami::realname`
+- `whoami::username_os`
+- `whoami::realname_os`
+
+With versions of the whoami crate >= 0.5.3 and < 1.0.1, calling any of the above functions also
+leads to a stack buffer overflow on these platforms:
+
+- Bitrig
+- DragonFlyBSD
+- FreeBSD
+- NetBSD
+- OpenBSD
+
+This occurs because of an incorrect definition of the `passwd` struct on those platforms.
+
+As a result of this issue, denial of service and data corruption have both been observed in the
+wild. The issue is possibly exploitable as well.
+
+This vulnerability also affects other Unix platforms that aren't Linux or macOS.
 
 This issue has been addressed in whoami 1.5.0.
 

--- a/crates/whoami/RUSTSEC-2024-0020.md
+++ b/crates/whoami/RUSTSEC-2024-0020.md
@@ -9,7 +9,9 @@ keywords = ["buffer-overflow", "stack-buffer-overflow", "cwe-121"]
 
 [affected]
 # Other Unix OSes that aren't Linux or macOS are affected as well.
-os = ["illumos", "solaris", "bitrig", "dragonfly", "freebsd", "netbsd", "openbsd"]
+# bitrig is also vulnerable, but not available as a platform with
+# RustSec (and appears to be a dead platform anyway).
+os = ["illumos", "solaris", "dragonfly", "freebsd", "netbsd", "openbsd"]
 
 [affected.functions]
 "whoami::username" = ["< 1.5.0"]


### PR DESCRIPTION
Add information about more platforms affected, per https://github.com/rustsec/advisory-db/pull/1911#issuecomment-1978963801.