### PR TITLE
Report unsoundness in cortex-m

### DIFF
--- a/crates/cortex-m/RUSTSEC-0000-0000.md
+++ b/crates/cortex-m/RUSTSEC-0000-0000.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "cortex-m"
+date = "2024-12-23"
+url = "https://github.com/rust-embedded/cortex-m/issues/485"
+references = ["https://github.com/rust-embedded/cortex-m/pull/493"]
+categories = []
+keywords = ["uninitialized"]
+informational = "unsound"
+[versions]
+patched = []
+[affected]
+functions = {"cortex_m::peripheral::SCB::vect_active" = ["<= 0.7.7"]}
+```
+
+# Unsound layout assumption of `volatile_register::RW` 
+
+The wrapper struct `volatile_register::RW` didn't have stable layout, and rustc would preserve the right to insert padding or reorder the structure. It should be declared as transparent; otherwise, casting it to u32 could lead to UB such as uninitialized memory exposure and break the safety guarantees of `ptr::read_volatile`.  
+
+This was patched by changing dependency version of `volatile_register::RW`, which was defined as `#[repr(transparent)]` in version of `0.2.2`.


### PR DESCRIPTION
The [issue](https://github.com/rust-embedded/cortex-m/issues/485) has been patched in Nov 2023 but it is still not released in the latest version (0.7.7). We can ask whether the maintainer plan to release it first.