### PR TITLE
Add advisory for unsound problems in `substreams`

### DIFF
--- a/crates/substreams/RUSTSEC-0000-0000.md
+++ b/crates/substreams/RUSTSEC-0000-0000.md
@@ -1,0 +1,26 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "substreams"
+date = "2024-07-07"
+url = "https://github.com/streamingfast/substreams-rs/issues/24"
+informational = "unsound"
+categories = ["memory-exposure"]
+
+[affected.functions]
+"substreams::memory::get_output_data" = ["<= 0.5.20"]
+"substreams::memory::read_u32_from_heap" = ["<= 0.5.20"]
+"substreams::proto::decode_ptr" = ["<= 0.5.20"]
+
+[versions]
+patched = []
+```
+
+# Unsoundly mark unsafe functions as safe
+
+The functions `read_u32_from_heap`, `get_output_data`, and `decode_ptr` in crate
+`substreams` are unsafe since they directly operate on the pointer passed in and
+have requirements for the caller.
+
+These functions allow the caller to access memory illegally and generate undefined
+`Vec` which could lead to more undefined behaviors.


### PR DESCRIPTION
The crate `substreams` unsoundly marks some 'unsafe' functions as 'safe'. So the caller could complete unsafe operations within safe Rust.
The details are described in https://github.com/streamingfast/substreams-rs/issues/24