### PR TITLE
fix typo in latest patched version of `ic-cdk` : RUSTSEC-2024-0372

### DIFF
--- a/crates/ic-cdk/RUSTSEC-2024-0372.md
+++ b/crates/ic-cdk/RUSTSEC-2024-0372.md
@@ -10,7 +10,7 @@ aliases = ["CVE-2024-7884", "GHSA-rwq6-crjg-9cpw"]
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 
 [versions]
-patched = ["^0.8.2", "^0.9.3", "^0.10.1", "^0.11.6", "^0.12.2", "^0.13.5", "^0.14.1", "^0.15.1", ">= 16.0.0"]
+patched = ["^0.8.2", "^0.9.3", "^0.10.1", "^0.11.6", "^0.12.2", "^0.13.5", "^0.14.1", "^0.15.1", ">= 0.16.0"]
 unaffected = ["< 0.8.0"]
 ```
 # Memory leak when calling a canister method via `ic_cdk::call`


### PR DESCRIPTION
`16.0.0` -> `0.16.0 `