### PR TITLE
Protobuf DoS

### DIFF
--- a/crates/protobuf/RUSTSEC-0000-0000.md
+++ b/crates/protobuf/RUSTSEC-0000-0000.md
@@ -15,7 +15,7 @@ patched = []
 functions = { "protobuf::coded_input_stream::CodedInputStream::skip_group" = ["<= 3.4.0"] }
 ```
 
-# RustSec Advisory Template - Advisory Title Goes Here
+# Crash due to uncontrolled recursion in protobuf crate
 
 Affected version of this crate did not properly parse unknown fields when parsing a user-supplied input.
 

--- a/crates/protobuf/RUSTSEC-0000-0000.md
+++ b/crates/protobuf/RUSTSEC-0000-0000.md
@@ -6,7 +6,7 @@ date = "2024-12-12"
 url = "https://github.com/stepancheg/rust-protobuf/issues/749"
 categories = ["denial-of-service"]
 keywords = ["panic"]
-informational = "unmaintained"
+related = ["GHSA-735f-pc8j-v9w8"]
 
 [versions]
 patched = []

--- a/crates/protobuf/RUSTSEC-0000-0000.md
+++ b/crates/protobuf/RUSTSEC-0000-0000.md
@@ -8,6 +8,9 @@ categories = ["denial-of-service"]
 keywords = ["panic"]
 informational = "unmaintained"
 
+[versions]
+patched = []
+
 [affected]
 functions = { "protobuf::coded_input_stream::CodedInputStream::skip_group" = ["<= 3.4.0"] }
 ```

--- a/crates/protobuf/RUSTSEC-0000-0000.md
+++ b/crates/protobuf/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "protobuf"
+date = "2024-12-12"
+url = "https://github.com/stepancheg/rust-protobuf/issues/749"
+categories = ["denial-of-service"]
+keywords = ["panic"]
+informational = "unmaintained"
+
+[affected]
+functions = { "protobuf::coded_input_stream::CodedInputStream::skip_group" = ["<= 3.4.0"] }
+```
+
+# RustSec Advisory Template - Advisory Title Goes Here
+
+Affected version of this crate did not properly parse unknown fields when parsing a user-supplied input.
+
+This allows an attacker to cause a stack overflow when parsing the mssage on untrusted data.


### PR DESCRIPTION
This (public) advisory follows two emails sent on August 9 and October 3rd.

The crate is affected by the same vulnerability as described in https://github.com/protocolbuffers/protobuf/security/advisories/GHSA-735f-pc8j-v9w8