### PR TITLE
List patched version for protobuf crate

### DIFF
--- a/crates/protobuf/RUSTSEC-2024-0437.md
+++ b/crates/protobuf/RUSTSEC-2024-0437.md
@@ -9,7 +9,7 @@ keywords = ["panic"]
 related = ["GHSA-735f-pc8j-v9w8"]
 
 [versions]
-patched = []
+patched = ["^3.7.2"]
 
 [affected]
 functions = { "protobuf::coded_input_stream::CodedInputStream::skip_group" = ["<= 3.4.0"] }

--- a/crates/protobuf/RUSTSEC-2024-0437.md
+++ b/crates/protobuf/RUSTSEC-2024-0437.md
@@ -9,7 +9,7 @@ keywords = ["panic"]
 related = ["GHSA-735f-pc8j-v9w8"]
 
 [versions]
-patched = ["^3.7.2"]
+patched = [">= 3.7.2"]
 
 [affected]
 functions = { "protobuf::coded_input_stream::CodedInputStream::skip_group" = ["<= 3.4.0"] }


### PR DESCRIPTION
Update RUSTSEC-2024-0437 with the released patched version. The is on crates.io and per the [changelog] contains a fix for the recursion issue.


[changelog]: https://github.com/stepancheg/rust-protobuf/blob/330b78658ead005aebc7698a7af7cba185ad9702/CHANGELOG.md#372---2025-03-10-to-be-released