### PR TITLE
Unmaintained advisory for resolve crate

### DIFF
--- a/crates/resolve/RUSTSEC-0000-0000.md
+++ b/crates/resolve/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "resolve"
+date = "2025-02-21"
+references = ["https://github.com/murarth/resolve"]
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+# resolve is unmaintained
+
+resolve crate's GitHub repository is archived with no commits for seven years.
+Latest crates.io release is also seven years old.
+
+## Possible alternatives
+
+ * [hickory-resolver](https://crates.io/crates/hickory-resolver)


### PR DESCRIPTION
resolve crate's [GitHub repository](https://github.com/murarth/resolve) is archived since 2019-11-03 with no commits for seven years. Latest [crates.io release](https://crates.io/crates/resolve) is also seven years old. Crate's author @murarth seems to be in GitHub once in a while. Maybe this reaches them as well?