### PR TITLE
wren_rust unsound and unmaintain

### DIFF
--- a/crates/wren_rust/RUSTSEC-0000-0000.md
+++ b/crates/wren_rust/RUSTSEC-0000-0000.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wren_rust"
+date = "2025-05-06"
+informational = "unsound"
+url = "https://docs.rs/wren_rust"
+categories = ["memory-corruption"]
+
+[affected.functions]
+"wren_rust::macros::_default_realloc" = ["<= 0.1.3"]
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# soundness issue and unmaintained
+`wren_rust::macros::_default_realloc()` lacks sufficient checks to it pointer parameter which passed into `free` and `realloc`
+
+`wren_rust` is unmaintained.


### PR DESCRIPTION
Original repository https://github.com/calviken/wren-rust and user @calviken both seems unavailable. 
Would like to contact to confirm this repository is unmaintained.