### PR TITLE
Add advisory for unsound problem in `wasmtime_jit_debug`

### DIFF
--- a/crates/wasmtime_jit_debug/RUSTSEC-0000-0000.md
+++ b/crates/wasmtime_jit_debug/RUSTSEC-0000-0000.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime_jit_debug"
+date = "2024-07-06"
+url = "https://github.com/bytecodealliance/wasmtime/issues/8905"
+informational = "unsound"
+categories = ["memory-exposure"]
+
+[affected]
+functions = { "wasmtime_jit_debug::perf_jitdump::JitDumpFile::dump_code_load_record" = ["<= 22.0.0"] }
+
+[versions]
+patched = []
+```
+
+# Dump Undefined Memory by `JitDumpFile`
+
+The unsound function `dump_code_load_record` uses `from_raw_parts` to directly convert 
+the pointer `addr` and `len` into a slice without any validation and that memory block 
+would be dumped.
+
+Thus, the 'safe' function dump_code_load_record is actually 'unsafe' since it requires 
+the caller to guarantee that the addr is valid and len must not overflow.
+Otherwise, the function could dump the memory into file illegally, causing memory leak.


### PR DESCRIPTION
A soundness bug in `wasmtime_jit_debug` that wrongly marks the function `dump_code_load_record` as 'safe'.
The issue report: https://github.com/bytecodealliance/wasmtime/issues/8905