### PR TITLE
Multiple memory corruption vulnerabilities in arenavec

### DIFF
--- a/crates/arenavec/RUSTSEC-0000-0000.md
+++ b/crates/arenavec/RUSTSEC-0000-0000.md
@@ -4,7 +4,9 @@ id = "RUSTSEC-0000-0000"
 package = "arenavec"
 date = "2025-08-14"
 
-url = ["https://github.com/ibabushkin/arenavec/issues/4", "https://github.com/ibabushkin/arenavec/issues/5", "https://github.com/ibabushkin/arenavec/issues/6"]
+url = "https://github.com/ibabushkin/arenavec/issues/4"
+references = ["https://github.com/ibabushkin/arenavec/issues/5", "https://github.com/ibabushkin/arenavec/issues/6"]
+
 categories = ["memory-corruption"]
 keywords = ["memory-safety", "buffer-overflow", "double-free", "raw-pointer"]
 

--- a/crates/arenavec/RUSTSEC-0000-0000.md
+++ b/crates/arenavec/RUSTSEC-0000-0000.md
@@ -1,0 +1,29 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "arenavec"
+date = "2025-08-14"
+
+url = ["https://github.com/ibabushkin/arenavec/issues/4", "https://github.com/ibabushkin/arenavec/issues/5", "https://github.com/ibabushkin/arenavec/issues/6"]
+categories = ["memory-corruption"]
+keywords = ["memory-safety", "buffer-overflow", "double-free", "raw-pointer"]
+
+[affected.functions]
+"arenavec::common::AllocHandle::allocate" = ["<= 0.1.1"]
+"arenavec::common::AllocHandle::allocate_or_extend" = ["<= 0.1.1"]
+"arenavec::common::allocate_inner" = ["<= 0.1.1"]
+"arenavec::common::SliceVec::split_off" = ["<= 0.1.1"]
+
+[versions]
+patched = []
+```
+
+# Multiple memory corruption vulnerabilities in safe APIs
+
+The crate has the following vulnerabilities:
+
+- The public trait `arenavec::common::AllocHandle` allows the return of raw pointers through its methods `allocate` and `allocate_or_extend`. However, the trait is not marked as unsafe, meaning users of the crate may implement it under the assumption that the library safely handles the returned raw pointers. These raw pointers can later be dereferenced within safe APIs of the crate-such as `arenavec::common::SliceVec::push`-potentially leading to arbitrary memory access.
+
+- The safe API `arenavec::common::SliceVec::reserve` can reach the private function `arenavec::common::allocate_inner`. Incorrect behavior in `allocate_inner` may result in a `SliceVec` with an increased capacity, even though the underlying memory has not actually been expanded. This mismatch between `SliceVec.capacity` and the actual reserved memory can lead to a heap buffer overflow.
+
+- The safe API `arenavec::common::SliceVec::split_off` can duplicate the ownership of the elements in `self` (of type `SliceVec`) if they implement the `Drop` trait. Specifically, when `at == 0`, the method returns a new `SliceVec` with the same length as `self`. Since both `self` and the returned object point to the same heap memory, dropping one will deallocate the shared memory. When the other is subsequently dropped, it will attempt to free the same memory again, resulting in a double free violation.


### PR DESCRIPTION
Multiple memory corruption vulnerabilities have been discovered in the crate `arenavec`. These include arbitrary memory access due to user-defined implementations of safe traits that return raw pointers, as well as heap buffer overflows and double free violations.

The issues were reported to the crate's GitHub repository ([issue #4](https://github.com/ibabushkin/arenavec/issues/4), [issue #5](https://github.com/ibabushkin/arenavec/issues/5), [issue #6](https://github.com/ibabushkin/arenavec/issues/6)) 12 days ago, but there has been no response from the maintainers as of yet.