### PR TITLE
Clarify that RUSTSEC-2020-0071 is about `time` setting env vars

### DIFF
--- a/crates/time/RUSTSEC-2020-0071.md
+++ b/crates/time/RUSTSEC-2020-0071.md
@@ -42,7 +42,7 @@ unaffected = ["=0.2.0", "=0.2.1", "=0.2.2", "=0.2.3", "=0.2.4", "=0.2.5", "=0.2.
 
 ### Impact
 
-Unix-like operating systems may segfault due to dereferencing a dangling pointer in specific circumstances. This requires an environment variable to be set in a different thread than the affected functions. This may occur without the user's knowledge, notably in a third-party library.
+The affected functions set environment variables without synchronization. On Unix-like operating systems, this can crash in multithreaded programs. Programs may segfault due to dereferencing a dangling pointer if an environment variable is read in a different thread than the affected functions. This may occur without the user's knowledge, notably in the Rust standard library or third-party libraries.
 
 The affected functions from time 0.2.7 through 0.2.22 are:
 
@@ -55,9 +55,10 @@ The affected functions from time 0.2.7 through 0.2.22 are:
 
 The affected functions in time 0.1 (all versions) are:
 
-- `at`
-- `at_utc`
-- `now`
+- `time::at_utc`
+- `time::at`
+- `time::now`
+- `time::tzset`
 
 Non-Unix targets (including Windows and wasm) are unaffected.
 


### PR DESCRIPTION
Fixes #1976.