### PR TITLE
RUSTSEC-2024-0402: Fix `unaffected` declaration

### DIFF
--- a/crates/hashbrown/RUSTSEC-2024-0402.md
+++ b/crates/hashbrown/RUSTSEC-2024-0402.md
@@ -9,7 +9,7 @@ keywords = ["borsh"]
 
 [versions]
 patched = [">= 0.15.1"]
-unaffected = ["<= 0.14"]
+unaffected = ["< 0.15.0"]
 
 [affected]
 functions = { "hashbrown::HashMap::borsh_serialize" = ["=0.15.0"] }


### PR DESCRIPTION
see https://github.com/rustsec/advisory-db/pull/2100#discussion_r1869452789

