### PR TITLE
Add aliases to RUSTSEC-2024-0343

### DIFF
--- a/crates/nano-id/RUSTSEC-2024-0343.md
+++ b/crates/nano-id/RUSTSEC-2024-0343.md
@@ -5,6 +5,7 @@ package = "nano-id"
 date = "2024-06-03"
 categories = ["crypto-failure"]
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:L"
+aliases = ["GHSA-2hfw-w739-p7x5", "GHSA-9hc7-6w9r-wj94", "CVE-2024-36400"]
 
 [affected]
 functions = { "nano_id::base58" = ["< 0.4.0"], "nano_id::base62" = ["< 0.4.0"], "nano_id::gen" = ["< 0.4.0"] }


### PR DESCRIPTION
Added following aliases to RUSTSEC-2024-0343.

- https://github.com/advisories/GHSA-2hfw-w739-p7x5
- https://github.com/advisories/GHSA-9hc7-6w9r-wj94
- https://nvd.nist.gov/vuln/detail/CVE-2024-36400