### PR TITLE
Mark atty as officially unmaintained

### DIFF
--- a/crates/atty/RUSTSEC-0000-0000.md
+++ b/crates/atty/RUSTSEC-0000-0000.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "atty"
+date = "2024-09-25"
+informational = "unmaintained"
+url = "https://github.com/softprops/atty/issues/57"
+
+[versions]
+patched = []
+```
+
+# `atty` is unmaintained
+
+The maintainer of `atty` has [published](https://github.com/softprops/atty/commit/5bfdbe9e48c6ca6a4909e8d5b04f5e843a257e93) an official notice that the crate is no longer
+under development, and that users should instead rely on the functionality in the standard library's [`IsTerminal`](https://doc.rust-lang.org/std/io/trait.IsTerminal.html) trait.
+
+## Alternative(s)
+
+- [std::io::IsTerminal](https://doc.rust-lang.org/stable/std/io/trait.IsTerminal.html) - Stable since Rust 1.70.0 and the recommended replacement per the `atty` maintainer.
+- [is-terminal](https://crates.io/crates/is-terminal) - Standalone crate supporting Rust older than 1.70.0


### PR DESCRIPTION
Should be fairly uncontroversial as it explicitly meets the [unmaintained policy's](https://github.com/rustsec/advisory-db/blob/main/HOWTO_UNMAINTAINED.md#definition-of-an-unmaintained-crate) of explicit:
> Explicitly unmaintained: a crate's author has declared that they are no longer maintaining a particular crate.

The author of `atty` published [this README update](https://github.com/softprops/atty/commit/5bfdbe9e48c6ca6a4909e8d5b04f5e843a257e93#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R5) making the maintenance status official:
>  This is crate is no longer maintained and users are encouraged to prefer the equivalant functionality of [std.io.IsTerminal]...

Since the previous maintainer was clear about alternatives, I made them more explicit in the advisory instead of the usual "these have not been looked and might not work, etc".

Closes https://github.com/rustsec/advisory-db/issues/2087