### PR TITLE
Add vulnerability advisory for n2

### DIFF
--- a/crates/n2/RUSTSEC-2024-0397.md
+++ b/crates/n2/RUSTSEC-2024-0397.md
@@ -1,0 +1,24 @@
+# Advisory for n2
+```toml
+[advisory]
+id = "RUSTSEC-2024-0397"
+package = "n2"
+date = "2024-11-11"
+informational = "unsound"
+url = "https://github.com/evmar/n2/issues/121"
+references = ["https://github.com/evmar/n2/issues/122", "https://github.com/evmar/n2/issues/123"]
+aliases = []
+
+[versions]
+patched = []
+```
+
+# Multiple soundness issues
+
+`n2` contains multiple soundness issues:
+
+n2 contains multiple soundness issues:
+
+1. Invalid Input Handling in Scanner::slice Method. When using the Scanner::slice method, passing an out-of-bounds argument causes the program to panic abort. This indicates a potential design flaw, as it fails to handle invalid input properly, impacting the stability of the application. [Issue #121](https://github.com/evmar/n2/issues/121)
+2. Out of Bounds Access in Scanner::peek Method. The peek method in the Scanner struct does not handle out-of-bounds accesses correctly. When the internal offset exceeds the length of the buffer, it causes a panic abort. [Issue #122](https://github.com/evmar/n2/issues/122)
+3. Invalid Input Handling in Scanner::peek_newline Method. The peek_newline method fails to handle cases where the internal offset exceeds the size of the buffer, leading to a panic abort. This indicates a design flaw as invalid input is not handled properly. [Issue #123](https://github.com/evmar/n2/issues/123)


### PR DESCRIPTION
Multiple soundness issues in n2.

n2 contains multiple soundness issues:

1. Invalid Input Handling in Scanner::slice Method. When using the Scanner::slice method, passing an out-of-bounds argument causes the program to panic abort. This indicates a potential design flaw, as it fails to handle invalid input properly, impacting the stability of the application. [Issue #121](https://github.com/evmar/n2/issues/121)
2. Out of Bounds Access in Scanner::peek Method. The peek method in the Scanner struct does not handle out-of-bounds accesses correctly. When the internal offset exceeds the length of the buffer, it causes a panic abort. [Issue #122](https://github.com/evmar/n2/issues/122)
3. Invalid Input Handling in Scanner::peek_newline Method. The peek_newline method fails to handle cases where the internal offset exceeds the size of the buffer, leading to a panic abort. This indicates a design flaw as invalid input is not handled properly. [Issue #123](https://github.com/evmar/n2/issues/123)