### PR TITLE
Update versions for RUSTSEC-2024-0361

### DIFF
--- a/crates/cosmwasm-vm/RUSTSEC-2024-0361.md
+++ b/crates/cosmwasm-vm/RUSTSEC-2024-0361.md
@@ -9,7 +9,7 @@ keywords = ["resource-consumption"]
 aliases = ["GHSA-rg2q-2jh9-447q"]
 
 [versions]
-patched = [">= 1.5.6, < 2.0.0", ">= 2.0.5, < 2.1.0", ">= 2.1.2"]
+patched = [">= 1.5.7, < 2.0.0", ">= 2.0.6, < 2.1.0", ">= 2.1.3"]
 ```
 
 # CWA-2024-004: Gas mispricing in cosmwasm-vm


### PR DESCRIPTION
We noticed a problem with our previous patch that leads to consensus problem because of a missing cache invalidation.
This bumps the versions in the advisory to the ones where this was fixed.