### PR TITLE
Add advisory for segfault in openssl-probe due to environment setters

### DIFF
--- a/crates/openssl-probe/RUSTSEC-0000-0000.md
+++ b/crates/openssl-probe/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "openssl-probe"
+date = "2025-01-10"
+url = "https://github.com/alexcrichton/openssl-probe/issues/30"
+references = ["https://www.edgedb.com/blog/c-stdlib-isn-t-threadsafe-and-even-safe-rust-didn-t-save-us"]
+informational = "unsound"
+categories = ["memory-corruption"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H"
+keywords = ["ssl", "openssl", "environment"]
+
+[affected]
+os = ["linux"]
+
+[versions]
+patched = []

--- a/crates/openssl-probe/RUSTSEC-0000-0000.md
+++ b/crates/openssl-probe/RUSTSEC-0000-0000.md
@@ -25,8 +25,15 @@ patched = [">= 0.1.6"]
 
 `openssl-probe` offers non-`unsafe` methods that call `std::env::set_var`, which may be called
 in a multithreaded environment, and potentially clash with environment access on other threads.
+In pure Rust code, concurrent read and write access to the environment is actually safe due to a lock
+taken in the platform implementations of the environment accessors (the documentation does not
+state this, and it's possible it _could_ change in the future). Libraries using other runtimes
+(including Python, those written in pure C and others) do not make use of these internal Rust
+environment locks, however, and instead use their own locks, or unprotected raw access to `libc`'s 
+`getenv`, `setenv`, or even worse, `char** environ`.
 
-When these methods are called while other threads are active and accessing the environment, it
+When these methods in `openssl-probe` (or that matter, any other pure Rust code calling `std::env::set_env`)
+are called while other threads are active and accessing the environment, it
 may cause other threads to access dangling environment pointers in the cases where the underlying
 environment data is moved or resized in response to an additional environment variable being
 added, or a variable's contents being enlarged.

--- a/crates/openssl-probe/RUSTSEC-0000-0000.md
+++ b/crates/openssl-probe/RUSTSEC-0000-0000.md
@@ -48,7 +48,7 @@ environment occur.
 ## Rust's `set_env`
 
 This crate, and all other callers of the Rust `set_env` function (<https://doc.rust-lang.org/std/env/fn.set_var.html>)
-are unsound due to the unfortunate reality of the POSIX standard which defines these enviornment access methods
+are unsound due to the unfortunate reality of the POSIX standard which defines these environment access methods
 without making any sort of thread-safety guarantees.
 
 In Rust's 2024 edition `std::env::set_var` is marked as `unsafe` and the documentation was updated to note

--- a/crates/openssl-probe/RUSTSEC-0000-0000.md
+++ b/crates/openssl-probe/RUSTSEC-0000-0000.md
@@ -16,3 +16,16 @@ os = ["linux"]
 [versions]
 patched = []
 ```
+
+# `openssl-probe` may cause memory corruption in multi-threaded processes
+
+`openssl-probe` offers non-`unsafe` methods that call environment setters, which may be called
+in a multithreaded environment, and potentially clash with environment access on other threads.
+
+When these methods are called while other threads are active and accessing the environment, it
+may cause the other threads to access dangling pointer values in the cases where the underlying
+environment data is moved or resized in response to an additional environment variable being
+added, or a variable's contents being enlarged.
+
+The affected function is `try_init_ssl_cert_env_vars` in 
+<https://github.com/alexcrichton/openssl-probe/blob/master/src/lib.rs#L65>.

--- a/crates/openssl-probe/RUSTSEC-0000-0000.md
+++ b/crates/openssl-probe/RUSTSEC-0000-0000.md
@@ -33,7 +33,21 @@ added, or a variable's contents being enlarged.
 This is shown to occur on Linux, but it will also likely occur on any other platform where `getenv`
 and `setenv` are not thread-safe, though trigger conditions may vary widely.
 
+## Affected Code
+
 The affected function is `try_init_ssl_cert_env_vars` in 
-<https://github.com/alexcrichton/openssl-probe/blob/db67c9e5b333b1b4164467b17f5d99207fad004c/src/lib.rs#L65>.
+<https://github.com/alexcrichton/openssl-probe/blob/db67c9e5b333b1b4164467b17f5d99207fad004c/src/lib.rs#L65>, and
+any other library's function which may call this function directly or indirectly
+<https://github.com/search?q=try_init_ssl_cert_env_vars&type=code>.  `native_tls <= 0.2.12` may
+do so in certain configurations <https://github.com/sfackler/rust-native-tls/blob/2424bc5efd1b8b4bcf60dbda93259a3f29db7f06/Cargo.toml>.
 
 The crate's author released a fix in versions `>=0.1.6` which marks these functions as `unsafe` and `#[deprecated]`.
+
+## Alternative Mitigations
+
+In the case of glibc users, some thread-safety improvements may protect you from `setenv`/`getenv` clashes
+which were introduced in <https://github.com/bminor/glibc/commit/7a61e7f557a97ab597d6fca5e2d1f13f65685c61>,
+however direct `environ` access in multithreaded programs will still risk dangling pointer access.
+
+Users of other `libc` implementations should consult their sourcecode listings for thread-safety guarantees
+around multithreaded environment read/write access, though readers should be prepared to be disappointed.

--- a/crates/openssl-probe/RUSTSEC-0000-0000.md
+++ b/crates/openssl-probe/RUSTSEC-0000-0000.md
@@ -10,11 +10,14 @@ categories = ["memory-corruption"]
 cvss = "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:N/I:N/A:H"
 keywords = ["ssl", "openssl", "environment"]
 
+[affected.functions]
+"openssl_probe::try_init_ssl_cert_env_vars" = ["< 0.1.6"]
+
 [affected]
 os = ["linux"]
 
 [versions]
-patched = []
+patched = [">= 0.1.6"]
 ```
 
 # `openssl-probe` may cause memory corruption in multi-threaded processes
@@ -27,5 +30,10 @@ may cause the other threads to access dangling pointer values in the cases where
 environment data is moved or resized in response to an additional environment variable being
 added, or a variable's contents being enlarged.
 
+This is shown to occur on Linux, but it will also likely occur on any other platform where `getenv`
+and `setenv` are not thread-safe, though trigger conditions may vary widely.
+
 The affected function is `try_init_ssl_cert_env_vars` in 
-<https://github.com/alexcrichton/openssl-probe/blob/master/src/lib.rs#L65>.
+<https://github.com/alexcrichton/openssl-probe/blob/db67c9e5b333b1b4164467b17f5d99207fad004c/src/lib.rs#L65>.
+
+The crate's author released a fix in versions `>=0.1.6` which marks these functions as `unsafe` and `#[deprecated]`.

--- a/crates/openssl-probe/RUSTSEC-0000-0000.md
+++ b/crates/openssl-probe/RUSTSEC-0000-0000.md
@@ -62,10 +62,17 @@ any other crate's call-graph which may call this function directly or indirectly
 <[https://github.com/search?q=try_init_ssl_cert_env_vars&type=code](https://github.com/search?q=try_init_ssl_cert_env_vars+OR+init_ssl_cert_env_vars&type=code)>.  `native_tls <= 0.2.12` may
 do so in certain configurations <https://github.com/sfackler/rust-native-tls/blob/2424bc5efd1b8b4bcf60dbda93259a3f29db7f06/Cargo.toml>.
 
+## Fix and Mitigation
+
 The crate's author released a fix in versions `>=0.1.6` which marks these functions as `#[deprecated]` and adds
 new `unsafe` equivalents with safety guidance <https://github.com/alexcrichton/openssl-probe/commit/3ea7c1af24d7f03c5786872f06ff066e03b75138>.
 
-## Alternative Mitigations
+The correct fix is to [use the new `load_verify_locations` method available in `openssl` >= 0.10.69](https://docs.rs/openssl/latest/openssl/ssl/struct.SslConnectorBuilder.html#method.load_verify_locations):
+
+ - https://github.com/neonmoe/minreq/commit/4bc16dba61ae19e3f81de33b80c8a3c0c8a33a0d
+ - https://github.com/sfackler/rust-native-tls/commit/a35127a5cc6d0519c4d6b4dce1fb14ab945ad347
+
+### Alternative Mitigations
 
 In the case of glibc users, some future thread-safety improvements may protect you from `setenv`/`getenv` clashes
 which were introduced in <https://github.com/bminor/glibc/commit/7a61e7f557a97ab597d6fca5e2d1f13f65685c61>,

--- a/crates/openssl-probe/RUSTSEC-0000-0000.md
+++ b/crates/openssl-probe/RUSTSEC-0000-0000.md
@@ -22,25 +22,28 @@ patched = [">= 0.1.6"]
 
 # `openssl-probe` may cause memory corruption in multi-threaded processes
 
-`openssl-probe` offers non-`unsafe` methods that call environment setters, which may be called
+`openssl-probe` offers non-`unsafe` methods that call `std::env::set_var`, which may be called
 in a multithreaded environment, and potentially clash with environment access on other threads.
 
 When these methods are called while other threads are active and accessing the environment, it
-may cause the other threads to access dangling pointer values in the cases where the underlying
+may cause other threads to access dangling environment pointers in the cases where the underlying
 environment data is moved or resized in response to an additional environment variable being
 added, or a variable's contents being enlarged.
 
 This is shown to occur on Linux, but it will also likely occur on any other platform where `getenv`
 and `setenv` are not thread-safe, though trigger conditions may vary widely.
 
+Note that these function calls are completely safe and sound in purely single-threaded environments,
+or multi-threaded environments where it can be proven that no simultaneous read and writes to the
+environment occur.
+
 ## Rust's `set_env`
 
-This crate, and all callers of the Rust `set_env` function (<https://doc.rust-lang.org/std/env/fn.set_var.html>)
-are unsound due to some early decisions in the Rust ecosystem that provided these functions without
-an `unsafe` marker. The real problem, however, lies in the POSIX standard which defines this method
+This crate, and all other callers of the Rust `set_env` function (<https://doc.rust-lang.org/std/env/fn.set_var.html>)
+are unsound due to the unfortunate reality of the POSIX standard which defines these enviornment access methods
 without making any sort of thread-safety guarantees.
 
-In Rust's 2024 edition these environment setters are made `unsafe` and the documentation was updated to note
+In Rust's 2024 edition `std::env::set_var` is marked as `unsafe` and the documentation was updated to note
 that the only safe way to use these functions is in a single-threaded context.
 
 ## Affected Code
@@ -52,11 +55,11 @@ any other library's function which may call this function directly or indirectly
 do so in certain configurations <https://github.com/sfackler/rust-native-tls/blob/2424bc5efd1b8b4bcf60dbda93259a3f29db7f06/Cargo.toml>.
 
 The crate's author released a fix in versions `>=0.1.6` which marks these functions as `#[deprecated]` and adds
-new `unsafe` equivalents <https://github.com/alexcrichton/openssl-probe/commit/3ea7c1af24d7f03c5786872f06ff066e03b75138>.
+new `unsafe` equivalents with safety guidance <https://github.com/alexcrichton/openssl-probe/commit/3ea7c1af24d7f03c5786872f06ff066e03b75138>.
 
 ## Alternative Mitigations
 
-In the case of glibc users, some thread-safety improvements may protect you from `setenv`/`getenv` clashes
+In the case of glibc users, some future thread-safety improvements may protect you from `setenv`/`getenv` clashes
 which were introduced in <https://github.com/bminor/glibc/commit/7a61e7f557a97ab597d6fca5e2d1f13f65685c61>,
 however direct `environ` access in multithreaded programs will still risk dangling pointer access.
 

--- a/crates/openssl-probe/RUSTSEC-0000-0000.md
+++ b/crates/openssl-probe/RUSTSEC-0000-0000.md
@@ -12,7 +12,7 @@ keywords = ["ssl", "openssl", "environment"]
 
 [affected.functions]
 "openssl_probe::try_init_ssl_cert_env_vars" = ["< 0.1.6"]
-
+"
 [affected]
 os = ["linux"]
 
@@ -33,15 +33,26 @@ added, or a variable's contents being enlarged.
 This is shown to occur on Linux, but it will also likely occur on any other platform where `getenv`
 and `setenv` are not thread-safe, though trigger conditions may vary widely.
 
+## Rust's `set_env`
+
+This crate, and all callers of the Rust `set_env` function (<https://doc.rust-lang.org/std/env/fn.set_var.html>)
+are unsound due to some early decisions in the Rust ecosystem that provided these functions without
+an `unsafe` marker. The real problem, however, lies in the POSIX standard which defines this method
+without making any sort of thread-safety guarantees.
+
+In Rust's 2024 edition these environment setters are made `unsafe` and the documentation was updated to note
+that the only safe way to use these functions is in a single-threaded context.
+
 ## Affected Code
 
-The affected function is `try_init_ssl_cert_env_vars` in 
-<https://github.com/alexcrichton/openssl-probe/blob/db67c9e5b333b1b4164467b17f5d99207fad004c/src/lib.rs#L65>, and
+The affected functions are `init_ssl_cert_env_vars` and `try_init_ssl_cert_env_vars` in 
+<https://github.com/alexcrichton/openssl-probe/blob/db67c9e5b333b1b4164467b17f5d99207fad004c/src/lib.rs#L52> and <https://github.com/alexcrichton/openssl-probe/blob/db67c9e5b333b1b4164467b17f5d99207fad004c/src/lib.rs#L65>, respectively, and
 any other library's function which may call this function directly or indirectly
-<https://github.com/search?q=try_init_ssl_cert_env_vars&type=code>.  `native_tls <= 0.2.12` may
+<[https://github.com/search?q=try_init_ssl_cert_env_vars&type=code](https://github.com/search?q=try_init_ssl_cert_env_vars+OR+init_ssl_cert_env_vars&type=code)>.  `native_tls <= 0.2.12` may
 do so in certain configurations <https://github.com/sfackler/rust-native-tls/blob/2424bc5efd1b8b4bcf60dbda93259a3f29db7f06/Cargo.toml>.
 
-The crate's author released a fix in versions `>=0.1.6` which marks these functions as `unsafe` and `#[deprecated]`.
+The crate's author released a fix in versions `>=0.1.6` which marks these functions as `#[deprecated]` and adds
+new `unsafe` equivalents <https://github.com/alexcrichton/openssl-probe/commit/3ea7c1af24d7f03c5786872f06ff066e03b75138>.
 
 ## Alternative Mitigations
 

--- a/crates/openssl-probe/RUSTSEC-0000-0000.md
+++ b/crates/openssl-probe/RUSTSEC-0000-0000.md
@@ -1,3 +1,4 @@
+```
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "openssl-probe"
@@ -14,3 +15,4 @@ os = ["linux"]
 
 [versions]
 patched = []
+```

--- a/crates/openssl-probe/RUSTSEC-0000-0000.md
+++ b/crates/openssl-probe/RUSTSEC-0000-0000.md
@@ -67,7 +67,8 @@ do so in certain configurations <https://github.com/sfackler/rust-native-tls/blo
 The crate's author released a fix in versions `>=0.1.6` which marks these functions as `#[deprecated]` and adds
 new `unsafe` equivalents with safety guidance <https://github.com/alexcrichton/openssl-probe/commit/3ea7c1af24d7f03c5786872f06ff066e03b75138>.
 
-The correct fix is to [use the new `load_verify_locations` method available in `openssl` >= 0.10.69](https://docs.rs/openssl/latest/openssl/ssl/struct.SslConnectorBuilder.html#method.load_verify_locations):
+The correct fix is to use the safe `openssl_probe::probe` method to fetch the certificate location, and pass that to
+[the new `load_verify_locations` method](https://docs.rs/openssl/latest/openssl/ssl/struct.SslConnectorBuilder.html#method.load_verify_locations) available in `openssl` >= 0.10.69:
 
  - https://github.com/neonmoe/minreq/commit/4bc16dba61ae19e3f81de33b80c8a3c0c8a33a0d
  - https://github.com/sfackler/rust-native-tls/commit/a35127a5cc6d0519c4d6b4dce1fb14ab945ad347

--- a/crates/openssl-probe/RUSTSEC-0000-0000.md
+++ b/crates/openssl-probe/RUSTSEC-0000-0000.md
@@ -1,4 +1,4 @@
-```
+```toml
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "openssl-probe"

--- a/crates/openssl-probe/RUSTSEC-0000-0000.md
+++ b/crates/openssl-probe/RUSTSEC-0000-0000.md
@@ -12,7 +12,8 @@ keywords = ["ssl", "openssl", "environment"]
 
 [affected.functions]
 "openssl_probe::try_init_ssl_cert_env_vars" = ["< 0.1.6"]
-"
+"openssl_probe::init_ssl_cert_env_vars" = ["< 0.1.6"]
+
 [affected]
 os = ["linux"]
 
@@ -50,7 +51,7 @@ that the only safe way to use these functions is in a single-threaded context.
 
 The affected functions are `init_ssl_cert_env_vars` and `try_init_ssl_cert_env_vars` in 
 <https://github.com/alexcrichton/openssl-probe/blob/db67c9e5b333b1b4164467b17f5d99207fad004c/src/lib.rs#L52> and <https://github.com/alexcrichton/openssl-probe/blob/db67c9e5b333b1b4164467b17f5d99207fad004c/src/lib.rs#L65>, respectively, and
-any other library's function which may call this function directly or indirectly
+any other crate's call-graph which may call this function directly or indirectly
 <[https://github.com/search?q=try_init_ssl_cert_env_vars&type=code](https://github.com/search?q=try_init_ssl_cert_env_vars+OR+init_ssl_cert_env_vars&type=code)>.  `native_tls <= 0.2.12` may
 do so in certain configurations <https://github.com/sfackler/rust-native-tls/blob/2424bc5efd1b8b4bcf60dbda93259a3f29db7f06/Cargo.toml>.
 


### PR DESCRIPTION
We tracked down a crash to an interaction with environment setters in openssl-probe and environment access in another thread. CVE scoring was cloned from a previous environment soundness issue (https://nvd.nist.gov/vuln/detail/CVE-2020-26235).

Filed issue with more details: https://github.com/alexcrichton/openssl-probe/issues/30

This is not really a sensitive issue, so it could probably be delayed a bit to give the crate a chance to update.

## Open Questions

 - [ ] Release 0.2.0 of openssl-probe and mark `< 0.2.0` as vulnerable?

## Major crate status

 - [x] native-tls (117M dl) - completed in https://github.com/sfackler/rust-native-tls/commit/a35127a5cc6d0519c4d6b4dce1fb14ab945ad347, released
 - [x] rustls-native-certs (105M dl)- not vulnerable, version bumped
 - [x] minreq (2M) - completed in https://github.com/neonmoe/minreq/commit/4bc16dba61ae19e3f81de33b80c8a3c0c8a33a0d

### Unfixed or partially fixed

 - [ ] git2-rs (41M) - unfixed
 - [ ] curl-rust (24M) - unfixed
 - [ ] mongodb (5M) - unfixed, but migrated to new, unsafe APIs (still at risk of crash) -- https://github.com/mongodb/mongo-rust-driver/pull/1294#issuecomment-2625713530
 - [ ] pingora-core - unfixed
