### PR TITLE
wasmtime: `fd_renumber` panic

### DIFF
--- a/crates/wasmtime/RUSTSEC-0000-0000.md
+++ b/crates/wasmtime/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime"
+date = "2025-07-18"
+url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-fm79-3f68-h2fc"
+categories = []
+keywords = []
+aliases = ["CVE-2025-53901", "GHSA-fm79-3f68-h2fc"]
+license = "CC0-1.0"
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:L"
+
+[versions]
+patched = [">= 34.0.2", ">= 33.0.2, < 34.0.0", ">= 24.0.4, < 25.0.0"]
+unaffected = ["< 10.0.0"]
+```
+
+# Host panic with `fd_renumber` WASIp1 function
+
+This is an entry in the RustSec database for the Wasmtime security advisory
+located at
+https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-fm79-3f68-h2fc.
+For more information see the GitHub-hosted security advisory.


### PR DESCRIPTION
Adding an entry for wasmtime CVE-2025-53901 https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-fm79-3f68-h2fc