### PR TITLE
add unmaintained advisory for `surf`

### DIFF
--- a/crates/surf/RUSTSEC-0000-0000.md
+++ b/crates/surf/RUSTSEC-0000-0000.md
@@ -1,0 +1,26 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "surf"
+date = "2025-05-17"
+references = ["https://github.com/http-rs/surf/issues/352"]
+informational = "unmaintained"
+categories = []
+
+[versions]
+patched = []
+```
+
+# surf is unmaintained
+
+The developer has indicated that the crate is unmaintained.
+
+The last release is over three years old (from 2021), the crate depends on the
+deprecated `async-std` crate and on a very old version of `rustls` for TLS
+support.
+
+## Possible alternatives
+
+- [reqwest](https://crates.io/crates/reqwest)
+- [ureq](https://crates.io/crates/ureq)
+


### PR DESCRIPTION
Based on discussion in https://github.com/rustsec/advisory-db/issues/1471#issuecomment-2873417980

I listed `reqwest` and `ureq` as possible alternatives, they seem to be the two most-used HTTP client libraries right now.