### PR TITLE
`xcb` `connect_to_fd*` constructors unsound

### DIFF
--- a/crates/xcb/RUSTSEC-0000-0000.md
+++ b/crates/xcb/RUSTSEC-0000-0000.md
@@ -4,26 +4,29 @@ id = "RUSTSEC-0000-0000"
 package = "xcb"
 date = "2025-08-05"
 url = "https://github.com/rust-x-bindings/rust-xcb/issues/282"
-references = ["https://github.com/rust-x-bindings/rust-xcb/issues/167"]
+references = [
+  "https://github.com/rust-x-bindings/rust-xcb/issues/167",
+  "https://github.com/rust-x-bindings/rust-xcb/pull/283"
+]
 informational = "unsound"
 
 [versions]
-patched = []
+patched = [">= 1.6.0"]
 
 [affected.functions]
 "xcb::Connection::connect_to_fd" = [">= 1.0.0-beta.0"]
 "xcb::Connection::connect_to_fd_with_extensions" = [">= 1.0.0-beta.0"]
 ```
 
-# Unsoundness in `xcb::Connection::connect_to_fd*` functions
+# `xcb::Connection::connect_to_fd*` functions violate I/O safety
 
 The API of `xcb::Connection` has constructors which allow an arbitrary `RawFd`
 to be used as a socket connection. On either failure of these constructors or
 on the drop of `Connection`, it closes the associated file descriptor. Thus, a
 program which uses an `OwnedFd` (such as a `UnixStream`) as the file descriptor
 can close the file descriptor and continue to attempt using it or close an
-already-closed file descriptor.
+already-closed file descriptor, violating I/O safety.
 
-The functions not being safe was previously documented, although with no
-specifics (https://github.com/rust-x-bindings/rust-xcb/issues/167). No action
-was taken.
+Starting in version 1.6.0, `xcb` provides `Connection::connect_with_fd` and
+`Connection::connect_with_fd_and_extensions` as safe alternatives and
+deprecates the problematic functions.

--- a/crates/xcb/RUSTSEC-0000-0000.md
+++ b/crates/xcb/RUSTSEC-0000-0000.md
@@ -1,0 +1,29 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "xcb"
+date = "2025-08-05"
+url = "https://github.com/rust-x-bindings/rust-xcb/issues/282"
+references = ["https://github.com/rust-x-bindings/rust-xcb/issues/167"]
+informational = "unsound"
+
+[versions]
+patched = []
+
+[affected.functions]
+"xcb::Connection::connect_to_fd" = [">= 1.0.0-beta.0"]
+"xcb::Connection::connect_to_fd_with_extensions" = [">= 1.0.0-beta.0"]
+```
+
+# Unsoundness in `xcb::Connection::connect_to_fd*` functions
+
+The API of `xcb::Connection` has constructors which allow an arbitrary `RawFd`
+to be used as a socket connection. On either failure of these constructors or
+on the drop of `Connection`, it closes the associated file descriptor. Thus, a
+program which uses an `OwnedFd` (such as a `UnixStream`) as the file descriptor
+can close the file descriptor and continue to attempt using it or close an
+already-closed file descriptor.
+
+The functions not being safe was previously documented, although with no
+specifics (https://github.com/rust-x-bindings/rust-xcb/issues/167). No action
+was taken.


### PR DESCRIPTION
Identifies a flaw in `xcb::Connection::connect_to_fd` and `xcb::Connection::connect_to_fd_with_extensions` which allows file descriptors to be used after close and/or double closed. An [issue was raised back in 2022](https://github.com/rust-x-bindings/rust-xcb/issues/167) to mark these functions as unsafe with no additional context. I discovered this unsoundness causing problems working on a different project and [reported my findings to xcb](https://github.com/rust-x-bindings/rust-xcb/issues/282).
It is unclear as to whether the project is maintained, though previously there was an issue raised as to its maintained status (see #653).
I did not put any categories or keywords. I just did not know what to put for them.