### PR TITLE
report unsound issue in bcc

### DIFF
--- a/crates/bcc/RUSTSEC-0000-0000.md
+++ b/crates/bcc/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "bcc"
+date = "2024-08-21"
+url = "https://github.com/rust-bpf/rust-bcc/issues/200"
+#informational = "unmaintained"
+categories = ["memory-corruption"]
+keywords = ["misalignment"]
+
+[versions]
+patched = []
+```
+
+# Unsound usage of unsafe implementation from `Vec<u8>` to `T`
+
+Unsafe misaligned conversion found at function `null_or_mut_ptr`. The pointer to 'Vec<u8>' is converted to a struct `T`. This unsound implementation would create a misalignment issues if the type size of `Vec<u8>` is smaller than the type size of struct `T`.
+If we further manipulate the problematic converted types, it would potentially lead to different undefined behavior such as access out-of-bound.
+
+In the meantime, bcc will no longer be maintained. Users are encouraged to migrate to libbpf-rs.


### PR DESCRIPTION
For more information, see: [rust-bcc/issues/200](https://github.com/rust-bpf/rust-bcc/issues/200)
In the meantime, bcc will no longer be maintained. Users are encouraged to migrate to libbpf-rs.
