### PR TITLE
Import old Wasmtime security advisories 

### DIFF
--- a/crates/wasmtime/RUSTSEC-0000-0000.0.md
+++ b/crates/wasmtime/RUSTSEC-0000-0000.0.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime"
+date = "2022-03-28"
+url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-gwc9-348x-qwv2"
+categories = ["memory-corruption"]
+keywords = []
+aliases = ["CVE-2022-24791", "GHSA-gwc9-348x-qwv2"]
+license = "CC0-1.0"
+
+[versions]
+patched = [">= 0.35.2", ">= 0.34.2, < 0.35.0"]
+```
+
+#  Use after free with `externref`s and epoch interruption in Wasmtime
+
+This is an entry in the RustSec database for the Wasmtime security advisory
+located at
+https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-gwc9-348x-qwv2.
+For more information see the GitHub-hosted security advisory.

--- a/crates/wasmtime/RUSTSEC-0000-0000.1.md
+++ b/crates/wasmtime/RUSTSEC-0000-0000.1.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime"
+date = "2022-06-27"
+url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-jqwc-c49r-4w2x"
+categories = []
+keywords = []
+aliases = ["CVE-2022-31104", "GHSA-jqwc-c49r-4w2x"]
+license = "CC0-1.0"
+
+[versions]
+patched = [">= 0.38.1"]
+```
+
+# Miscompilation of `i8x16.swizzle` and `select` with v128 inputs
+
+This is an entry in the RustSec database for the Wasmtime security advisory
+located at
+https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-jqwc-c49r-4w2x.
+For more information see the GitHub-hosted security advisory.

--- a/crates/wasmtime/RUSTSEC-0000-0000.10.md
+++ b/crates/wasmtime/RUSTSEC-0000-0000.10.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime"
+date = "2023-04-21"
+url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-ch89-5g45-qwc7"
+categories = ["memory-corruption"]
+keywords = []
+aliases = ["CVE-2023-30624", "GHSA-ch89-5g45-qwc7"]
+license = "CC0-1.0"
+cvss = "CVSS:3.1/AV:N/AC:H/PR:H/UI:R/S:U/C:L/I:L/A:L"
+
+[versions]
+patched = [">= 6.0.2, < 7.0.0", ">= 7.0.1, < 8.0.0", ">= 8.0.1"]
+```
+
+# Undefined Behavior in Rust runtime functions
+
+This is an entry in the RustSec database for the Wasmtime security advisory
+located at
+https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-ch89-5g45-qwc7.
+For more information see the GitHub-hosted security advisory.

--- a/crates/wasmtime/RUSTSEC-0000-0000.11.md
+++ b/crates/wasmtime/RUSTSEC-0000-0000.11.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime"
+date = "2023-09-05"
+url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-gw5p-q8mj-p7gh"
+categories = []
+keywords = []
+aliases = ["CVE-2023-41880", "GHSA-gw5p-q8mj-p7gh"]
+license = "CC0-1.0"
+cvss = "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:N/I:L/A:N"
+
+[versions]
+patched = [">= 10.0.2, < 11.0.0", ">= 11.0.2, < 12.0.0", ">= 12.0.2"]
+```
+
+# Miscompilation of wasm `i64x2.shr_s` instruction with constant input on x86\_64
+
+This is an entry in the RustSec database for the Wasmtime security advisory
+located at
+https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-gw5p-q8mj-p7gh.
+For more information see the GitHub-hosted security advisory.

--- a/crates/wasmtime/RUSTSEC-0000-0000.12.md
+++ b/crates/wasmtime/RUSTSEC-0000-0000.12.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime"
+date = "2024-04-02"
+url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-75hq-h6g9-h4q5"
+categories = []
+keywords = []
+aliases = ["CVE-2024-30266", "GHSA-75hq-h6g9-h4q5"]
+license = "CC0-1.0"
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L"
+
+[versions]
+patched = [">= 19.0.1"]
+unaffected = ["< 19.0.0"]
+```
+
+# Panic when using a dropped extenref-typed element segment
+
+This is an entry in the RustSec database for the Wasmtime security advisory
+located at
+https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-75hq-h6g9-h4q5.
+For more information see the GitHub-hosted security advisory.

--- a/crates/wasmtime/RUSTSEC-0000-0000.13.md
+++ b/crates/wasmtime/RUSTSEC-0000-0000.13.md
@@ -1,0 +1,29 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime"
+date = "2024-10-02"
+url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-q8hx-mm92-4wvg"
+categories = []
+keywords = []
+aliases = ["CVE-2024-47763", "GHSA-q8hx-mm92-4wvg"]
+license = "CC0-1.0"
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H"
+
+[versions]
+patched = [
+    ">= 21.0.2, < 22.0.0",
+    ">= 22.0.1, < 23.0.0",
+    ">= 23.0.3, < 24.0.0",
+    ">= 24.0.1, < 25.0.0",
+    ">= 25.0.2",
+]
+unaffected = ["< 21.0.0"]
+```
+
+# Runtime crash when combining tail calls with stack traces
+
+This is an entry in the RustSec database for the Wasmtime security advisory
+located at
+https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-q8hx-mm92-4wvg.
+For more information see the GitHub-hosted security advisory.

--- a/crates/wasmtime/RUSTSEC-0000-0000.14.md
+++ b/crates/wasmtime/RUSTSEC-0000-0000.14.md
@@ -1,0 +1,29 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime"
+date = "2024-10-03"
+url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-7qmx-3fpx-r45m"
+categories = []
+keywords = []
+aliases = ["CVE-2024-47813", "GHSA-7qmx-3fpx-r45m"]
+license = "CC0-1.0"
+cvss = "CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:U/C:N/I:L/A:L"
+
+[versions]
+patched = [
+    ">= 21.0.2, < 22.0.0",
+    ">= 22.0.1, < 23.0.0",
+    ">= 23.0.3, < 24.0.0",
+    ">= 24.0.1, < 25.0.0",
+    ">= 25.0.2",
+]
+unaffected = ["< 19.0.0"]
+```
+
+# Race condition could lead to WebAssembly control-flow integrity and type safety violations
+
+This is an entry in the RustSec database for the Wasmtime security advisory
+located at
+https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-7qmx-3fpx-r45m.
+For more information see the GitHub-hosted security advisory.

--- a/crates/wasmtime/RUSTSEC-0000-0000.15.md
+++ b/crates/wasmtime/RUSTSEC-0000-0000.15.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime"
+date = "2024-11-02"
+url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-c2f5-jxjv-2hh8"
+categories = []
+keywords = []
+aliases = ["CVE-2024-51745", "GHSA-c2f5-jxjv-2hh8"]
+license = "CC0-1.0"
+
+[versions]
+patched = [">= 24.0.2, < 25.0.0", ">= 25.0.3, < 26.0.0", ">= 26.0.1"]
+```
+
+# Wasmtime doesn't fully sandbox all the Windows device filenames
+
+This is an entry in the RustSec database for the Wasmtime security advisory
+located at
+https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-c2f5-jxjv-2hh8.
+For more information see the GitHub-hosted security advisory.

--- a/crates/wasmtime/RUSTSEC-0000-0000.2.md
+++ b/crates/wasmtime/RUSTSEC-0000-0000.2.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime"
+date = "2022-07-05"
+url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-7f6x-jwh5-m9r4"
+categories = []
+keywords = []
+aliases = ["CVE-2022-23636", "GHSA-7f6x-jwh5-m9r4"]
+license = "CC0-1.0"
+
+[versions]
+patched = [">= 0.38.2"]
+```
+
+# Miscompilation of constant values in division on AArch64
+
+This is an entry in the RustSec database for the Wasmtime security advisory
+located at
+https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-7f6x-jwh5-m9r4.
+For more information see the GitHub-hosted security advisory.

--- a/crates/wasmtime/RUSTSEC-0000-0000.3.md
+++ b/crates/wasmtime/RUSTSEC-0000-0000.3.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime"
+date = "2022-07-12"
+url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-5fhj-g3p3-pq9g"
+categories = ["memory-corruption"]
+keywords = []
+aliases = ["CVE-2022-31146", "GHSA-5fhj-g3p3-pq9g"]
+license = "CC0-1.0"
+
+[versions]
+patched = [">= 0.38.2"]
+```
+
+# Use After Free with `externref`s in Wasmtime
+
+This is an entry in the RustSec database for the Wasmtime security advisory
+located at
+https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-5fhj-g3p3-pq9g.
+For more information see the GitHub-hosted security advisory.

--- a/crates/wasmtime/RUSTSEC-0000-0000.4.md
+++ b/crates/wasmtime/RUSTSEC-0000-0000.4.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime"
+date = "2022-11-05"
+url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-44mr-8vmm-wjhg"
+categories = []
+keywords = []
+aliases = ["CVE-2022-39392", "GHSA-44mr-8vmm-wjhg"]
+license = "CC0-1.0"
+cvss = "CVSS:3.1/AV:N/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:N"
+
+[versions]
+patched = [">= 1.0.2, < 2.0.0", ">= 2.0.2"]
+```
+
+# Out of bounds read/write with zero-memory-pages configuration
+
+This is an entry in the RustSec database for the Wasmtime security advisory
+located at
+https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-44mr-8vmm-wjhg.
+For more information see the GitHub-hosted security advisory.

--- a/crates/wasmtime/RUSTSEC-0000-0000.5.md
+++ b/crates/wasmtime/RUSTSEC-0000-0000.5.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime"
+date = "2022-11-05"
+url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-wh6w-3828-g9qf"
+categories = []
+keywords = []
+aliases = ["CVE-2022-39393", "GHSA-wh6w-3828-g9qf"]
+license = "CC0-1.0"
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:N/A:N"
+
+[versions]
+patched = [">= 1.0.2, < 2.0.0", ">= 2.0.2"]
+```
+
+# Data leakage between instances in the pooling allocator
+
+This is an entry in the RustSec database for the Wasmtime security advisory
+located at
+https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-wh6w-3828-g9qf.
+For more information see the GitHub-hosted security advisory.

--- a/crates/wasmtime/RUSTSEC-0000-0000.6.md
+++ b/crates/wasmtime/RUSTSEC-0000-0000.6.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime"
+date = "2022-11-07"
+url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-h84q-m8rr-3v9q"
+categories = []
+keywords = []
+aliases = ["CVE-2022-39394", "GHSA-h84q-m8rr-3v9q"]
+license = "CC0-1.0"
+cvss = "CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:U/C:L/I:L/A:L"
+
+[versions]
+patched = [">= 1.0.2, < 2.0.0", ">= 2.0.2"]
+```
+
+# Out of bounds write in `wasmtime_trap_code` C API function
+
+This is an entry in the RustSec database for the Wasmtime security advisory
+located at
+https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-h84q-m8rr-3v9q.
+For more information see the GitHub-hosted security advisory.

--- a/crates/wasmtime/RUSTSEC-0000-0000.7.md
+++ b/crates/wasmtime/RUSTSEC-0000-0000.7.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime"
+date = "2023-03-02"
+url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-ff4p-7xrq-q5r8"
+categories = ["memory-corruption"]
+keywords = []
+aliases = ["CVE-2023-26489", "GHSA-ff4p-7xrq-q5r8"]
+license = "CC0-1.0"
+cvss = "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"
+
+[versions]
+patched = [">= 4.0.1, < 5.0.0", ">= 5.0.1, < 6.0.0", ">= 6.0.1"]
+```
+
+# Guest-controlled out-of-bounds read/write on x86\_64
+
+This is an entry in the RustSec database for the Wasmtime security advisory
+located at
+https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-ff4p-7xrq-q5r8.
+For more information see the GitHub-hosted security advisory.

--- a/crates/wasmtime/RUSTSEC-0000-0000.8.md
+++ b/crates/wasmtime/RUSTSEC-0000-0000.8.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime"
+date = "2023-03-03"
+url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-xm67-587q-r2vw"
+categories = []
+keywords = []
+aliases = ["CVE-2023-27477", "GHSA-xm67-587q-r2vw"]
+license = "CC0-1.0"
+cvss = "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:N/I:L/A:N"
+
+[versions]
+patched = [">= 4.0.1, < 5.0.0", ">= 5.0.1, < 6.0.0", ">= 6.0.1"]
+```
+
+# Miscompilation of `i8x16.select` with the same inputs on x86\_64
+
+This is an entry in the RustSec database for the Wasmtime security advisory
+located at
+https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-xm67-587q-r2vw.
+For more information see the GitHub-hosted security advisory.

--- a/crates/wasmtime/RUSTSEC-0000-0000.md
+++ b/crates/wasmtime/RUSTSEC-0000-0000.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime"
+date = "2022-02-17"
+url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-88xq-w8cq-xfg7"
+categories = ["memory-corruption"]
+keywords = []
+aliases = ["CVE-2022-23636", "GHSA-88xq-w8cq-xfg7"]
+license = "CC0-1.0"
+
+[versions]
+patched = [">= 0.33.1, < 0.34.0", ">= 0.34.1"]
+```
+
+# Invalid drop of VMExternRef from partially-initialized instances in the pooling instance allocator
+
+This is an entry in the RustSec database for the Wasmtime security advisory
+located at
+https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-88xq-w8cq-xfg7.
+For more information see the GitHub-hosted security advisory.


### PR DESCRIPTION
[Wasmtime] recently got a [request] to have our security advisories
published on the RustSec database as well. We've got a few old
advisories on here but we haven't been keeping up-to-date with later
advisories. In lieu of automatic imports from GitHub to RustSec we
figured we'd in the interim manually fill in some fields.

In this PR I'm back-filling security advisories we've had in Wasmtime
into the RustSec database here. The oldest advisory here is 3 years old
and the goal is to have this serve as a template for importing future
advisories that Wasmtime gets. It's not expected for this to cause any
churn or undue warnings but instead is intended to bring RustSec
up-to-date with the advisories we have for this crate.

[Wasmtime]: https://crates.io/crates/wasmtime
[request]: https://github.com/bytecodealliance/wasmtime/issues/10344
