### PR TITLE
Fix incorrect fixed version for may_queue

### DIFF
--- a/crates/may_queue/RUSTSEC-2020-0111.md
+++ b/crates/may_queue/RUSTSEC-2020-0111.md
@@ -10,7 +10,7 @@ categories = ["memory-corruption", "thread-safety"]
 keywords = ["concurrency"]
 
 [versions]
-patched = [">= 0.3.19"]
+patched = [">= 0.1.8"]
 ```
 
 # may_queue's Queue lacks Send/Sync bound for its Send/Sync trait.


### PR DESCRIPTION
According to https://github.com/Xudong-Huang/may/issues/88, this was fixed in 0.3.19, but that refers to the main "may" crate. The correct version for the "may_queue" sub crate is 0.1.8 (based on manual checking the bounds for the affected type on docs.rs)

My bad in the previous PR (#2105) for trusting the number written in the relevant bug report.