### PR TITLE
Add unmaintained advisory for libp2p-tokio-socks5

### DIFF
--- a/crates/libp2p-tokio-socks5/RUSTSEC-0000-0000.md
+++ b/crates/libp2p-tokio-socks5/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libp2p-tokio-socks5"
+date = "2024-04-05"
+url = "https://github.com/comit-network/rust-libp2p-tokio-socks5/commit/e1fdc92ca69ffd254824ab80fbad5660f4aac911"
+informational = "unmaintained"
+license = "CC-BY-4.0"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# `libp2p-tokio-socks5` is unmaintained
+
+Note the repository was archived without an issue so we link directly
+to the commit that marked the repository as unmaintained.
+
+To the best of the original authors knowledge the crate has no
+vulnerabilities as of the last release, it is just unmaintained due to
+laziness - new maintainer welcome.
+


### PR DESCRIPTION
I was the original author and am still the crate owner (on crates.io), I do not, however have write access to the source repository because I no longer work for the company that controls it.

I stopped maintaining this crate in 2021 but did not know about the RustSec Advisory process then.