### PR TITLE
Update RUSTSEC-2024-0376 affected versions

### DIFF
--- a/crates/tonic/RUSTSEC-2024-0376.md
+++ b/crates/tonic/RUSTSEC-2024-0376.md
@@ -10,6 +10,7 @@ aliases = ["CVE-2024-47609", "GHSA-4jwc-w2hc-78qv"]
 
 [versions]
 patched = [">= 0.12.3"]
+unaffected = ["<= 0.11.0"]
 ```
 
 # Remotely exploitable Denial of Service in Tonic


### PR DESCRIPTION
Update the security advisory for tonic related https://github.com/rustsec/advisory-db/issues/2093, it was previously missing an additional unaffected field.