### PR TITLE
Fix [affected.functions] in gix-worktree-state advisory

### DIFF
--- a/crates/gix-worktree-state/RUSTSEC-0000-0000.md
+++ b/crates/gix-worktree-state/RUSTSEC-0000-0000.md
@@ -10,7 +10,7 @@ aliases = ["CVE-2025-22620"]
 license = "CC0-1.0"
 
 [affected.functions]
-"gix_worktree_state::checkout" = ["*"]
+"gix_worktree_state::checkout" = ["< 0.17.0"]
 
 [versions]
 patched = [">= 0.17.0"]


### PR DESCRIPTION
I clicked "merge" too quickly, oops

But it's okay since the advisory is not yet live