### PR TITLE
static_cell: report unsoundness in `ConstStaticCell`

### DIFF
--- a/crates/static_cell/RUSTSEC-0000-0000.md
+++ b/crates/static_cell/RUSTSEC-0000-0000.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "static_cell"
+date = "2025-07-17"
+url = "https://github.com/embassy-rs/static-cell/issues/19"
+informational = "unsound"
+categories = ["memory-exposure", "memory-corruption"]
+keywords = ["send", "thread-safety"]
+
+[versions]
+patched = [">= 2.1.1"]
+unaffected = ["<= 2.0.0"]
+
+[affected]
+
+[affected.functions]
+"static_cell::ConstStaticCell::new" = ["= 2.1.0"]
+```
+
+# ConstStaticCell could have been used to pass non-Send values to another thread
+
+`ConstStaticCell<T>` could have been used to pass non-`Send` values to another thread, because `T` was not required to be `Send` while `ConstStaticCell` is `Send`.
+
+This was corrected by introducing a `T: Send` bound.


### PR DESCRIPTION
I am not the owner of `static_cell`, but [the owner has manifested their intention not to file an advisory themself](https://github.com/embassy-rs/static-cell/issues/19#issuecomment-3073545476).