### PR TITLE
Add CVE number for RUSTSEC-2024-0367 (config scopes)

### DIFF
--- a/crates/gix-path/RUSTSEC-2024-0367.md
+++ b/crates/gix-path/RUSTSEC-2024-0367.md
@@ -4,9 +4,9 @@ id = "RUSTSEC-2024-0367"
 package = "gix-path"
 date = "2024-08-31"
 url = "https://github.com/Byron/gitoxide/security/advisories/GHSA-v26r-4c9c-h3j6"
-keywords = ["configuration-failure", "information-leak"]
 cvss = "CVSS:3.1/AV:L/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N"
-aliases = ["GHSA-v26r-4c9c-h3j6"]
+keywords = ["configuration-failure", "information-leak"]
+aliases = ["CVE-2024-45305", "GHSA-v26r-4c9c-h3j6"]
 license = "CC0-1.0"
 
 [affected.functions]


### PR DESCRIPTION
This adds CVE-2024-45305 to `aliases` for RUSTSEC-2024-0367.

No CVE had been issued for that vulnerability when it was added to the RUSTSEC database in #2055, but it has been assigned since. (This CVE number can, if desired, be confirmed at https://github.com/Byron/gitoxide/security/advisories/GHSA-v26r-4c9c-h3j6, under "CVE ID" on the sidebar.)

Although I suspect an entry in the GitHub Advisory Database will be created, and as GHSA-v26r-4c9c-h3j6 is the repo-level GHSA that URL will likely be https://github.com/advisories/GHSA-v26r-4c9c-h3j6, I have refrained from adding that here because the page does not yet exist and I don't want to add inaccurate information. I'll open another PR if/when there is more to add.

cc @Byron