### PR TITLE
Add security advistory for fast-float.

### DIFF
--- a/crates/fast-float/RUSTSEC-0000-0000.md
+++ b/crates/fast-float/RUSTSEC-0000-0000.md
@@ -1,0 +1,26 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "fast-float"
+date = "2024-10-31"
+informational = "unsound"
+url = "https://github.com/aldanor/fast-float-rust/issues/35"
+references = ["https://github.com/aldanor/fast-float-rust/issues/28", "https://github.com/aldanor/fast-float-rust/issues/37"]
+aliases = []
+
+[versions]
+patched = []
+```
+
+# Multiple soundness issues
+
+`fast-float` contains multiple soundness issues:
+
+ 1. [Undefined behavior when checking input length](https://github.com/aldanor/fast-float-rust/issues/28), which has been merged but no package [pubished](https://github.com/aldanor/fast-float-rust/issues/35).
+ 1. [Many functions marked as safe with non-local safety guarantees](https://github.com/aldanor/fast-float-rust/issues/37)
+
+The library is also unmaintained.
+
+## Alternatives
+
+For quickly parsing floating-point numbers third-party crates are generally no longer needed. A fast float parsing algorithm by the author of `lexical` has been [merged](https://github.com/rust-lang/rust/pull/86761) into libcore. When requiring direct parsing from bytes and/or partial parsers, the [`fast-float2`](https://crates.io/crates/fast-float2) fork of `fast-float` containing these security patches and reduces overall usage of unsafe.


### PR DESCRIPTION
[fast-float](https://github.com/aldanor/fast-float-rust) is currently unmaintained and contains undefined behavior in checking the length of the input https://github.com/aldanor/fast-float-rust/issues/28. Although a patch was implemented and [merged](https://github.com/aldanor/fast-float-rust/pull/29), no release was published and there has been no communication by the author in over 3 years.

In addition, there's also potential unsoundness, due to the use of many functions that are non-local safety [guarantees](https://github.com/aldanor/fast-float-rust/issues/37) marked as safe, assuming the necessary safety guarantees have been met by the caller. The simplest example is in [AsciiStr::first](https://github.com/aldanor/fast-float-rust/blob/83a49b8b5a530d8e950a6dbfdc11089d213b9ac9/src/common.rs#L37), however, this is widely used through the repository:

```rust
impl<'a> AsciiStr<'a> {
    #[inline]
    pub fn first(&self) -> u8 {
        unsafe { *self.ptr }
    }
}
```

I've created a [fork](https://crates.io/crates/fast-float2) that publishes the patches for the undefined behavior and also removes the general unsoundness:
- https://github.com/aldanor/fast-float-rust/pull/29
- https://github.com/Alexhuszagh/fast-float-rust/pull/7
- https://github.com/Alexhuszagh/fast-float-rust/pull/8
- https://github.com/Alexhuszagh/fast-float-rust/pull/13