### PR TITLE
Add advisories for unmaintained gtk-layer-shell GTK3 bindings

### DIFF
--- a/crates/gtk-layer-shell-sys/RUSTSEC-0000-0000.md
+++ b/crates/gtk-layer-shell-sys/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "gtk-layer-shell-sys"
+date = "2024-12-09"
+url = "https://github.com/pentamassiv/gtk-layer-shell-gir/commit/094c356273f209e04bf481fb404dc17990ae76e0"
+informational = "unmaintained"
+keywords = ["gtk", "gtk-rs", "gnome", "GUI"]
+
+[versions]
+patched = []
+
+```
+# gtk-layer-shell-sys GTK3 bindings - no longer maintained
+
+The gtk-layer-shell-sys GTK3 bindings are no longer maintained.
+
+The maintainers have archived the repository, and added a note to the crate
+description and its README.md that the crates are no longer maintained.
+
+Please take a look at [gtk4-layer-shell](https://github.com/pentamassiv/gtk4-layer-shell-gir) instead.
+```

--- a/crates/gtk-layer-shell/RUSTSEC-0000-0000.md
+++ b/crates/gtk-layer-shell/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "gtk-layer-shell"
+date = "2024-12-09"
+url = "https://github.com/pentamassiv/gtk-layer-shell-gir/commit/094c356273f209e04bf481fb404dc17990ae76e0"
+informational = "unmaintained"
+keywords = ["gtk", "gtk-rs", "gnome", "GUI"]
+
+[versions]
+patched = []
+
+```
+# gtk-layer-shell GTK3 bindings - no longer maintained
+
+The gtk-layer-shell GTK3 bindings are no longer maintained.
+
+The maintainers have archived the repository, and added a note to the crate
+description and its README.md that the crates are no longer maintained.
+
+Please take a look at [gtk4-layer-shell](https://github.com/pentamassiv/gtk4-layer-shell-gir) instead.
+```


### PR DESCRIPTION
I am the maintainer of the `gtk-layer-shell` and `gtk-layer-shell-sys` crates. The foundation of `gtk-layer-shell` are the `gtk` crates. It does not make sense to continue maintaining the crates if the foundation is unmaintained (https://github.com/rustsec/advisory-db/pull/2164), so I also stopped the development of them and marked them as unmaintained. Users should use GTK4 and the `gtk4-layer-shell` crate instead.