### PR TITLE
Fix bare URL hyperlinks in RUSTSEC-2025-0001

### DIFF
--- a/crates/gix-worktree-state/RUSTSEC-2025-0001.md
+++ b/crates/gix-worktree-state/RUSTSEC-2025-0001.md
@@ -67,13 +67,13 @@ Specifically, [`checkout::entry::checkout`](https://github.com/GitoxideLabs/gito
 
 - With `destination_is_initially_empty: true`, executable permissions are specified when opening the file, via [`OpenOptionsEx::mode`](https://doc.rust-lang.org/std/os/unix/fs/trait.OpenOptionsExt.html#tymethod.mode), by its effect on the behavior of [`OpenOptions::open`](https://doc.rust-lang.org/std/fs/struct.OpenOptions.html#method.open). A mode of 0777 is safe here, for the same reason the default mode of 0666 is safe. When creating a file, the applied mode is the specified mode with any bits unset from it that are set in the umask.
 
-   https://github.com/GitoxideLabs/gitoxide/blob/8d84818240d44e1f5fe78a231b5d9bffd0283918/gix-worktree-state/src/checkout/entry.rs#L265-L268
+   <https://github.com/GitoxideLabs/gitoxide/blob/8d84818240d44e1f5fe78a231b5d9bffd0283918/gix-worktree-state/src/checkout/entry.rs#L265-L268>
 
   The `set_executable_after_creation` flag in the `open_file` return value is then `false`.
 
 - With `destination_is_initially_empty: false`, executable permissions are set in a separate step, via [`PermissionsExt::set_mode`](https://doc.rust-lang.org/beta/std/os/unix/fs/trait.PermissionsExt.html#tymethod.set_mode) and [`set_permissions`](https://doc.rust-lang.org/beta/std/fs/fn.set_permissions.html). A mode of 0777 is not safe here, because the umask is not applied. The vulnerable code appears in [`checkout::entry::finalize_entry`](https://github.com/GitoxideLabs/gitoxide/blob/8d84818240d44e1f5fe78a231b5d9bffd0283918/gix-worktree-state/src/checkout/entry.rs#L279-L299), which receives the `set_executable_after_creation` flag originally from `open_file`:
 
-  https://github.com/GitoxideLabs/gitoxide/blob/8d84818240d44e1f5fe78a231b5d9bffd0283918/gix-worktree-state/src/checkout/entry.rs#L288-L293
+  <https://github.com/GitoxideLabs/gitoxide/blob/8d84818240d44e1f5fe78a231b5d9bffd0283918/gix-worktree-state/src/checkout/entry.rs#L288-L293>
 
   The file has unrestricted permissions.
 


### PR DESCRIPTION
In #2193, the body text for [RUSTSEC-2025-0001](https://rustsec.org/advisories/RUSTSEC-2025-0001.html) (CVE-2025-22620) is from GHSA-fqmf-w4xh-33rh, and I forgot to make the two bare URLs linkified in the different Markdown dialect used on rustsec.org. (They link to directly relevant portions of code. Other hyperlinks are on text other than the URL itself, and thus already work.)

This adds `<` `>` around each of them, which I think is sufficient to linkify them as intended in a RUSTSEC advisory.