### PR TITLE
Improve references in RUSTSEC-2024-0359

### DIFF
--- a/crates/gix-attributes/RUSTSEC-2024-0359.md
+++ b/crates/gix-attributes/RUSTSEC-2024-0359.md
@@ -21,3 +21,5 @@ patched = [">= 0.22.3"]
 The problem is that the non-UTF8 `str` **is** exposed to outside code: first to the `kstring` crate itself, which requires UTF-8 in its documentation and may have UB as a consequence of this, but also to `serde`, where it propagates to e.g. `serde_json`, `serde_yaml`, etc., where the same problems occur.
 
 This is not sound, and it could cause further UB down the line in these places that can view the `&str`.
+
+*Thanks to [Devin Jeanpierre](https://github.com/ssbr) for discovering and reporting this issue.*

--- a/crates/gix-attributes/RUSTSEC-2024-0359.md
+++ b/crates/gix-attributes/RUSTSEC-2024-0359.md
@@ -3,8 +3,9 @@
 id = "RUSTSEC-2024-0359"
 package = "gix-attributes"
 date = "2024-07-24"
-url = "https://github.com/Byron/gitoxide/issues/1460"
+url = "https://github.com/GitoxideLabs/gitoxide/issues/1460"
 informational = "unsound"
+aliases = ["GHSA-cx7h-h87r-jpgr"]
 
 [versions]
 patched = [">= 0.22.3"]


### PR DESCRIPTION
This improves credit and adds a missing GHSA alias in [RUSTSEC-2024-0359](https://rustsec.org/advisories/RUSTSEC-2024-0359.html) (which is based on https://github.com/GitoxideLabs/gitoxide/issues/1460 and originally added in #2027). See commit messages for details, including rationale.

cc @Byron @ssbr