### PR TITLE
`instant` is unmaintained

### DIFF
--- a/crates/instant/RUSTSEC-0000-0000.md
+++ b/crates/instant/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "instant"
+date = "2024-09-01"
+references = [
+    "https://crates.io/crates/instant/0.1.13",
+    "https://github.com/sebcrozet/instant/issues/52",
+]
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `instant` is unmaintained
+
+This crate is no longer maintained, and the author recommends using the maintained [`web-time`] crate instead.
+
+[`web-time`]: https://crates.io/crates/web-time


### PR DESCRIPTION
The author has stated in the project's README and [crates.io page](https://crates.io/crates/instant/0.1.13) that the crate is unmaintained, and links to `web-time` as an alternative.
See also https://github.com/sebcrozet/instant/issues/52.

CC @sebcrozet @daxpedda