### PR TITLE
update resolution for RUSTSEC-2024-0363 (sqlx)

### DIFF
--- a/crates/sqlx/RUSTSEC-2024-0363.md
+++ b/crates/sqlx/RUSTSEC-2024-0363.md
@@ -45,12 +45,9 @@ For web application backends, consider adding some middleware that limits the si
 
 ## Resolution
 
-Work has started on a branch to add `#[deny]` directives for the following Clippy lints:
+`sqlx 0.8.1` has been released with the fix: <https://github.com/launchbadge/sqlx/blob/main/CHANGELOG.md#081---2024-08-23>
 
-* [`cast_possible_truncation`](https://rust-lang.github.io/rust-clippy/master/#/cast_possible_truncation)
-* [`cast_possible_wrap`](https://rust-lang.github.io/rust-clippy/master/#/cast_possible_wrap)
-* [`cast_sign_loss`](https://rust-lang.github.io/rust-clippy/master/#/cast_sign_loss)
+Postgres users are advised to upgrade ASAP as a possible exploit has been demonstrated:
+<https://github.com/launchbadge/sqlx/issues/3440#issuecomment-2307956901>
 
-and to manually audit the code that they flag.
-
-A fix is expected to be included in the `0.8.1` release (still WIP as of writing).
+MySQL and SQLite do not _appear_ to be exploitable, but upgrading is recommended nonetheless.


### PR DESCRIPTION
There's no instructions in https://github.com/rustsec/advisory-db/blob/main/CONTRIBUTING.md on what should be done to update an advisory, or if updating an advisory is allowed.

Also, in the process of addressing the issue, I was able to demonstrate a possible exploit for Postgres. Does this mean I should file a CVE as well?