### PR TITLE
Update patched version list for RUSTSEC-2025-0023

### DIFF
--- a/crates/tokio/RUSTSEC-2025-0023.md
+++ b/crates/tokio/RUSTSEC-2025-0023.md
@@ -8,7 +8,7 @@ informational = "unsound"
 categories = ["memory-corruption"]
 
 [versions]
-patched = [">= 1.38.2, < 1.39.0", ">= 1.43.1, < 1.44.0", ">= 1.44.2"]
+patched = [">= 1.38.2, < 1.39.0", ">= 1.42.1, < 1.43.0", ">= 1.43.1, < 1.44.0", ">= 1.44.2"]
 unaffected = ["< 0.2.5"]
 ```
 


### PR DESCRIPTION
We backported this fix to one more minor release series.