### PR TITLE
The API ArrayQueue::push_front is not panic-safe

### DIFF
--- a/crates/array-queue/RUSTSEC-0000-0000.md
+++ b/crates/array-queue/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "array-queue"
+date = "2025-08-14"
+
+url = "https://github.com/raviqqe/array-queue/issues/3"
+categories = ["memory-corruption"]
+keywords = ["memory-safety", "panic-safety", "uninitialized-memory"]
+
+[affected.functions]
+"array_queue::ArrayQueue::push_front" = [">= 0.3.0, <= 0.3.3"]
+
+[versions]
+patched = []
+unaffected = ["< 0.3.0"]
+```
+
+# ArrayQueue::push_front is not panic-safe
+
+The safe API `array_queue::ArrayQueue::push_front` can lead to deallocating uninitialized memory if a panic occurs while invoking the `clone` method on the passed argument.
+
+Specifically, `push_front` receives an argument that is intended to be cloned and pushed, whose type implements the `Clone` trait. Furthermore, the method updates the queue's `start` index before initializing the slot for the newly pushed element. User-defined implementations of `Clone` may include a `clone` method that can panic. If such a panic occurs during initialization, the structure is left with an advanced `start` index pointing to an uninitialized slot. When `ArrayQueue` is later dropped, its destructor treats that slot as initialized and attempts to drop it, resulting in an attempt to free uninitialized memory.


### PR DESCRIPTION
The safe API `array_queue::ArrayQueue::push_front` of the crate `array-queue`, can lead to deallocating uninitialized memory if a panic occurs while invoking the `clone` method on the passed argument.

This issue was reported to the crate's GitHub repository ([issue #3](https://github.com/raviqqe/array-queue/issues/3)) 30 days ago, but there has been no response from the maintainers as of yet.