### PR TITLE
fast-xml is unmaintained

### DIFF
--- a/crates/fast-xml/RUSTSEC-0000-0000.md
+++ b/crates/fast-xml/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "fast-xml"
+date = "2024-11-14"
+informational = "unmaintained"
+url = "https://github.com/Mingun/fast-xml/commit/38f2a2f01aed8c642e878e6f91a2c3c4d4645ffe"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# The `fast-xml` fork of `quick-xml` has been abandoned
+
+Please use the `quick-xml` crate instead.


### PR DESCRIPTION
[fast-xml](https://lib.rs/crates/fast-xml) fork has been explicitly marked as end-of-life by the owner: https://github.com/Mingun/fast-xml/commit/38f2a2f01aed8c642e878e6f91a2c3c4d4645ffe and hasn't been touched since (for over 2 years).
