### PR TITLE
Adjust patched versions in mp3-metadata advisory

### DIFF
--- a/crates/mp3-metadata/RUSTSEC-2025-0027.md
+++ b/crates/mp3-metadata/RUSTSEC-2025-0027.md
@@ -11,7 +11,7 @@ categories = ["denial-of-service"]
 functions = {"mp3_metadata::read_from_slice" = ["< 0.4.0"]}
 
 [versions]
-patched = ["0.4.0"]
+patched = [">= 0.4.0"]
 ```
 
 # Panic in mp3-metadata due to the lack of bounds checking


### PR DESCRIPTION
Fixes #2301. This was my oversight, oops!