### PR TITLE
Add advisory for olm-sys (unmaintained, crypto failure)

### DIFF
--- a/crates/olm-sys/RUSTSEC-0000-0000.md
+++ b/crates/olm-sys/RUSTSEC-0000-0000.md
@@ -5,7 +5,6 @@ package = "olm-sys"
 date = "2024-09-02"
 url = "https://gitlab.gnome.org/BrainBlasted/olm-sys/-/issues/12"
 references = ["https://matrix.org/blog/2024/08/libolm-deprecation/"]
-informational = "unmaintained"
 categories = ["crypto-failure"]
 related = ["CVE-2024-45191", "CVE-2024-45192", "CVE-2024-45193"]
 

--- a/crates/olm-sys/RUSTSEC-0000-0000.md
+++ b/crates/olm-sys/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "olm-sys"
+date = "2024-09-02"
+url = "https://gitlab.gnome.org/BrainBlasted/olm-sys/-/issues/12"
+references = ["https://matrix.org/blog/2024/08/libolm-deprecation/"]
+informational = "unmaintained"
+categories = ["crypto-failure"]
+related = ["CVE-2024-45191", "CVE-2024-45192", "CVE-2024-45193"]
+
+[versions]
+patched = []
+```
+
+# olm-sys: wrapped library unmaintained, potentially vulnerable
+
+After several cryptographic vulnerabilities in `libolm` were disclosed publicly, the Matrix Foundation has [officially deprecated the library](https://matrix.org/blog/2024/08/libolm-deprecation/). `olm-sys` is a thin wrapper around `libolm` and is now deprecated and potentially vulnerable in kind.
+
+Users of `olm-sys` and its higher-level abstraction, `olm-rs`, are highly encouraged to switch to [`vodozemac`](https://crates.io/crates/vodozemac) as soon as possible. It is the successor effort to `libolm` and is written in Rust.


### PR DESCRIPTION
I have been the almost sole maintainer of `olm-sys` for several years now. For about two years nothing has happened, as the successor effort `vodozemac` has taken off. However, a recent high-profile blog post has publicly disclosed crypto failures in `libolm`, the library that `olm-sys` wraps, and as a result the library has been [officially declared as deprecated](https://matrix.org/blog/2024/08/libolm-deprecation/).

The advisory in this PR is filled to reflect the unmaintained and simultaneously vulnerable status. Let me know if anything needs changing. Thanks.