### PR TITLE
RUSTSEC-2025-0030: Indicate 'totally-safe-transmute' is a toy.

### DIFF
--- a/crates/totally-safe-transmute/RUSTSEC-2025-0030.md
+++ b/crates/totally-safe-transmute/RUSTSEC-2025-0030.md
@@ -15,6 +15,8 @@ unaffected = []
 
 # totally-safe-transmute allows transmuting any type to any other type in safe Rust
 
-This crate uses a known soundness issue (https://github.com/rust-lang/rust/issues/32670) that will never get fixed. In short, Linux provides a file called `/proc/self/mem` which can be used by a program to modify its own memory. This library modifies an enum variant number by accessing its own memory as a file to effectively transmute a variable.
+This crate is a toy and should never be used.
+
+It showcases a known soundness issue (https://github.com/rust-lang/rust/issues/32670) that will never get fixed. In short, Linux provides a file called `/proc/self/mem` which can be used by a program to modify its own memory. This library modifies an enum variant number by accessing its own memory as a file to effectively transmute a variable.
 
 See also <https://doc.rust-lang.org/std/os/unix/io/index.html#procselfmem-and-similar-os-features>


### PR DESCRIPTION
per #2221. Disclaimer: I'm the author of totally-safe-transmute.

People should know that totally-safe-transmute is a toy that's intentionally doing broken things, so that

a) they don't come after me

b) they know not to expect it to get patched

c) they question why someone is pulling toy code into their dependencies