### PR TITLE
Add advisory for unsound problems in `workflow-core`

### DIFF
--- a/crates/workflow-core/RUSTSEC-0000-0000.md
+++ b/crates/workflow-core/RUSTSEC-0000-0000.md
@@ -1,0 +1,26 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "workflow-core"
+date = "2024-07-07"
+url = "https://github.com/workflow-rs/workflow-rs/issues/11"
+informational = "unsound"
+categories = ["memory-exposure", "memory-corruption"]
+
+[affected.functions]
+"workflow_core::utils::buffer_as_slice" = ["<= 0.13.3"]
+"workflow_core::utils::buffer_as_slice_mut" = ["<= 0.13.3"]
+
+[versions]
+patched = []
+```
+
+# Create illegal slice by util function
+
+The util functions `buffer_as_slice` and `buffer_as_slice_mut` in crate 
+`workflow-core` are very powerful and useful to get slice of other types 
+but are rather unsafe as well:
+
+1. The pointer calculation with `byte_offset` could lead to alignment problem, which is an undefined behavior.
+
+2. The `from_raw_parts` could create an out-of-bound slice that allows the user to access or even change the memory illegally.


### PR DESCRIPTION
The util functions `buffer_as_slice` and `buffer_as_slice_mut` in crate `workflow-core` could create illegal slice.
The details are described in https://github.com/workflow-rs/workflow-rs/issues/11