### PR TITLE
rustsec patch: unmaintained

### DIFF
--- a/crates/patch/RUSTSEC-0000-0000.md
+++ b/crates/patch/RUSTSEC-0000-0000.md
@@ -1,0 +1,30 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "patch"
+date = "2025-04-15"
+url = "https://github.com/uniphil/patch-rs/issues/29"
+references = [
+  "https://github.com/uniphil/patch-rs/issues/23",
+  "https://github.com/uniphil/patch-rs/issues/24",
+  "https://github.com/uniphil/patch-rs/issues/25",
+  "https://github.com/uniphil/patch-rs/issues/27",]
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# patch crate is unmaintained
+
+[patch](https://crates.io/crates/patch) crate owner is unreachable. Last version published was `0.7.0` about 2 years ago.
+Bugs has been reported without being addressed, including panics.
+
+## Recommendation
+
+The project has been forked and fixes applied:
+
+- Repo: [https://github.com/gitpatch-rs/gitpatch](https://github.com/gitpatch-rs/gitpatch)
+- Crate: [https://crates.io/crates/gitpatch](https://crates.io/crates/gitpatch)
+
+`gitpatch` version `0.7.1` is compatible with `patch` version `0.7.0` and should be a direct replacement.


### PR DESCRIPTION
# patch crate is unmaintained

[patch](https://crates.io/crates/patch) crate owner is unreachable. Last version published was `0.7.0` about 2 years ago.
Bugs has been reported without being addressed, including panics.

## Recommendation

The project has been forked and fixes applied:

- Repo: [https://github.com/gitpatch-rs/gitpatch](https://github.com/gitpatch-rs/gitpatch)
- Crate: [https://crates.io/crates/gitpatch](https://crates.io/crates/gitpatch)

`gitpatch` version `0.7.1` is compatible with `patch` version `0.7.0` and should be a direct replacement.

## References

- https://github.com/uniphil/patch-rs/issues/29 (main discussion)
- https://github.com/uniphil/patch-rs/issues/23
- https://github.com/uniphil/patch-rs/issues/24
- https://github.com/uniphil/patch-rs/issues/25
- https://github.com/uniphil/patch-rs/issues/27


