### PR TITLE
Add crossbeam-channel advisory re upstream MR #1187

### DIFF
--- a/crates/crossbeam-channel/RUSTSEC-0000-0000.md
+++ b/crates/crossbeam-channel/RUSTSEC-0000-0000.md
@@ -1,0 +1,33 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "crossbeam-channel"
+date = "2025-04-08"
+url = "https://github.com/crossbeam-rs/crossbeam/pull/1187"
+categories = ["memory-corruption"]
+keywords = ["race"]
+aliases = ["TROVE-2025-013"]
+
+[versions]
+patched = [">= 0.5.14"]
+unaffected = ["<= 0.5.11"]
+```
+
+# crossbeam-channel: double free on Drop
+
+The internal `Channel` type's `Drop` method has a race
+which could, in some circumstances, lead to a double-free.
+This could result in memory corruption.
+
+Quoting from the
+[upstream description in merge request \#1187](https://github.com/crossbeam-rs/crossbeam/pull/1187#issue-2980761131):
+
+> The problem lies in the fact that `dicard_all_messages` contained two paths that could lead to `head.block` being read but only one of them would swap the value. This meant that `dicard_all_messages` could end up observing a non-null block pointer (and therefore attempting to free it) without setting `head.block` to null. This would then lead to `Channel::drop` making a second attempt at dropping the same pointer.
+
+The bug was introduced while fixing a memory leak, in
+upstream [MR \#1084](https://github.com/crossbeam-rs/crossbeam/pull/1084),
+first published in 0.5.12.
+
+The fix is in
+upstream [MR \#1187](https://github.com/crossbeam-rs/crossbeam/pull/1187)
+and has been published in 0.5.15

--- a/crates/crossbeam-channel/RUSTSEC-0000-0000.md
+++ b/crates/crossbeam-channel/RUSTSEC-0000-0000.md
@@ -9,7 +9,7 @@ keywords = ["race"]
 aliases = ["TROVE-2025-013"]
 
 [versions]
-patched = [">= 0.5.14"]
+patched = [">= 0.5.15"]
 unaffected = ["<= 0.5.11"]
 ```
 


### PR DESCRIPTION
https://github.com/crossbeam-rs/crossbeam/pull/1187

At the Tor Project we've assigned this [TROVE-2025-013](https://gitlab.torproject.org/tpo/core/team/-/wikis/NetworkTeam/TROVE). Our ticket https://gitlab.torproject.org/tpo/core/arti/-/issues/1942

Thanks for your attention.