### PR TITLE
Report unsoundness in `cve-rs`, `totally-safe-transmute` and `totally-safe`

### DIFF
--- a/crates/cve-rs/RUSTSEC-0000-0000.md
+++ b/crates/cve-rs/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "cve-rs"
+date = "2025-02-10"
+url = "https://github.com/Speykious/cve-rs"
+categories = ["memory-corruption"]
+informational = "unsound"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# cve-rs introduces memory vulnerabilities in safe Rust
+
+`cve-rs` allows you to introduce common memory vulnerabilities (such as buffer overflows and segfaults) into your Rust program in a memory safe manner.
+
+Internally, this crate does not use unsafe code, it instead exploits a soundness bug in rustc: https://github.com/rust-lang/rust/issues/25860

--- a/crates/cve-rs/RUSTSEC-0000-0000.md
+++ b/crates/cve-rs/RUSTSEC-0000-0000.md
@@ -6,6 +6,7 @@ date = "2025-02-10"
 url = "https://github.com/Speykious/cve-rs"
 categories = ["memory-corruption"]
 informational = "unsound"
+keywords = ["soundness-hole"]
 
 [versions]
 patched = []

--- a/crates/totally-safe-transmute/RUSTSEC-0000-0000.md
+++ b/crates/totally-safe-transmute/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "totally-safe-transmute"
+date = "2025-02-10"
+url = "https://github.com/ben0x539/totally-safe-transmute"
+categories = ["memory-corruption"]
+informational = "unsound"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# totally-safe-transmute allows transmuting any type to any other type in safe Rust
+
+This crate uses a known soundness issue (https://github.com/rust-lang/rust/issues/32670) that will never get fixed. In short, Linux provides a file called `/proc/self/mem` which can be used by a program to modify its own memory. This library modifies an enum variant number by accessing its own memory as a file to effectively transmute a variable.
+
+See also <https://doc.rust-lang.org/std/os/unix/io/index.html#procselfmem-and-similar-os-features>

--- a/crates/totally-safe-transmute/RUSTSEC-0000-0000.md
+++ b/crates/totally-safe-transmute/RUSTSEC-0000-0000.md
@@ -6,6 +6,7 @@ date = "2025-02-10"
 url = "https://github.com/ben0x539/totally-safe-transmute"
 categories = ["memory-corruption"]
 informational = "unsound"
+keywords = ["soundness-hole"]
 
 [versions]
 patched = []

--- a/crates/totally-safe/RUSTSEC-0000-0000.md
+++ b/crates/totally-safe/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "totally-safe"
+date = "2025-02-10"
+url = "https://github.com/viktorlott/totally-safe"
+categories = ["memory-corruption"]
+informational = "unsound"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# totally-safe introduces memory vulnerabilities in safe Rust
+
+`totally-safe` provides unsound APIs that exploit a soundness bug in rustc: https://github.com/rust-lang/rust/issues/25860

--- a/crates/totally-safe/RUSTSEC-0000-0000.md
+++ b/crates/totally-safe/RUSTSEC-0000-0000.md
@@ -6,6 +6,7 @@ date = "2025-02-10"
 url = "https://github.com/viktorlott/totally-safe"
 categories = ["memory-corruption"]
 informational = "unsound"
+keywords = ["soundness-hole"]
 
 [versions]
 patched = []


### PR DESCRIPTION
We are using `cargo audit -D warnings` to avoid problematic dependencies.

To prevent anyone from using these crates in the dependency tree (accidentally?), I think it is meaningful to include them in advisories.

+ https://github.com/meithecatte/fake-static ([RUSTSEC-2020-0013](https://rustsec.org/advisories/RUSTSEC-2020-0013.html))
+ https://github.com/Speykious/cve-rs
+ https://github.com/ben0x539/totally-safe-transmute
+ https://github.com/viktorlott/totally-safe

Reverse dependencies
+ https://crates.io/crates/cve-rs/reverse_dependencies (0 dependents)
+ https://crates.io/crates/totally-safe-transmute/reverse_dependencies (1 dependent)
+ https://crates.io/crates/totally-safe/reverse_dependencies (0 dependents)

resolves #826 