### PR TITLE
Remove listing of unix-likes from advisory

### DIFF
--- a/crates/gix-worktree-state/RUSTSEC-2025-0001.md
+++ b/crates/gix-worktree-state/RUSTSEC-2025-0001.md
@@ -10,21 +10,6 @@ aliases = ["CVE-2025-22620"]
 license = "CC0-1.0"
 
 [affected]
-# This vulnerability affects Unix-like operating systems.
-os = [
-    "aix",
-    "android",
-    "dragonfly",
-    "freebsd",
-    "fuchsia",
-    "illumos",
-    "ios",
-    "linux",
-    "macos",
-    "netbsd",
-    "openbsd",
-    "solaris",
-]
 
 [affected.functions]
 "gix_worktree_state::checkout" = ["< 0.17.0"]


### PR DESCRIPTION
Keeps causing issues on old cargo-audit versions, see https://github.com/rustsec/advisory-db/pull/2201#issuecomment-2606804520