### PR TITLE
tanton_engine: possible public unsound api

### DIFF
--- a/crates/tanton_engine/RUSTSEC-0000-0000.md
+++ b/crates/tanton_engine/RUSTSEC-0000-0000.md
@@ -1,0 +1,29 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tanton_engine"
+date = "2025-04-24"
+categories = ["memory-corruption"]
+
+[affected.functions]
+"tanton_engine::Stack::offset" = ["1.0.0"]
+"tanton_engine::ThreadStack::get" = ["1.0.0"]
+"tanton_engine::RootMoveList::insert_score_depth" = ["1.0.0"]
+"tanton_engine::RootMoveList::insert_score" = ["1.0.0"]
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# Unsound public API in unmaintained crate
+
+The following functions in the `tanton_engine` crate are unsound due to lack of sufficient boundary
+checks in public API:
+
+- `Stack::offset()`
+- `ThreadStack::get()`
+- `RootMoveList::insert_score_depth()`
+- `RootMoveList::insert_score()`
+
+The tanton_engine crate is no longer maintained, so there are no plans to fix this issue.


### PR DESCRIPTION
The original github repo seems like got deleted, not sure how to create the PR/issue at the upstream project