### PR TITLE
Add more alternatives to proc-macro-error

### DIFF
--- a/crates/proc-macro-error/RUSTSEC-2024-0370.md
+++ b/crates/proc-macro-error/RUSTSEC-2024-0370.md
@@ -18,4 +18,6 @@ proc-macro-error also depends on `syn 1.x`, which may be bringing duplicate depe
 
 ## Possible Alternative(s)
 
+- [manyhow](https://crates.io/crates/manyhow)
 - [proc-macro-error2](https://crates.io/crates/proc-macro-error2)
+- [proc-macro2-diagnostics](https://github.com/SergioBenitez/proc-macro2-diagnostics)


### PR DESCRIPTION
Adds [manyhow](https://crates.io/crates/manyhow) & [proc-macro2-diagnostics](https://github.com/SergioBenitez/proc-macro2-diagnostics), which are actively being used as alternatives

e.g. https://github.com/TeXitoi/structopt/pull/536 and https://github.com/nvksv/maybe-async-cfg/pull/9