### PR TITLE
Add references to RUSTSEC-2025-0021

### DIFF
--- a/crates/gix-features/RUSTSEC-2025-0021.md
+++ b/crates/gix-features/RUSTSEC-2025-0021.md
@@ -4,6 +4,10 @@ id = "RUSTSEC-2025-0021"
 package = "gix-features"
 date = "2025-04-03"
 url = "https://github.com/GitoxideLabs/gitoxide/security/advisories/GHSA-2frx-2596-x5r6"
+references = [
+    "https://github.com/advisories/GHSA-2frx-2596-x5r6",
+    "https://nvd.nist.gov/vuln/detail/CVE-2025-31130",
+]
 categories = ["crypto-failure"]
 cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:N/I:H/A:N"
 keywords = ["hash-collision", "sha-1", "weak-hash"]


### PR DESCRIPTION
Since it was added in #2268, [RUSTSEC-2025-0021](https://rustsec.org/advisories/RUSTSEC-2025-0021.html) (CVE-2025-31130) has an entry in the GitHub Advisory Database. As planned in #2268, this adds the link to that global GHSA, as well as to the National Vulnerability Database entry for the CVE.

Some additional information may end up being posted in the pull request or issue, in which case one or both of those may make sense to add as references, but I am not sure yet. If so, I can add those separately. But I didn't want to add these references as planned.