### PR TITLE
Create `mmap` unmaintained advisory

### DIFF
--- a/crates/mmap/RUSTSEC-0000-0000.md
+++ b/crates/mmap/RUSTSEC-0000-0000.md
@@ -1,0 +1,15 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "mmap"
+date = "2024-06-10"
+url = "https://github.com/rbranson/rust-mmap"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# mmap unmaintained
+
+The `mmap` crate is unmaintained as its [repository has been archived](https://github.com/rbranson/rust-mmap) on Feb 10, 2022.

--- a/crates/mmap/RUSTSEC-0000-0000.md
+++ b/crates/mmap/RUSTSEC-0000-0000.md
@@ -13,3 +13,4 @@ patched = []
 # mmap unmaintained
 
 The `mmap` crate is unmaintained as its [repository has been archived](https://github.com/rbranson/rust-mmap) on Feb 10, 2022.
+The main alternative seems to be `memmap2` crate.


### PR DESCRIPTION
Note: Did not ask the author about the status explicitly but the repository is archived for over two years so it should be a good indication