### PR TITLE
pingora request smuggling and cache poisoning

### DIFF
--- a/crates/pingora-core/RUSTSEC-0000-0000.md
+++ b/crates/pingora-core/RUSTSEC-0000-0000.md
@@ -4,9 +4,6 @@ id = "RUSTSEC-0000-0000"
 package = "pingora-core"
 date = "2025-05-22"
 url = "https://blog.cloudflare.com/resolving-a-request-smuggling-vulnerability-in-pingora/"
-# Valid categories: "code-execution", "crypto-failure", "denial-of-service", "file-disclosure"
-# "format-injection", "memory-corruption", "memory-exposure", "privilege-escalation"
-categories = []
 keywords = ["request-smuggling", "cache-poisoning"]
 aliases = ["CVE-2025-4366"]
 # cvss = "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:A/VC:H/VI:H/VA:N/SC:L/SI:L/SA:N"

--- a/crates/pingora-core/RUSTSEC-0000-0000.md
+++ b/crates/pingora-core/RUSTSEC-0000-0000.md
@@ -9,7 +9,7 @@ url = "https://blog.cloudflare.com/resolving-a-request-smuggling-vulnerability-i
 categories = []
 keywords = ["request-smuggling", "cache-poisoning"]
 aliases = ["CVE-2025-4366"]
-cvss = "4.0/AV:N/AC:H/AT:P/PR:N/UI:A/VC:H/VI:H/VA:N/SC:L/SI:L/SA:N"
+cvss = "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:A/VC:H/VI:H/VA:N/SC:L/SI:L/SA:N"
 
 [versions]
 patched = [">= 0.5.0"]

--- a/crates/pingora-core/RUSTSEC-0000-0000.md
+++ b/crates/pingora-core/RUSTSEC-0000-0000.md
@@ -8,8 +8,8 @@ url = "https://blog.cloudflare.com/resolving-a-request-smuggling-vulnerability-i
 # "format-injection", "memory-corruption", "memory-exposure", "privilege-escalation"
 categories = []
 keywords = ["request-smuggling", "cache-poisoning"]
-# todo CVE is now live yet
-#cvss = "4.0/AV:N/AC:H/AT:P/PR:N/UI:A/VC:H/VI:H/VA:N/SC:L/SI:L/SA:N"
+aliases = ["CVE-2025-4366"]
+cvss = "4.0/AV:N/AC:H/AT:P/PR:N/UI:A/VC:H/VI:H/VA:N/SC:L/SI:L/SA:N"
 
 [versions]
 patched = [">= 0.5.0"]

--- a/crates/pingora-core/RUSTSEC-0000-0000.md
+++ b/crates/pingora-core/RUSTSEC-0000-0000.md
@@ -9,7 +9,7 @@ url = "https://blog.cloudflare.com/resolving-a-request-smuggling-vulnerability-i
 categories = []
 keywords = ["request-smuggling", "cache-poisoning"]
 aliases = ["CVE-2025-4366"]
-cvss = "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:A/VC:H/VI:H/VA:N/SC:L/SI:L/SA:N"
+# cvss = "CVSS:4.0/AV:N/AC:H/AT:P/PR:N/UI:A/VC:H/VI:H/VA:N/SC:L/SI:L/SA:N"
 
 [versions]
 patched = [">= 0.5.0"]

--- a/crates/pingora-core/RUSTSEC-0000-0000.md
+++ b/crates/pingora-core/RUSTSEC-0000-0000.md
@@ -1,7 +1,7 @@
 ```toml
 [advisory]
 id = "RUSTSEC-0000-0000"
-package = "pingora"
+package = "pingora-core"
 date = "2025-05-22"
 url = "https://blog.cloudflare.com/resolving-a-request-smuggling-vulnerability-in-pingora/"
 # Valid categories: "code-execution", "crypto-failure", "denial-of-service", "file-disclosure"

--- a/crates/pingora-core/RUSTSEC-0000-0000.md
+++ b/crates/pingora-core/RUSTSEC-0000-0000.md
@@ -21,7 +21,7 @@ unaffected = []
 
 Pingora versions prior to 0.5.0 which used the caching functionality in pingora-proxy did not properly drain the downstream request body on cache hits.
 
-This allows an attacker to craft malicious requests which could lead to request smuggling or cache poisoning.
+This allows an attacker to craft malicious HTTP/1.1 requests which could lead to request smuggling or cache poisoning.
 
 This flaw was corrected in commit fda3317ec822678564d641e7cf1c9b77ee3759ff by ensuring that the downstream request body is always drained before a connection can be reused.
 

--- a/crates/pingora-core/RUSTSEC-0000-0000.md
+++ b/crates/pingora-core/RUSTSEC-0000-0000.md
@@ -19,7 +19,7 @@ unaffected = []
 
 # Pingora Request Smuggling and Cache Poisoning
 
-Pingora versions prior to 0.5.0 which used the caching functionality in pingora-cache did not properly drain the downstream request body on cache hits.
+Pingora versions prior to 0.5.0 which used the caching functionality in pingora-proxy did not properly drain the downstream request body on cache hits.
 
 This allows an attacker to craft malicious requests which could lead to request smuggling or cache poisoning.
 

--- a/crates/pingora/RUSTSEC-0000-0000.md
+++ b/crates/pingora/RUSTSEC-0000-0000.md
@@ -8,6 +8,7 @@ url = "https://blog.cloudflare.com/resolving-a-request-smuggling-vulnerability-i
 # "format-injection", "memory-corruption", "memory-exposure", "privilege-escalation"
 categories = []
 keywords = ["request-smuggling", "cache-poisoning"]
+# todo CVE is now live yet
 #cvss = "4.0/AV:N/AC:H/AT:P/PR:N/UI:A/VC:H/VI:H/VA:N/SC:L/SI:L/SA:N"
 
 [versions]

--- a/crates/pingora/RUSTSEC-0000-0000.md
+++ b/crates/pingora/RUSTSEC-0000-0000.md
@@ -1,0 +1,34 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "pingora"
+date = "2025-05-22"
+url = "https://blog.cloudflare.com/resolving-a-request-smuggling-vulnerability-in-pingora/"
+# Valid categories: "code-execution", "crypto-failure", "denial-of-service", "file-disclosure"
+# "format-injection", "memory-corruption", "memory-exposure", "privilege-escalation"
+categories = []
+keywords = ["request-smuggling", "cache-poisoning"]
+#aliases = ["CVE-YYYY-NNNN"]
+#cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+
+[versions]
+patched = [">= 0.5.0"]
+unaffected = []
+
+[affected]
+#arch = ["x86"]
+#os = ["windows"]
+
+#[affected.functions]
+#"crate_name::MyStruct::vulnerable_fn" = [">= 1.3.0, < 1.3.4"]
+```
+
+# Pingora Request Smuggling and Cache Poisoning
+
+Pingora versions prior to 0.5.0 which used the caching functionality in pingora-cache did not properly drain the downstream request body on cache hits.
+
+This allows an attacker to craft malicious requests which could lead to request smuggling or cache poisoning.
+
+This flaw was corrected in commit fda3317ec822678564d641e7cf1c9b77ee3759ff by ensuring that the downstream request body is always drained before a connection can be reused.
+
+See [the blog post](https://blog.cloudflare.com/resolving-a-request-smuggling-vulnerability-in-pingora/) for more information.

--- a/crates/pingora/RUSTSEC-0000-0000.md
+++ b/crates/pingora/RUSTSEC-0000-0000.md
@@ -8,19 +8,12 @@ url = "https://blog.cloudflare.com/resolving-a-request-smuggling-vulnerability-i
 # "format-injection", "memory-corruption", "memory-exposure", "privilege-escalation"
 categories = []
 keywords = ["request-smuggling", "cache-poisoning"]
-#aliases = ["CVE-YYYY-NNNN"]
 #cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
 
 [versions]
 patched = [">= 0.5.0"]
 unaffected = []
 
-[affected]
-#arch = ["x86"]
-#os = ["windows"]
-
-#[affected.functions]
-#"crate_name::MyStruct::vulnerable_fn" = [">= 1.3.0, < 1.3.4"]
 ```
 
 # Pingora Request Smuggling and Cache Poisoning

--- a/crates/pingora/RUSTSEC-0000-0000.md
+++ b/crates/pingora/RUSTSEC-0000-0000.md
@@ -8,7 +8,7 @@ url = "https://blog.cloudflare.com/resolving-a-request-smuggling-vulnerability-i
 # "format-injection", "memory-corruption", "memory-exposure", "privilege-escalation"
 categories = []
 keywords = ["request-smuggling", "cache-poisoning"]
-#cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+#cvss = "4.0/AV:N/AC:H/AT:P/PR:N/UI:A/VC:H/VI:H/VA:N/SC:L/SI:L/SA:N"
 
 [versions]
 patched = [">= 0.5.0"]


### PR DESCRIPTION
Pingora has a request smuggling and cache poisoning vulnerability affecting versions 0.5.0 and older, as documented here: https://blog.cloudflare.com/resolving-a-request-smuggling-vulnerability-in-pingora/