### PR TITLE
List Unix-like target OSes as affected by CVE-2025-22620

### DIFF
--- a/crates/gix-worktree-state/RUSTSEC-0000-0000.md
+++ b/crates/gix-worktree-state/RUSTSEC-0000-0000.md
@@ -9,6 +9,38 @@ keywords = ["permissions"]
 aliases = ["CVE-2025-22620"]
 license = "CC0-1.0"
 
+[affected]
+# This vulnerability affects Unix-like operating systems.
+os = [
+    "aix",
+    "android",
+    "dragonfly",
+    "emscripten",
+    "espidf",
+    "freebsd",
+    "fuchsia",
+    "haiku",
+    "horizon",
+    "hurd",
+    "illumos",
+    "ios",
+    "l4re",
+    "linux",
+    "macos",
+    "netbsd",
+    "nto",
+    "nuttx",
+    "openbsd",
+    "redox",
+    "rtems",
+    "solaris",
+    "tvos",
+    "visionos",
+    "vita",
+    "vxworks",
+    "watchos",
+]
+
 [affected.functions]
 "gix_worktree_state::checkout" = ["< 0.17.0"]
 


### PR DESCRIPTION
This builds on #2193 by listing all Unix-like target operating systems as affected (since a category of OSes like "unix" cannot currently be represented in RUSTSEC advisory metadata).

The list was obtained by running the command given in https://github.com/rustsec/advisory-db/pull/1911#discussion_r1512022858.

The vulnerability is specific to Unix-like operating systems because:

- The vulnerable code runs only in the `unix` build configuration.

- 0777 permissions are meaningful on such systems and (due to containing 0002) allow any user account on the system to write.

Therefore, if there are any Unix-like systems where Unix-style filesystem permissions are not used, or that are *truly* single user (i.e. do not use multiple user accounts, not even for running daemons with limited privileges), then this vulnerability would not affect such systems.

In addition, I have not attempted specifically to run the proof of concept for the vulnerability on most of the listed operating systems, nor examined whether `gix-worktree-state` might not be usable on some of them for reasons unrealted to this vulnerability.

Conversely, if new target OSes are added in the future, and they are Unix-like, then they would probably be vulnerable, even though not listed here. (It may not be likely that anyone would be using an affected version of `gix-worktree-state` by that time, though.)