### PR TITLE
Add disclosure for hasbrown's borsh encoding

### DIFF
--- a/crates/hashbrown/RUSTSEC-0000-0000.md
+++ b/crates/hashbrown/RUSTSEC-0000-0000.md
@@ -8,7 +8,7 @@ categories = []
 keywords = ["borsh"]
 
 [versions]
-patched = []
+patched = [">= 0.15.1"]
 unaffected = ["<= 0.14"]
 
 [affected]
@@ -23,3 +23,5 @@ It also did not perform canonicty checks on decoding.
 
 This can result in consensus splits and cause equivalent objects to be
 considered distinct.
+
+This was patched in 0.15.1.

--- a/crates/hashbrown/RUSTSEC-0000-0000.md
+++ b/crates/hashbrown/RUSTSEC-0000-0000.md
@@ -8,7 +8,7 @@ categories = []
 keywords = ["borsh"]
 
 [versions]
-patched = [">= 0.16"]
+patched = []
 unaffected = ["<= 0.14"]
 
 [affected]
@@ -23,5 +23,3 @@ It also did not perform canonicty checks on decoding.
 
 This can result in consensus splits and cause equivalent objects to be
 considered distinct.
-
-This was fixed in 0.16.

--- a/crates/hashbrown/RUSTSEC-0000-0000.md
+++ b/crates/hashbrown/RUSTSEC-0000-0000.md
@@ -1,0 +1,27 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "hashbrown"
+date = "2024-10-11"
+url = "https://github.com/rust-lang/hashbrown/issues/576"
+categories = []
+keywords = ["borsh"]
+
+[versions]
+patched = [">= 0.16"]
+unaffected = ["<= 0.14"]
+
+[affected]
+functions = { "hashbrown::HashMap::borsh_serialize" = ["=0.15"] }
+```
+
+# Borsh serialization of HashMap is non-canonical
+
+The borsh serialization of the HashMap did not follow the borsh specification.
+It potentially produced non-canonical encodings dependent on insertion order.
+It also did not perform canonicty checks on decoding.
+
+This can result in consensus splits and cause equivalent objects to be
+considered distinct.
+
+This was fixed in 0.16.

--- a/crates/hashbrown/RUSTSEC-0000-0000.md
+++ b/crates/hashbrown/RUSTSEC-0000-0000.md
@@ -12,7 +12,7 @@ patched = [">= 0.15.1"]
 unaffected = ["<= 0.14"]
 
 [affected]
-functions = { "hashbrown::HashMap::borsh_serialize" = ["=0.15"] }
+functions = { "hashbrown::HashMap::borsh_serialize" = ["=0.15.0"] }
 ```
 
 # Borsh serialization of HashMap is non-canonical


### PR DESCRIPTION
I wrote this as fixed in 0.16 due to that being the plan documented here: https://github.com/rust-lang/hashbrown/pull/570#issuecomment-2406017398

Until that PR is merged and 0.16 is released, this cannot be merged/must be edited to be described as unpatched.