### PR TITLE
RUSTSEC-2025-0028: Indicate 'cve-rs' is a joke

### DIFF
--- a/crates/cve-rs/RUSTSEC-2025-0028.md
+++ b/crates/cve-rs/RUSTSEC-2025-0028.md
@@ -15,6 +15,8 @@ unaffected = []
 
 # cve-rs introduces memory vulnerabilities in safe Rust
 
-`cve-rs` allows you to introduce common memory vulnerabilities (such as buffer overflows and segfaults) into your Rust program in a memory safe manner.
+This crate is a joke and should never be used.
+
+`cve-rs` provides demonstrations of common memory vulnerabilities (such as buffer overflows and segfaults) implemented completely within safe Rust.
 
 Internally, this crate does not use unsafe code, it instead exploits a soundness bug in rustc: https://github.com/rust-lang/rust/issues/25860


### PR DESCRIPTION
Per #2221, following the footsteps of #2309.

The description is now slightly better - the sarcastic description is funny, but describing the implementation as "memory safe" would be categorically incorrect (I think).