### PR TITLE
Advisory for CVE-2025-31130 (weak SHA-1) in gix-features

### DIFF
--- a/crates/gix-features/RUSTSEC-0000-0000.md
+++ b/crates/gix-features/RUSTSEC-0000-0000.md
@@ -10,6 +10,17 @@ keywords = ["hash-collision", "sha-1", "weak-hash"]
 aliases = ["CVE-2025-31130", "GHSA-2frx-2596-x5r6"]
 license = "CC0-1.0"
 
+[affected.functions]
+"gix_features::hash::bytes_of_file" = ["< 0.41.0"]
+"gix_features::hash::bytes" = ["< 0.41.0"]
+"gix_features::hash::bytes_with_hasher" = ["< 0.41.0"]
+"gix_features::hash::hasher" = ["< 0.41.0"]
+"gix_features::hash::Hasher::update" = ["< 0.41.0"]
+"gix_features::hash::Hasher::digest" = ["< 0.41.0"]
+"gix_features::hash::Write::new" = ["< 0.41.0"]
+"gix_features::hash::Write::write" = ["< 0.41.0"]
+"gix_features::hash::Write::flush" = ["< 0.41.0"]
+
 [versions]
 patched = [">= 0.41.0"]
 ```

--- a/crates/gix-features/RUSTSEC-0000-0000.md
+++ b/crates/gix-features/RUSTSEC-0000-0000.md
@@ -1,0 +1,81 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "gix-features"
+date = "2025-04-03"
+url = "https://github.com/GitoxideLabs/gitoxide/security/advisories/GHSA-2frx-2596-x5r6"
+categories = ["crypto-failure"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:N/I:H/A:N"
+keywords = ["hash-collision", "sha-1", "weak-hash"]
+aliases = ["CVE-2025-31130", "GHSA-2frx-2596-x5r6"]
+license = "CC0-1.0"
+
+[versions]
+patched = [">= 0.41.0"]
+```
+
+# SHA-1 collision attacks are not detected
+
+### Summary
+gitoxide uses SHA-1 hash implementations without any collision detection, leaving it vulnerable to hash collision attacks.
+
+### Details
+gitoxide uses the `sha1_smol` or `sha1` crate, both of which implement standard SHA-1 without any mitigations for collision attacks. This means that two distinct Git objects with colliding SHA-1 hashes would break the Git object model and integrity checks when used with gitoxide.
+
+The SHA-1 function is considered cryptographically insecure. However, in the wake of the SHAttered attacks, this issue was mitigated in Git 2.13.0 in 2017 by using the [sha1collisiondetection](https://github.com/crmarcstevens/sha1collisiondetection) algorithm by default and producing an error when known SHA-1 collisions are detected. Git is in the process of migrating to using SHA-256 for object hashes, but this has not been rolled out widely yet and gitoxide does not support SHA-256 object hashes.
+
+### PoC
+The following program demonstrates the problem, using the two [SHAttered PDFs](https://shattered.io/):
+
+```rust
+use sha1_checked::{CollisionResult, Digest};
+
+fn sha1_oid_of_file(filename: &str) -> gix::ObjectId {
+    let mut hasher = gix::features::hash::hasher(gix::hash::Kind::Sha1);
+    hasher.update(&std::fs::read(filename).unwrap());
+    gix::ObjectId::Sha1(hasher.digest())
+}
+
+fn sha1dc_oid_of_file(filename: &str) -> Result<gix::ObjectId, String> {
+    // Matches Git’s behaviour.
+    let mut hasher = sha1_checked::Builder::default().safe_hash(false).build();
+    hasher.update(&std::fs::read(filename).unwrap());
+    match hasher.try_finalize() {
+        CollisionResult::Ok(digest) => Ok(gix::ObjectId::Sha1(digest.into())),
+        CollisionResult::Mitigated(_) => unreachable!(),
+        CollisionResult::Collision(digest) => Err(format!(
+            "Collision attack: {}",
+            gix::ObjectId::Sha1(digest.into()).to_hex()
+        )),
+    }
+}
+
+fn main() {
+    dbg!(sha1_oid_of_file("shattered-1.pdf"));
+    dbg!(sha1_oid_of_file("shattered-2.pdf"));
+    dbg!(sha1dc_oid_of_file("shattered-1.pdf"));
+    dbg!(sha1dc_oid_of_file("shattered-2.pdf"));
+}
+```
+
+The output is as follows:
+
+```
+[src/main.rs:24:5] sha1_oid_of_file("shattered-1.pdf") = Sha1(38762cf7f55934b34d179ae6a4c80cadccbb7f0a)
+[src/main.rs:25:5] sha1_oid_of_file("shattered-2.pdf") = Sha1(38762cf7f55934b34d179ae6a4c80cadccbb7f0a)
+[src/main.rs:26:5] sha1dc_oid_of_file("shattered-1.pdf") = Err(
+    "Collision attack: 38762cf7f55934b34d179ae6a4c80cadccbb7f0a",
+)
+[src/main.rs:27:5] sha1dc_oid_of_file("shattered-2.pdf") = Err(
+    "Collision attack: 38762cf7f55934b34d179ae6a4c80cadccbb7f0a",
+)
+```
+
+The latter behaviour matches Git.
+
+Since the SHAttered PDFs are not in a valid format for Git objects, a direct proof‐of‐concept using higher‐level APIs cannot be immediately demonstrated without significant computational resources.
+
+### Impact
+An attacker with the ability to mount a collision attack on SHA-1 like the [SHAttered](https://shattered.io/) or [SHA-1 is a Shambles](https://sha-mbles.github.io/) attacks could create two distinct Git objects with the same hash. This is becoming increasingly affordable for well‐resourced attackers, with the Shambles researchers in 2020 estimating $45k for a chosen‐prefix collision or $11k for a classical collision, and projecting less than $10k for a chosen‐prefix collision by 2025. The result could be used to disguise malicious repository contents, or potentially exploit assumptions in the logic of programs using gitoxide to cause further vulnerabilities.
+
+This vulnerability affects any user of gitoxide, including `gix-*` library crates, that reads or writes Git objects.


### PR DESCRIPTION
This adds a notice for CVE-2025-31130 (GHSA-2frx-2596-x5r6) in `gix-features`.

Although `gix-features` is usually used as a "knob" for adjusting features across `gix-*` crates, as well as being used internally:

- The functionality replaced to fix the vulnerability was in `gix-features`.
- All vulnerable crates depend directly or indirectly on `gix-features`.

My understanding is that the usual practice for RUSTSEC advisories in such a situation is to have only an advisory for that one crate, as in https://github.com/rustsec/advisory-db/pull/1705#issuecomment-1575170900. So this adds a RUSTSEC notice only for `gix-features`. (The published repository-local GHSA, and forthcoming global GHSA, are not limited to one affected crate per advisory, and accordingly list more crates.)
 
As in some past advisories, when a global GHSA is published, I can open another PR to add a reference to that.

cc @Byron @emilazy