### PR TITLE
Add unmaintained advisory for strason

### DIFF
--- a/crates/strason/RUSTSEC-0000-0000.md
+++ b/crates/strason/RUSTSEC-0000-0000.md
@@ -1,0 +1,15 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "strason"
+date = "2024-09-04"
+url = "https://github.com/apoelstra/strason/issues/4"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# strason is unmaintained
+
+strason will no longer be maintained as declared by the developer. The project has been archived.


### PR DESCRIPTION
strason will no longer be maintained as declared by the developer. For more information, see: [strason/issues/4](https://github.com/apoelstra/strason/issues/4).