### PR TITLE
Update RUSTSEC-2024-0436 to include possible alternative

### DIFF
--- a/crates/paste/RUSTSEC-2024-0436.md
+++ b/crates/paste/RUSTSEC-2024-0436.md
@@ -14,3 +14,7 @@ patched = []
 
 The creator of the crate `paste` has stated in the [`README.md`](https://github.com/dtolnay/paste/blob/master/README.md) 
 that this project is not longer maintained as well as archived the repository
+
+## Possible Alternative(s)
+
+- [pastey](https://crates.io/crates/pastey), a fork of paste and is aimed to be a drop-in replacement with additional features for paste crate


### PR DESCRIPTION
Update RUSTSEC-2024-0436 to include pastey as an alternative to paste.