### PR TITLE
Report denial-of-service in web-push via malicious Web Push endpoint

### DIFF
--- a/crates/web-push/RUSTSEC-0000-0000.md
+++ b/crates/web-push/RUSTSEC-0000-0000.md
@@ -1,0 +1,30 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "web-push"
+date = "2025-02-16"
+url = "https://github.com/pimeys/rust-web-push/pull/68"
+categories = ["denial-of-service"]
+keywords = ["panic", "oom"]
+
+[versions]
+patched = [">= 0.10.3"]
+```
+
+# Denial of Service via malicious Web Push endpoint
+
+Prior to version 0.10.3, the built-in clients of the `web-push` crate
+eagerly allocated memory based on the `Content-Length` header returned by the
+Web Push endpoint. Malicious Web Push endpoints could return a large
+`Content-Length` without ever having to send as much data, leading to
+denial of service by memory exhaustion.
+
+Services providing Web Push notifications typically allow the user to
+register an arbitrary endpoint, so the endpoint should not be trusted.
+
+The fixed version 0.10.3 now limits the amount of memory it will allocate
+for each response, limits the amount of data it will read from the endpoint,
+and returns an error if the endpoint sends too much data.
+
+As before, it is recommended that services add a timeout for each request
+to Web Push endpoints.


### PR DESCRIPTION
Reported privately via e-mail, fixed via https://github.com/pimeys/rust-web-push/pull/68 and published in v0.10.3