### PR TITLE
Add unmaintained advisory for `serde`

### DIFF
--- a/crates/serde/RUSTSEC-0000-0000.md
+++ b/crates/serde/RUSTSEC-0000-0000.md
@@ -1,0 +1,52 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "serde"
+date = "2024-08-04"
+url = "https://github.com/serde-rs/serde/issues/1723"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# serde crate is effectively unmaintained
+
+The `serde` crate has been effectively unmaintained for a long time: the created PRs are not reviewed
+by the owners/maintainers of the repository, the created issues does not receive any feedback from them.
+Rarely, commits concern infrastructure support, so we can conclude that the author(s) see the new
+issues/PRs, but do not react to them in any way, even after several reminders.
+
+Even PRs, which are trivial fixes that take a maximum of 5 minutes to review, do not receive attention,
+confirmed bugs with a reproduction example and a [confirmed fix], in my opinion, many of them should
+not take more than 30 minutes to review.
+
+## Examples of PRs without any attention from maintainers:
+
+- https://github.com/serde-rs/serde/pull/2295
+- https://github.com/serde-rs/serde/pull/2367
+- https://github.com/serde-rs/serde/pull/2476
+- https://github.com/serde-rs/serde/pull/2513 (usability issue fix)
+- https://github.com/serde-rs/serde/pull/2561 (usability issue fix)
+- https://github.com/serde-rs/serde/pull/2781
+- https://github.com/serde-rs/serde/pull/2929 (changes only in tests)
+- https://github.com/serde-rs/serde/pull/2931 (refactoring, but personally allows me to work on other PRs without being distracted by small details, trivial)
+- https://github.com/serde-rs/serde/pull/2933
+- https://github.com/serde-rs/serde/pull/2936 (refactoring, but personally allows me to work on other PRs without being distracted by small details, trivial)
+- https://github.com/serde-rs/serde/pull/2937 (usability issue fix, trivial)
+
+## Examples of PRs which was reviewed, but then abandoned by mainteiners
+
+- https://github.com/serde-rs/serde/pull/1922
+- https://github.com/serde-rs/serde/pull/2520 (bug fix, maintainers agreed that the fix is correct, but after that it has been ignored for almost 2 years even after several reminders)
+- https://github.com/serde-rs/serde/pull/2922 (usability issue fix)
+
+----------------------------------------------------------------------------------------------------
+
+Given that `serde` is used in most crates in the Rust ecosystem, it is important to keep it maintained:
+respond to community requests in a timely manner and provide feedback for PRs. Unfortunately, current
+maintainers (who is officially unknown for average user of GitHub, because this information is not
+public, or I don't know where to see it) do not acknowledge the problem and do not respond to any
+attempts to offer maintenance assistance, or simply to raise this question in a public space.
+
+[confirmed fix]: https://github.com/serde-rs/serde/pull/2520


### PR DESCRIPTION
Unfortunately, after several attempts to get the `serde` maintenance business off the ground, I am forced to turn to more formal channels. I hope that the Rust community will treat the problem with due attention and perhaps offer some alternatives on how to help the project