### PR TITLE
Add advisory for the unsound problem in `arrow2`

### DIFF
--- a/crates/arrow2/RUSTSEC-0000-0000.md
+++ b/crates/arrow2/RUSTSEC-0000-0000.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "arrow2"
+date = "2024-07-07"
+url = "https://github.com/jorgecarleitao/arrow2/blob/main/src/compute/sort/row/mod.rs#L272"
+informational = "unsound"
+categories = ["memory-exposure"]
+
+[affected]
+functions = { "arrow2::compute::sort::row::Rows::row_unchecked" = [">= 0.14.2, <= 0.18.0"] }
+
+[versions]
+patched = []
+```
+
+# Unsoundly mark unsafe function as safe
+
+The function `Rows::row_unchecked` is wrongly marked as safe, which would confuse 
+the boundary between safe and unsafe Rust and allow illegal memory access in safe
+Rust.


### PR DESCRIPTION
The function `Rows::row_unchecked` is wrongly marked as safe.
Since the repository of [`arrow2`](https://github.com/jorgecarleitao/arrow2) have been archived, we link the url the function signature and create a [PR](https://github.com/rerun-io/re_arrow2/pull/5) in its folk repository.