### PR TITLE
*ring* is maintained again

### DIFF
--- a/crates/ring/RUSTSEC-2025-0007.md
+++ b/crates/ring/RUSTSEC-2025-0007.md
@@ -5,6 +5,7 @@ package = "ring"
 date = "2025-02-20"
 informational = "unmaintained"
 url = "https://github.com/briansmith/ring/discussions/2414"
+withdrawn = "2025-02-22"
 
 [versions]
 patched = []
@@ -16,3 +17,9 @@ unaffected = []
 The author has announced an indefinite hiatus in its development, noting that
 any reported security vulnerabilities may go unaddressed for prolonged periods
 of time.
+
+# Update: security maintenance only
+
+After this advisory was published, the author graciously agreed to give
+access to the rustls team. The rustls team is committed to providing
+security (only) maintenance for *ring* for the foreseeable future.


### PR DESCRIPTION
Remove unmaintained advisory RUSTSEC-2025-0007.

@ctz and the rustls maintainers now have access to the crates.io entry for ring.