### PR TITLE
RUSTSEC-2024-0399: fix 0.22 version constraint

### DIFF
--- a/crates/rustls/RUSTSEC-2024-0399.md
+++ b/crates/rustls/RUSTSEC-2024-0399.md
@@ -8,7 +8,7 @@ categories = ["denial-of-service"]
 
 [versions]
 patched = [">= 0.23.18"]
-unaffected = [">= 0.23, < 0.23.13", "<= 0.22"]
+unaffected = [">= 0.23, < 0.23.13", "< 0.23"]
 ```
 
 # rustls network-reachable panic in `Acceptor::accept`


### PR DESCRIPTION
Apologies for the noise. Verified this covers the correct versions with `rustsec-admin list-affected-versions`