### PR TITLE
arror2 unsound API

### DIFF
--- a/crates/arrow2/RUSTSEC-0000-0000.md
+++ b/crates/arrow2/RUSTSEC-0000-0000.md
@@ -1,0 +1,37 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "arrow2"
+date = "2025-04-24"
+categories = ["unsound"]
+
+
+```
+
+# Arrow2 unsound APIs
+At arrow2-0.18.0
+
+src/compute/sort/row/mod.rs:271
+```
+
+#[derive(Debug)]
+pub struct Rows {
+    /// Underlying row bytes
+    buffer: Box<[u8]>,
+    /// Row `i` has data `&buffer[offsets[i]..offsets[i+1]]`
+    offsets: Box<[usize]>,
+}
+
+impl Rows {
+    pub fn row_unchecked(&self, row: usize) -> Row<'_> {
+        let data = unsafe {
+            let end = *self.offsets.get_unchecked(row + 1);
+            let start = *self.offsets.get_unchecked(row);
+            self.buffer.get_unchecked(start..end)
+        };
+        Row { data }
+    }
+...
+```
+
+Struct Rows and its row_unchecked is public accessible, and row_unchecked does not mark with unsafe. However, it does not have enough check to the row, which might cause memory risks, under a safe API. In Rust, we are not expecting memory risks if merely using safe API.


### PR DESCRIPTION
The arror2 repository looks like is archieved. Not sure where to open the PR/issue on the upstream project.