### PR TITLE
Report sevenz-rust and lzma-rust as unmaintained

### DIFF
--- a/crates/lzma-rust/RUSTSEC-0000-0000.md
+++ b/crates/lzma-rust/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "lzma-rust"
+date = "2024-09-23"
+informational = "unmaintained"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# lzma-rust is unmaintained
+
+The owner of the crate has deleted their GitHub account and the repository associated with the crate.
+
+There is no way to contact the crate owner.
+
+
+**Links:**
+- <https://github.com/dyz1990>
+- <https://github.com/dyz1990/sevenz-rust/tree/main/lzma-rust>

--- a/crates/sevenz-rust/RUSTSEC-0000-0000.md
+++ b/crates/sevenz-rust/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "sevenz-rust"
+date = "2024-09-23"
+informational = "unmaintained"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# sevenz-rust is unmaintained
+
+The owner of the crate has deleted their GitHub account and the repository associated with the crate.
+
+There is no way to contact the crate owner.
+
+
+**Links:**
+- <https://github.com/dyz1990>
+- <https://github.com/dyz1990/sevenz-rust>


### PR DESCRIPTION
Hello everyone,

The owner ([dyz1990](https://crates.io/users/dyz1990)) of the two crates `sevenz-rust` and `lzma-rust` has deleted their GitHub account and the associated GitHub repositories.
There is no way to contact the author or open a GitHub issue according to the unmaintained policy, so the `url` field is not included in the advisory.

Regarding the "implicitly unmaintained" rationale:
The last release was 2 months ago, but as described in the previous paragraph: The author has deleted their GitHub account and therefore abandoned the crates, and neither "stale repository" nor "90 days unresponsive" can be applied.

Best regards
Felix