### PR TITLE
Add some FAQ entries linking to security policies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,19 @@ A: We do not presently handle embargoed vulnerabilities. Please ensure embargoes
    have been lifted and details have been disclosed to the public prior to filing
    them against RustSec.
 
+**Q: Is this where I report a vulnerability in `rustc`?**
+
+A: No, for official Rust projects, please see the [Rust Security Policy](https://www.rust-lang.org/policies/security) and follow the guidelines there.
+
+**Q: Is this where I report intentionally malicious code or malware present on crates.io?**
+
+A: No, please see the [Crates.io Security Policy](https://crates.io/policies/security) to get content violating crates.io's policies taken down.
+
+**Q: I'm a crate author and someone reported a vulnerability in my crate to me. Can you help me?**
+
+A: The Rust Foundation has resources that can help handle Rust ecosystem security issues.
+Please see the [Ecosystem security help for crate authors](https://crates.io/policies/security#ecosystem-security-help) section of the crates.io security policy.
+
 [Pull Request]: https://github.com/RustSec/advisory-db/pulls
 [TOML advisory template]: https://github.com/RustSec/advisory-db#advisory-format
 [Yank]: https://doc.rust-lang.org/cargo/commands/cargo-yank.html


### PR DESCRIPTION
Hi! 

We recently created a security policy page for crates.io at https://crates.io/policies/security (which, incidentally, links to rustsec-- if you'd like anything changed about that section, please send us a PR! ❤️ )

I'm on a mission to make sure as many crate authors as possible know, before there's a major security incident, that the Rust Foundation can help handling security problems that happen in the ecosystem, so in addition to adding a more general FAQ linking to the crates.io security policy, I've added a question that links to the ecosystem security help section directly.

I also noticed the Rust security policy wasn't linked in the FAQs here at all, so I added one for that too.

I'm open to changing the wording on any of these new FAQ entries, and if there are other places instead of, or in addition to, this that this info should live, please let me know and I'm happy to change/add it!

Thank you for all your hard work! ❤️ 