### PR TITLE
add: Unmaintained advisory for chrono-english

### DIFF
--- a/crates/chrono-english/RUSTSEC-0000-0000.md
+++ b/crates/chrono-english/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "chrono-english"
+informational = "unmaintained"
+date = "2024-06-24"
+url = "https://github.com/stevedonovan/chrono-english/issues/29"
+
+[versions]
+patched = []
+```
+
+# The maintainer of chrono-english is unresponsible
+
+All versions will encounter compilation errors with a chrono version `>0.4.35`, due
+to backward incompatible API changes.
+
+User conradludgade reworked the original crate and created a fork with the same API
+surface called [interim](https://github.com/conradludgate/interim).
+
+The fork is better structured and passes the same test suite as chrono-english,
+ensuring backward compatibility.


### PR DESCRIPTION
Add advisory for `chrono-english`, which fails to build with the newest chrono versions.
https://github.com/stevedonovan/chrono-english/issues/29

The maintainer is unresponsive since three years, effectively making the repository unmaintained.
https://github.com/stevedonovan/chrono-english/issues/22

I propose [`interim`](https://github.com/conradludgate/interim) as a replacement, as its code is a lot cleaner and as it fixed several issues that still exist on chrono-english. The maintainer is active and notified me of this alternative when I ran into the compilation issues in one of my projects.

https://github.com/Nukesor/pueue/issues/534