### PR TITLE
Add global GHSA reference for RUSTSEC-2024-0367 (config scopes)

### DIFF
--- a/crates/gix-path/RUSTSEC-2024-0367.md
+++ b/crates/gix-path/RUSTSEC-2024-0367.md
@@ -31,9 +31,9 @@ patched = [">= 0.10.10"]
 
 In `gix_path::env`, the underlying implementation of the `installation_config` and `installation_config_prefix` functions calls `git config -l --show-origin` and parses the first line of the output to extract the path to the configuration file holding the configuration variable of highest [scope](https://git-scm.com/docs/git-config#SCOPES):
 
-https://github.com/Byron/gitoxide/blob/12251eb052df30105538fa831e641eea557f13d8/gix-path/src/env/git/mod.rs#L91
+<https://github.com/Byron/gitoxide/blob/12251eb052df30105538fa831e641eea557f13d8/gix-path/src/env/git/mod.rs#L91>
 
-https://github.com/Byron/gitoxide/blob/12251eb052df30105538fa831e641eea557f13d8/gix-path/src/env/git/mod.rs#L112
+<https://github.com/Byron/gitoxide/blob/12251eb052df30105538fa831e641eea557f13d8/gix-path/src/env/git/mod.rs#L112>
 
 While the configuration variable of highest scope is not usually in the local scope, there are practical situations where this occurs:
 

--- a/crates/gix-path/RUSTSEC-2024-0367.md
+++ b/crates/gix-path/RUSTSEC-2024-0367.md
@@ -4,6 +4,10 @@ id = "RUSTSEC-2024-0367"
 package = "gix-path"
 date = "2024-08-31"
 url = "https://github.com/Byron/gitoxide/security/advisories/GHSA-v26r-4c9c-h3j6"
+references = [
+   "https://github.com/advisories/GHSA-v26r-4c9c-h3j6",
+   "https://nvd.nist.gov/vuln/detail/CVE-2024-45305",
+]
 cvss = "CVSS:3.1/AV:L/AC:H/PR:N/UI:R/S:U/C:L/I:N/A:N"
 keywords = ["configuration-failure", "information-leak"]
 aliases = ["CVE-2024-45305", "GHSA-v26r-4c9c-h3j6"]


### PR DESCRIPTION
This adds a link to [the GitHub Advisory Database entry](https://github.com/advisories/GHSA-v26r-4c9c-h3j6) for [RUSTSEC-2024-0367](https://rustsec.org/advisories/RUSTSEC-2024-0367.html)/CVE-2024-45305/https://github.com/Byron/gitoxide/security/advisories/GHSA-v26r-4c9c-h3j6.

This entry was added to the GitHub Advisory Database since this RUSTSEC entry was created in #2055 and updated in #2061.

This also adds a reference to NVD entry, which has a useful summary and appears as a reference in the global GHSA's reference section, and fixes two bare URLs that are intended to be hyperlinks (and that are hyperlinks automatically in the global GHSA).

cc @Byron 