### PR TITLE
Add patch version for RUSTSEC-2021-0087.md

### DIFF
--- a/crates/columnar/RUSTSEC-2021-0087.md
+++ b/crates/columnar/RUSTSEC-2021-0087.md
@@ -9,7 +9,7 @@ informational = "unsound"
 aliases = ["CVE-2021-45685", "GHSA-9mp7-45qh-r8j8", "GHSA-cxcc-q839-2cw9"]
 
 [versions]
-patched = [0.1.0]
+patched = [">= 0.1.0"]
 ```
 
 # columnar: `Read` on uninitialized buffer may cause UB (ColumnarReadExt::read_typed_vec())

--- a/crates/columnar/RUSTSEC-2021-0087.md
+++ b/crates/columnar/RUSTSEC-2021-0087.md
@@ -9,7 +9,7 @@ informational = "unsound"
 aliases = ["CVE-2021-45685", "GHSA-9mp7-45qh-r8j8", "GHSA-cxcc-q839-2cw9"]
 
 [versions]
-patched = []
+patched = [0.1.0]
 ```
 
 # columnar: `Read` on uninitialized buffer may cause UB (ColumnarReadExt::read_typed_vec())


### PR DESCRIPTION
This issue was closed with version 0.1.0:
https://github.com/frankmcsherry/columnar/issues/6

Commit:
https://github.com/frankmcsherry/columnar/commit/a9335e6f018731b5d434fb7703ec92e35d716ed0

Let me know if you need anything else. I work with the maintainer and will advise them to yank old versions of this crate. Thanks!