### PR TITLE
Specify affected functions versions instead of `"*"`

### DIFF
--- a/crates/gix-path/RUSTSEC-2024-0355.md
+++ b/crates/gix-path/RUSTSEC-2024-0355.md
@@ -15,10 +15,10 @@ license = "CC0-1.0"
 os = ["windows"]
 
 [affected.functions]
-"gix_path::env::exe_invocation" = ["*"]
-"gix_path::env::installation_config" = ["*"]
-"gix_path::env::installation_config_prefix" = ["*"]
-"gix_path::env::system_prefix" = ["*"]
+"gix_path::env::exe_invocation" = [">= 0.10.8, < 0.10.9"]
+"gix_path::env::installation_config" = [">= 0.10.8, < 0.10.9"]
+"gix_path::env::installation_config_prefix" = [">= 0.10.8, < 0.10.9"]
+"gix_path::env::system_prefix" = [">= 0.10.8, < 0.10.9"]
 
 [versions]
 patched = [">= 0.10.9"]

--- a/crates/gix-path/RUSTSEC-2024-0367.md
+++ b/crates/gix-path/RUSTSEC-2024-0367.md
@@ -14,8 +14,8 @@ aliases = ["CVE-2024-45305", "GHSA-v26r-4c9c-h3j6"]
 license = "CC0-1.0"
 
 [affected.functions]
-"gix_path::env::installation_config" = ["*"]
-"gix_path::env::installation_config_prefix" = ["*"]
+"gix_path::env::installation_config" = ["< 0.10.10"]
+"gix_path::env::installation_config_prefix" = ["< 0.10.10"]
 
 [versions]
 patched = [">= 0.10.10"]

--- a/crates/gix-path/RUSTSEC-2024-0371.md
+++ b/crates/gix-path/RUSTSEC-2024-0371.md
@@ -12,8 +12,8 @@ aliases = ["CVE-2024-45405", "GHSA-m8rp-vv92-46c7"]
 license = "CC0-1.0"
 
 [affected.functions]
-"gix_path::env::installation_config" = ["*"]
-"gix_path::env::installation_config_prefix" = ["*"]
+"gix_path::env::installation_config" = ["< 0.10.11"]
+"gix_path::env::installation_config_prefix" = ["< 0.10.11"]
 
 [versions]
 patched = [">= 0.10.11"]


### PR DESCRIPTION
When including information about affected functions in advisory metadata, I have used `"*"` in a few advisories when the bounds were no narrower than the bounds for the vulnerability. But specific are still needed or preferred in that situation, as discussed in https://github.com/rustsec/advisory-db/pull/2193#pullrequestreview-2560582694.

This replaces `"*"` in those advisories with more specific bounds.

(For #2193 itself, this has already been done in #2195.)