### PR TITLE
Add advisory for unsound problem in `scanner-rust`

### DIFF
--- a/crates/scanner-rust/RUSTSEC-0000-0000.md
+++ b/crates/scanner-rust/RUSTSEC-0000-0000.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "scanner-rust"
+date = "2024-07-06"
+url = "https://github.com/magiclen/scanner-rust/issues/2"
+informational = "unsound"
+categories = ["format-injection"]
+
+[affected]
+functions = { "scanner-rust::ScannerU8SliceAscii::new" = ["<= 2.0.17"] }
+
+[versions]
+patched = []
+```
+
+# Create and parse non-utf8 str in `ScannerU8SliceAscii`
+
+`ScannerU8SliceAscii` uses lots of unsafe function `from_utf8_unchecked` to directly 
+convert the `[u8]` to `str` and then parse it to target type.
+
+However, there is no validation in `ScannerU8SliceAscii::new` to guarantee the `data` 
+is Ascii. So if the `ScannerU8SliceAscii` is used to scan the non-utf8 bytes, non-utf8 
+str would be generated and passed it to `parse` which might lead to undefined behaviors.


### PR DESCRIPTION
`ScannerU8SliceAscii` creates and parses non-utf8 str, which is unsound and might lead to undefined behaviors.
The details are described in https://github.com/magiclen/scanner-rust/issues/2.