### PR TITLE
DFs in slice-ring-buffer

### DIFF
--- a/crates/slice-ring-buffer/RUSTSEC-0000-0000.md
+++ b/crates/slice-ring-buffer/RUSTSEC-0000-0000.md
@@ -1,0 +1,27 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "slice-ring-buffer"
+date = "2025-06-16"
+
+url = "https://github.com/LiquidityC/slice_ring_buffer/issues/12"
+categories = ["memory-corruption"]
+keywords = ["memory-safety", "double-free"]
+
+[affected.functions]
+"slice_ring_buffer::SliceRingBuffer::extend_from_slice" = ["<= 0.3.4"]
+"slice_ring_buffer::SliceRingBuffer::shrink_to_fit" = ["<= 0.3.4"]
+"slice_ring_buffer::SliceRingBuffer::insert" = ["<= 0.3.4"]
+"slice_ring_buffer::IntoIter::clone" = ["<= 0.3.4"]
+
+[versions]
+patched = []
+```
+
+# Four Unique Double-Free Vulnerabilities Triggered via Safe APIs
+
+The crate [`slice-ring-buffer`](https://crates.io/crates/slice-ring-buffer) was developed as a fork of [`slice-deque`](https://crates.io/crates/slice-deque) to continue maintenance and provide security patches, since the latter has been officially unmaintained ([RUSTSEC-2020-0158](https://rustsec.org/advisories/RUSTSEC-2020-0158.html)).
+
+While `slice-ring-buffer` has addressed some previously reported memory safety issues inherited from its fork origin ([RUSTSEC-2021-0047](https://rustsec.org/advisories/RUSTSEC-2021-0047.html)), it still retains multiple unresolved memory corruption vulnerabilities.
+
+Specifically, we have discovered **four new memory safety bugs**, each resulting in **double-free violations** that can occur **when only safe APIs are invoked**. These vulnerabilities correspond to four distinct safe APIs in the crate, each exposing unsound and vulnerable behavior due to incorrect usage of unsafe code internally.

--- a/crates/slice-ring-buffer/RUSTSEC-0000-0000.md
+++ b/crates/slice-ring-buffer/RUSTSEC-0000-0000.md
@@ -18,10 +18,10 @@ keywords = ["memory-safety", "double-free"]
 patched = []
 ```
 
-# Four Unique Double-Free Vulnerabilities Triggered via Safe APIs
+# Four unique double-free vulnerabilities triggered via safe APIs
 
 The crate [`slice-ring-buffer`](https://crates.io/crates/slice-ring-buffer) was developed as a fork of [`slice-deque`](https://crates.io/crates/slice-deque) to continue maintenance and provide security patches, since the latter has been officially unmaintained ([RUSTSEC-2020-0158](https://rustsec.org/advisories/RUSTSEC-2020-0158.html)).
 
 While `slice-ring-buffer` has addressed some previously reported memory safety issues inherited from its fork origin ([RUSTSEC-2021-0047](https://rustsec.org/advisories/RUSTSEC-2021-0047.html)), it still retains multiple unresolved memory corruption vulnerabilities.
 
-Specifically, we have discovered **four new memory safety bugs**, each resulting in **double-free violations** that can occur **when only safe APIs are invoked**. These vulnerabilities correspond to four distinct safe APIs in the crate, each exposing unsound and vulnerable behavior due to incorrect usage of unsafe code internally.
+Specifically, we have discovered four new memory safety bugs, each resulting in double-free violations that can occur when only safe APIs are invoked. These vulnerabilities correspond to four distinct safe APIs in the crate, each exposing unsound and vulnerable behavior due to incorrect usage of unsafe code internally.

--- a/crates/slice-ring-buffer/RUSTSEC-0000-0000.md
+++ b/crates/slice-ring-buffer/RUSTSEC-0000-0000.md
@@ -25,3 +25,5 @@ The crate [`slice-ring-buffer`](https://crates.io/crates/slice-ring-buffer) was 
 While `slice-ring-buffer` has addressed some previously reported memory safety issues inherited from its fork origin ([RUSTSEC-2021-0047](https://rustsec.org/advisories/RUSTSEC-2021-0047.html)), it still retains multiple unresolved memory corruption vulnerabilities.
 
 Specifically, we have discovered four new memory safety bugs, each resulting in double-free violations that can occur when only safe APIs are invoked. These vulnerabilities correspond to four distinct safe APIs in the crate, each exposing unsound and vulnerable behavior due to incorrect usage of unsafe code internally.
+
+Unfortunately, the maintainer doesn't have much availability to resolve these issues so there's no concrete timeline for fixes. Community contributions towards fixing these vulnerabilities would be much appreciated.


### PR DESCRIPTION
Four new memory safety bugs have been discovered in `slice-ring-buffer` (a fork of the unmaintained `slice-deque` crate). 

All four bugs can lead to double-free violations, when only safe APIs are used. No patches for these vulnerabilities have been developed yet. 

We have contacted the maintainers of the crate (@LiquidityC), and they have granted us permission to request a security advisory for these issues.