### PR TITLE
Add global GHSA and references to RUSTSEC-2025-0001

### DIFF
--- a/crates/gix-worktree-state/RUSTSEC-2025-0001.md
+++ b/crates/gix-worktree-state/RUSTSEC-2025-0001.md
@@ -4,9 +4,13 @@ id = "RUSTSEC-2025-0001"
 package = "gix-worktree-state"
 date = "2025-01-18"
 url = "https://github.com/GitoxideLabs/gitoxide/security/advisories/GHSA-fqmf-w4xh-33rh"
+references = [
+   "https://github.com/advisories/GHSA-fqmf-w4xh-33rh",
+   "https://nvd.nist.gov/vuln/detail/CVE-2025-22620",
+]
 cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:N/I:H/A:N"
 keywords = ["permissions"]
-aliases = ["CVE-2025-22620"]
+aliases = ["CVE-2025-22620", "GHSA-fqmf-w4xh-33rh"]
 license = "CC0-1.0"
 
 [affected]


### PR DESCRIPTION
[RUSTSEC-2025-0001](https://rustsec.org/advisories/RUSTSEC-2025-0001.html) (CVE-2025-22620) now has an entry in the GitHub Advisory Database. This adds that as a reference, also adds the NVD link as a reference, and adds GHSA-fqmf-w4xh-33rh as another alias (after the CVE number).