### PR TITLE
Add advisory for timing variability in curve25519-dalek-ng

### DIFF
--- a/crates/curve25519-dalek-ng/RUSTSEC-0000-0000.md
+++ b/crates/curve25519-dalek-ng/RUSTSEC-0000-0000.md
@@ -19,9 +19,12 @@ patched = []
 Timing variability of any kind is problematic when working with  potentially secret values such as elliptic curve scalars, and such issues can potentially leak private keys and other secrets.
 
 To patch the vulnerability, backports of
-* https://github.com/dalek-cryptography/curve25519-dalek/pull/659, and
-* https://github.com/dalek-cryptography/curve25519-dalek/pull/661
+* [curve25519-dalek/pull/659](https://github.com/dalek-cryptography/curve25519-dalek/pull/659) and [curve25519-dalek/pull/661](https://github.com/dalek-cryptography/curve25519-dalek/pull/661), or the subsequent
+* [curve25519-dalek/pull/662](https://github.com/dalek-cryptography/curve25519-dalek/pull/662), or the subsequent
+* [curve25519-dalek/pull/665](https://github.com/dalek-cryptography/curve25519-dalek/pull/665)
 
-are required for `curve25519-dalek-ng`. For the former, [zkcrypto/curve25519-dalek-ng/pull/25](https://github.com/zkcrypto/curve25519-dalek-ng/pull/25) exists since Aug 14, 2024, but it remains open and unanswered. Because of this, to date, there is no patched version available.
+are required for `curve25519-dalek-ng`.
+
+A patch attempt exists with [zkcrypto/curve25519-dalek-ng/pull/25](https://github.com/zkcrypto/curve25519-dalek-ng/pull/25) since Aug 14, 2024, but it remains open and unanswered. To date, there is no patched version available.
 
 Crates that use `curve25519-dalek-ng`'s `Scalar` for private key operations are also vulnerable. An example of such a crate is [`ed25519-consensus`](https://crates.io/crates/ed25519-consensus).


### PR DESCRIPTION
The timing variability in `curve25519-dalek` that was reported via [RUSTSEC-2024-0344](https://rustsec.org/advisories/RUSTSEC-2024-0344) is also applicable to its fork [`curve25519-dalek-ng`](https://crates.io/crates/curve25519-dalek-ng).

This is relevant because crates such as [`ed255519-consensus`](https://crates.io/crates/ed25519-consensus), which are actively used by the community for secret key operations, depend on the vulnerable `curve25519-dalek-ng`.