### PR TITLE
Add lexical-core advisory.

### DIFF
--- a/crates/lexical-core/RUSTSEC-0000-0000.md
+++ b/crates/lexical-core/RUSTSEC-0000-0000.md
@@ -1,6 +1,6 @@
 ```toml
 [advisory]
-id = "RUSTSEC-2024-0377"
+id = "RUSTSEC-0000-0000"
 package = "lexical"
 date = "2023-09-03"
 informational = "unsound"

--- a/crates/lexical-core/RUSTSEC-0000-0000.md
+++ b/crates/lexical-core/RUSTSEC-0000-0000.md
@@ -1,7 +1,7 @@
 ```toml
 [advisory]
 id = "RUSTSEC-0000-0000"
-package = "lexical"
+package = "lexical-core"
 date = "2023-09-03"
 informational = "unsound"
 references = ["https://github.com/Alexhuszagh/rust-lexical/issues/102", "https://github.com/Alexhuszagh/rust-lexical/issues/101", "https://github.com/Alexhuszagh/rust-lexical/issues/95", "https://github.com/Alexhuszagh/rust-lexical/issues/104", "https://github.com/Alexhuszagh/rust-lexical/issues/126"]

--- a/crates/lexical-core/RUSTSEC-0000-0000.md
+++ b/crates/lexical-core/RUSTSEC-0000-0000.md
@@ -5,6 +5,7 @@ package = "lexical"
 date = "2023-09-03"
 informational = "unsound"
 references = ["https://github.com/Alexhuszagh/rust-lexical/issues/102", "https://github.com/Alexhuszagh/rust-lexical/issues/101", "https://github.com/Alexhuszagh/rust-lexical/issues/95", "https://github.com/Alexhuszagh/rust-lexical/issues/104", "https://github.com/Alexhuszagh/rust-lexical/issues/126"]
+related = ["RUSTSEC-2023-0055"]
 
 [versions]
 patched = [">= 1.0.0"]

--- a/crates/lexical-core/RUSTSEC-2024-0377.md
+++ b/crates/lexical-core/RUSTSEC-2024-0377.md
@@ -20,14 +20,4 @@ patched = [">= 1.0.0"]
  1. [`write_float()` calls `MaybeUninit::assume_init()` on uninitialized data, which is is not allowed by the Rust abstract machine](https://github.com/Alexhuszagh/rust-lexical/issues/95)
  1. [`radix()` calls `MaybeUninit::assume_init()` on uninitialized data, which is is not allowed by the Rust abstract machine](https://github.com/Alexhuszagh/rust-lexical/issues/126)
 
-The crate also has some correctness issues.
-
-## Alternatives
-
-For quickly parsing floating-point numbers third-party crates are no longer needed. A fast float parsing algorithm by the author of `lexical` has been [merged](https://github.com/rust-lang/rust/pull/86761) into libcore.
-
-For quickly parsing integers, consider `atoi` and `btoi` crates (100% safe code). `atoi_radix10` provides even faster parsing, but only with `-C target-cpu=native`, and at the cost of some `unsafe`.
-
-For formatting integers in a `#[no_std]` context consider the [`numtoa`](https://crates.io/crates/numtoa) crate.
-
-For working with big numbers consider `num-bigint` and `num-traits`.
+The crate also has some correctness issues prior to version 1.0.

--- a/crates/lexical-core/RUSTSEC-2024-0377.md
+++ b/crates/lexical-core/RUSTSEC-2024-0377.md
@@ -20,4 +20,4 @@ patched = [">= 1.0.0"]
  1. [`write_float()` calls `MaybeUninit::assume_init()` on uninitialized data, which is is not allowed by the Rust abstract machine](https://github.com/Alexhuszagh/rust-lexical/issues/95)
  1. [`radix()` calls `MaybeUninit::assume_init()` on uninitialized data, which is is not allowed by the Rust abstract machine](https://github.com/Alexhuszagh/rust-lexical/issues/126)
 
-The crate also has some correctness issues prior to version 1.0.
+Version 1.0 fixes these issues, removes the vast majority of `unsafe` code, and also fixes some correctness issues.

--- a/crates/lexical-core/RUSTSEC-2024-0377.md
+++ b/crates/lexical-core/RUSTSEC-2024-0377.md
@@ -1,19 +1,18 @@
 ```toml
 [advisory]
-id = "RUSTSEC-2023-0055"
+id = "RUSTSEC-2024-0377"
 package = "lexical"
 date = "2023-09-03"
 informational = "unsound"
 references = ["https://github.com/Alexhuszagh/rust-lexical/issues/102", "https://github.com/Alexhuszagh/rust-lexical/issues/101", "https://github.com/Alexhuszagh/rust-lexical/issues/95", "https://github.com/Alexhuszagh/rust-lexical/issues/104", "https://github.com/Alexhuszagh/rust-lexical/issues/126"]
-aliases = ["GHSA-c2hm-mjxv-89r4"]
 
 [versions]
-patched = [">= 7.0.0"]
+patched = [">= 1.0.0"]
 ```
 
 # Multiple soundness issues
 
-`lexical` contains multiple soundness issues:
+`RUSTSEC-2024-0377` contains multiple soundness issues:
 
  1. [Bytes::read() allows creating instances of types with invalid bit patterns](https://github.com/Alexhuszagh/rust-lexical/issues/102)
  1. [BytesIter::read() advances iterators out of bounds](https://github.com/Alexhuszagh/rust-lexical/issues/101)


### PR DESCRIPTION
This adds in an additional security advisory for `lexical` and adds in the same for `lexical-core`.

Closes #2080 2081