### PR TITLE
Fix typo in RUSTSEC-2025-0012

### DIFF
--- a/crates/backoff/RUSTSEC-2025-0012.md
+++ b/crates/backoff/RUSTSEC-2025-0012.md
@@ -11,6 +11,6 @@ patched = []
 unaffected = []
 ```
 
-# `backoff` is unmainted.
+# `backoff` is unmaintained.
 
 The [backoff](https://crates.io/crates/backoff) crate is no longer actively maintained. For exponential backoffs/retrying, you can use the [backon](https://crates.io/crates/backon) crate.


### PR DESCRIPTION
`unmainted` -> `unmaintained`