### PR TITLE
Unsoundness notice for gix-attributes (kstring integration)

### DIFF
--- a/crates/gix-attributes/RUSTSEC-0000-0000.md
+++ b/crates/gix-attributes/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "gix-attributes"
+date = "2024-07-24"
+url = "https://github.com/Byron/gitoxide/issues/1460"
+informational = "unsound"
+
+[versions]
+patched = [">= 0.22.3"]
+```
+
+# The kstring integration in gix-attributes is unsound
+
+gix-attributes (in [state::ValueRef](https://github.com/Byron/gitoxide/blob/main/gix-attributes/src/state.rs#L19-L27)) unsafely creates a `&str` from a `&[u8]` containing non-UTF8 data, with the justification that so long as nothing reads the &str and relies on it being UTF-8 in the &str, there is no UB:
+
+```rust
+// SAFETY: our API makes accessing that value as `str` impossible, so illformed UTF8 is never exposed as such.
+```
+
+The problem is that the non-UTF8 `str` **is** exposed to outside code: first to the `kstring` crate itself, which requires UTF-8 in its documentation and may have UB as a consequence of this, but also to `serde`, where it propagates to e.g. `serde_json`, `serde_yaml`, etc., where the same problems occur.
+
+As far as I know, this is not sound, and either is or can cause UB down the line in these places that can view the `&str`.

--- a/crates/gix-attributes/RUSTSEC-0000-0000.md
+++ b/crates/gix-attributes/RUSTSEC-0000-0000.md
@@ -12,7 +12,7 @@ patched = [">= 0.22.3"]
 
 # The kstring integration in gix-attributes is unsound
 
-gix-attributes (in [state::ValueRef](https://github.com/Byron/gitoxide/blob/main/gix-attributes/src/state.rs#L19-L27)) unsafely creates a `&str` from a `&[u8]` containing non-UTF8 data, with the justification that so long as nothing reads the &str and relies on it being UTF-8 in the &str, there is no UB:
+`gix-attributes` (in [`state::ValueRef`](https://github.com/Byron/gitoxide/blob/gix-attributes-v0.22.2/gix-attributes/src/state.rs#L19-L27)) unsafely creates a `&str` from a `&[u8]` containing non-UTF8 data, with the justification that so long as nothing reads the `&str` and relies on it being UTF-8 in the `&str`, there is no UB:
 
 ```rust
 // SAFETY: our API makes accessing that value as `str` impossible, so illformed UTF8 is never exposed as such.
@@ -20,4 +20,4 @@ gix-attributes (in [state::ValueRef](https://github.com/Byron/gitoxide/blob/main
 
 The problem is that the non-UTF8 `str` **is** exposed to outside code: first to the `kstring` crate itself, which requires UTF-8 in its documentation and may have UB as a consequence of this, but also to `serde`, where it propagates to e.g. `serde_json`, `serde_yaml`, etc., where the same problems occur.
 
-As far as I know, this is not sound, and either is or can cause UB down the line in these places that can view the `&str`.
+This is not sound, and it could cause further UB down the line in these places that can view the `&str`.


### PR DESCRIPTION
gix-attributes was found by @ssbr to be unsound, as reported in https://github.com/Byron/gitoxide/issues/1460. This adds an informational notice for that, as discussed in comments there (cc @Byron).

The text of the notice is taken from that issue (083656c), with slight modification (1a50df1).

It looks like the affected code, having been introduced in https://github.com/Byron/gitoxide/pull/400, was most likely present in all published versions of the crate prior to the fix in 0.22.3 (which was one of the bugs fixed in https://github.com/Byron/gitoxide/pull/1462). So I have not specified a minimum affected version.