### PR TITLE
Update RUSTSEC-2023-0033.md : add borsh v0.10.4 to list of patched versions

### DIFF
--- a/crates/borsh/RUSTSEC-2023-0033.md
+++ b/crates/borsh/RUSTSEC-2023-0033.md
@@ -11,7 +11,7 @@ aliases = ["GHSA-fjx5-qpf4-xjf2"]
 
 [affected]
 [versions]
-patched = [">= 1.0.0-alpha.1"]
+patched = [">= 1.0.0-alpha.1", "^0.10.4"]
 ```
 
 # Parsing borsh messages with ZST which are not-copy/clone is unsound


### PR DESCRIPTION
fix has been backported https://github.com/near/borsh-rs/pull/310
and published with 0.10.4 https://crates.io/crates/borsh/0.10.4