### PR TITLE
Unmaintained advisory for humantime

### DIFF
--- a/crates/humantime/RUSTSEC-0000-0000.md
+++ b/crates/humantime/RUSTSEC-0000-0000.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "humantime"
+date = "2025-03-08"
+url = "https://github.com/tailhook/humantime/issues/31"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# humantime is unmaintained
+
+Latest `humantime` crates.io release is four years old and GitHub repository has
+not seen commits in four years. Question about maintenance status has not gotten
+any reaction from maintainer: https://github.com/tailhook/humantime/issues/31
+
+## Possible alternatives
+
+ * [jiff](https://crates.io/crates/jiff) provides same kind of functionality


### PR DESCRIPTION
Last crates.io release 2021-01-13 and no GitHub commits since 2021-12-28.

Question about maintenance status posted 2022-08-04 with no answer from maintainer: https://github.com/tailhook/humantime/issues/31

This crate has some [big dependents](https://crates.io/crates/humantime/reverse_dependencies) like [`clap`](https://crates.io/crates/clap) (with 20309 dependents) and [`env_logger`](https://crates.io/crates/env_logger) (with 8090 dependents).

Update 2025-03-10: `env_logger` 0.11.7 dropped `humantime` dependency in favor of `jiff`.
