### PR TITLE
Make small readability improvements in RUSTSEC-2023-0064

### DIFF
--- a/crates/gix-transport/RUSTSEC-2023-0064.md
+++ b/crates/gix-transport/RUSTSEC-2023-0064.md
@@ -23,4 +23,4 @@ This will launch a calculator on OSX.
 
 See <https://secure.phabricator.com/T12961> for more details on similar vulnerabilities in `git`.
 
-Thanks for [vin01](https://github.com/vin01) for disclosing the issue.
+Thanks to [vin01](https://github.com/vin01) for disclosing the issue.

--- a/crates/gix-transport/RUSTSEC-2023-0064.md
+++ b/crates/gix-transport/RUSTSEC-2023-0064.md
@@ -21,6 +21,6 @@ PoC: `gix clone 'ssh://-oProxyCommand=open$IFS-aCalculator/foo'`
 
 This will launch a calculator on OSX.
 
-See https://secure.phabricator.com/T12961 for more details on similar vulnerabilities in `git`.
+See <https://secure.phabricator.com/T12961> for more details on similar vulnerabilities in `git`.
 
 Thanks for [vin01](https://github.com/vin01) for disclosing the issue.


### PR DESCRIPTION
[RUSTSEC-2023-0064](https://rustsec.org/advisories/RUSTSEC-2023-0064.html) was introduced in #1789 and does not have any major problems, but I noticed:

- A bare URL that seems intended to be linkified is not, because in the Markdown dialect used here. This is linkified automatically in https://github.com/advisories/GHSA-rrjw-j4m2-mf34.
- The wording in the acknowledgement is slightly cumbersome to read, since the object after "Thanks for" is usually an item or action that one is thankful to have received, rather than the person being thanked.

This does the minor fixes for both.

cc @Byron 