### PR TITLE
Add unmaintained advisory for bcc

### DIFF
--- a/crates/bcc/RUSTSEC-0000-0000.md
+++ b/crates/bcc/RUSTSEC-0000-0000.md
@@ -1,0 +1,15 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "bcc"
+date = "2024-09-04"
+url = "https://github.com/rust-bpf/rust-bcc/issues/200"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# bcc is unmaintained
+
+bcc will no longer be maintained as declared by the developer. Users are recommended to use libbpf-rs instead. See [libbpf-rs](https://github.com/libbpf/libbpf-rs).


### PR DESCRIPTION
bcc will no longer be maintained as declared by the developer. For more information, see: [rust-bcc/issues/200](https://github.com/rust-bpf/rust-bcc/issues/200).