### PR TITLE
Mark two pqcrypto- crates as unmaintained

### DIFF
--- a/crates/pqcrypto-dilithium/RUSTSEC-0000-0000.md
+++ b/crates/pqcrypto-dilithium/RUSTSEC-0000-0000.md
@@ -1,0 +1,26 @@
+```toml
+[advisory]
+# Identifier for the advisory (mandatory). Will be assigned a "RUSTSEC-YYYY-NNNN"
+# identifier e.g. RUSTSEC-2018-0001. Please use "RUSTSEC-0000-0000" in PRs.
+id = "RUSTSEC-0000-0000"
+
+# Name of the affected crate (mandatory)
+package = "pqcrypto-dilithium"
+
+# Disclosure date of the advisory as an RFC 3339 date (mandatory)
+date = "2024-10-24"
+
+# Optional: Indicates the type of informational security advisory
+#  - "unsound" for soundness issues
+#  - "unmaintained" for crates that are no longer maintained
+#  - "notice" for other informational notices
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Replaced by `pqcrypto-mldsa`
+
+This crate has been replaced by `pqcrypto-mldsa`, which provides a
+FIPS204-compatible implementation of ML-DSA.

--- a/crates/pqcrypto-kyber/RUSTSEC-0000-0000.md
+++ b/crates/pqcrypto-kyber/RUSTSEC-0000-0000.md
@@ -1,0 +1,26 @@
+```toml
+[advisory]
+# Identifier for the advisory (mandatory). Will be assigned a "RUSTSEC-YYYY-NNNN"
+# identifier e.g. RUSTSEC-2018-0001. Please use "RUSTSEC-0000-0000" in PRs.
+id = "RUSTSEC-0000-0000"
+
+# Name of the affected crate (mandatory)
+package = "pqcrypto-kyber"
+
+# Disclosure date of the advisory as an RFC 3339 date (mandatory)
+date = "2024-10-24"
+
+# Optional: Indicates the type of informational security advisory
+#  - "unsound" for soundness issues
+#  - "unmaintained" for crates that are no longer maintained
+#  - "notice" for other informational notices
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Replaced by `pqcrypto-mlkem`
+
+This crate has been replaced by `pqcrypto-mlkem`, which provides a
+FIPS203-compatible implementation of ML-KEM.


### PR DESCRIPTION
Since the official standards of these draft algorithms were released, they are replaced by crates that track the standards versions.