### PR TITLE
Fix patched zerovec-derive version

### DIFF
--- a/crates/zerovec-derive/RUSTSEC-2024-0346.md
+++ b/crates/zerovec-derive/RUSTSEC-2024-0346.md
@@ -6,7 +6,7 @@ date = "2024-07-01"
 categories = ["memory-corruption"]
 
 [versions]
-patched = [">= 0.10.4", ">= 0.9.7, <0.10.0"]
+patched = [">= 0.10.3", ">= 0.9.7, <0.10.0"]
 ```
 
 # Incorrect usage of `#[repr(packed)]`
@@ -16,4 +16,4 @@ The affected versions make unsafe memory accesses under the assumption that `#[r
 The Rust specification does not guarantee this, and https://github.com/rust-lang/rust/pull/125360 (1.80.0-beta) starts 
 reordering fields of `#[repr(packed)]` structs, leading to illegal memory accesses.
 
-The patched versions `0.9.7` and `0.10.4` use `#[repr(C, packed)]`, which guarantees field order.
+The patched versions `0.9.7` and `0.10.3` use `#[repr(C, packed)]`, which guarantees field order.


### PR DESCRIPTION
We accidentally proposed the wrong version here in #1990

zerovec 0.10.4 and zerovec-derive 0.10.3 are patched.