### PR TITLE
Add unmaintained advisory for hwloc

### DIFF
--- a/crates/hwloc/RUSTSEC-0000-0000.md
+++ b/crates/hwloc/RUSTSEC-0000-0000.md
@@ -1,0 +1,15 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "hwloc"
+date = "2024-09-04"
+url = "https://github.com/daschl/hwloc-rs/issues"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# hwloc is unmaintained
+
+hwloc will no longer be maintained as declared by the developer. The project has been archived without an issue.


### PR DESCRIPTION
hwloc will no longer be maintained as declared by the developer. For more information, see: [hwloc-rs/issues](https://github.com/daschl/hwloc-rs/issues).