### PR TITLE
Add unsound advisory for `mimalloc`

### DIFF
--- a/crates/mimalloc/RUSTSEC-0000-0000.md
+++ b/crates/mimalloc/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "mimalloc"
+date = "2022-11-23"
+url = "https://github.com/purpleprotocol/mimalloc_rust/issues/87"
+informational = "unsound"
+
+[versions]
+patched = [">= 0.1.39"]
+```
+
+# Mimalloc Can Allocate Memory with Bad Alignment
+This crate depended on a promise regarding alignments made by the author of the mimalloc allocator to avoid using aligned allocation functions where possible for performance reasons.
+Since then, the mimalloc allocator's logic changed, making it break this promise.
+This caused this crate to return memory with an incorrect alignment for some allocations, particularly those with large alignments.
+The flaw was fixed by always using the aligned allocation functions.


### PR DESCRIPTION
The [`mimalloc`](https://github.com/purpleprotocol/mimalloc_rust) crate had a soundness issue with returning unaligned memory a while back, and I think it deserves an advisory.