### PR TITLE
Add advisory for use after free in `pared` <=0.3.0

### DIFF
--- a/crates/pared/RUSTSEC-0000-0000.md
+++ b/crates/pared/RUSTSEC-0000-0000.md
@@ -1,0 +1,41 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "pared"
+date = "2025-03-13"
+url = "https://github.com/radekvit/pared/issues/2"
+categories = ["code-execution", "memory-corruption"]
+
+[versions]
+patched = [">= 0.4.0"]
+
+[affected]
+
+[affected.functions]
+"pared::prc::Prc::from_rc" = ["< 0.4.0"]
+"pared::prc::Prc::project" = ["< 0.4.0"]
+"pared::prc::Prc::try_from_rc" = ["< 0.4.0"]
+"pared::sync::Parc::from_arc" = ["< 0.4.0"]
+"pared::sync::Parc::project" = ["< 0.4.0"]
+"pared::sync::Parc::try_from_arc" = ["< 0.4.0"]
+```
+
+# Use after free in `Parc` and `Prc` due to missing lifetime constraints
+Affected versions of this crate didn't provide sufficient lifetime constraints to conversion
+functions from `alloc::sync::Arc` and `alloc::rc::Rc`, which made it possible to create
+projections of these reference counted pointers. Unlike the original reference counted pointers,
+these projections could outlive original data's lifetimes.
+
+This projected pointer could cause the original `Arc`'s or `Rc`'s `Drop::drop` to get called at
+a point where the original data was no longer valid, leading to a potential use after free.
+
+The affected functions were
+- `pared::prc::Prc::from_rc`
+- `pared::prc::Prc::project`
+- `pared::prc::Prc::try_from_rc`
+- `pared::sync::Parc::from_arc`
+- `pared::sync::Parc::project`
+- `pared::sync::Parc::try_from_arc`
+
+This flaw was fixed in [108f540ea8acb6073751a1aa386085c1cdc4fd1e](https://github.com/radekvit/pared/commit/108f540ea8acb6073751a1aa386085c1cdc4fd1e)
+by requiring that the type stored in the `Arc`s and `Rc`s passed to these functions contain `T: 'static`.


### PR DESCRIPTION
# Use after free in `Parc` and `Prc` due to missing lifetime constraints
Affected versions of this crate didn't provide sufficient lifetime constraints to conversion
functions from `alloc::sync::Arc` and `alloc::rc::Rc`, which made it possible to create
projections of these reference counted pointers. Unlike the original reference counted pointers,
these projections could outlive original data's lifetimes.

This projected pointer could cause the original `Arc`'s or `Rc`'s `Drop::drop` to get called at
a point where the original data was no longer valid, leading to a potential use after free.

The affected functions were
- `pared::prc::Prc::from_rc`
- `pared::prc::Prc::project`
- `pared::prc::Prc::try_from_rc`
- `pared::sync::Parc::from_arc`
- `pared::sync::Parc::project`
- `pared::sync::Parc::try_from_arc`

This flaw was fixed in [108f540ea8acb6073751a1aa386085c1cdc4fd1e](https://github.com/radekvit/pared/commit/108f540ea8acb6073751a1aa386085c1cdc4fd1e)
by requiring that the type stored in the `Arc`s and `Rc`s passed to these functions contain `T: 'static`.
