### PR TITLE
Advisory for uninitialized read in static-alloc

### DIFF
--- a/crates/static-alloc/RUSTSEC-0000-0000.md
+++ b/crates/static-alloc/RUSTSEC-0000-0000.md
@@ -1,0 +1,38 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "static-alloc"
+date = "2025-07-11"
+url = "https://github.com/197g/static-alloc/issues/81"
+informational = "unsound"
+categories = ["memory-exposure", "memory-corruption"]
+keywords = ["initialization"]
+
+[versions]
+patched = [">= 0.2.6"]
+unaffected = ["<= 0.2.1"]
+
+[affected]
+
+[affected.functions]
+"static_alloc::unsync::MemBump::new" = [">= 0.2.2"]
+```
+
+# Uninitialized read after allocating MemBump
+
+The affected function, `MemBump::new()`, would allocate memory without
+initializing it. Subsequently calling the created value's various `alloc`
+methods would then read and write the start of that memory as a `Cell` which is
+undefined behavior. Instead, it should zero initialize the start of the
+allocated memory.
+
+For instance, some values could violate the internal invariants of the type and
+cause an assertion failure. Nevertheless, no deterministic read is known to
+cause further uninitialized memory to be exposed.
+
+Affected downstream users that can not upgrade are advised to call
+`MemBump::reset` immediately after allocation to manually perform the missing
+write of the counter best-as-possible.
+
+The flaw was corrected in commit d8d6a7d096d3aaafd963b356a8f1bbd8d26fd967 by
+zeroing the Cell at the start of the allocated memory.


### PR DESCRIPTION
Reporting my own crate `static-alloc`.

Upstream issue: https://github.com/197g/static-alloc/issues/81
Upstream fix: https://github.com/197g/static-alloc/pull/82