### PR TITLE
File unmaintained advisory for `rsa-export`

### DIFF
--- a/crates/rsa-export/RUSTSEC-0000-0000.md
+++ b/crates/rsa-export/RUSTSEC-0000-0000.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rsa-export"
+date = "2024-04-06"
+references = [
+    "https://crates.io/crates/rsa-export/0.3.3",
+    "https://gitlab.com/smallglitch/rsa-export/-/commit/e29f17170d655a6f62eca8bf1f64ef0ce5807058",
+]
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `rsa-export` is unmaintained
+
+This crate has been deprecated in favour of using the native support for exporting RSA keys into the standard PEM format.  
+See [docs.rs documentation].
+
+In addition to that, the operations in this crate (arithmetic and Base64 encoding) are not done in constant-time, 
+potentially [exposing the user to sidechannel attacks].
+
+[docs.rs documentation]: https://docs.rs/rsa/0.9.6/rsa/index.html#pkcs8-rsa-key-encoding
+[exposing the user to sidechannel attacks]: https://arxiv.org/pdf/2108.04600.pdf


### PR DESCRIPTION
I am the original author and sole owner of this crate on crates.io.  
The source code is available on GitLab, as linked from the crate page.

I formally deprecated this crate 3-or-so years ago but there are surprisingly still users for it.

Considering the crate is unmaintained *and* the encoding is still done using variable time encodings, exposing the users to risks such as [Util::Lookup](https://arxiv.org/pdf/2108.04600.pdf), I've decided to finally file a RustSec advisory to hopefully get them to move.