### PR TITLE
Buffer overflow due to user-defined implementations of scratchpad::Tracking

### DIFF
--- a/crates/scratchpad/RUSTSEC-0000-0000.md
+++ b/crates/scratchpad/RUSTSEC-0000-0000.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-0000-0000"
 package = "scratchpad"
 date = "2025-08-14"
 
-url = ["https://github.com/okready/scratchpad/issues/2"]
+url = "https://github.com/okready/scratchpad/issues/2"
 categories = ["memory-corruption"]
 keywords = ["memory-safety", "buffer-overflow", "raw-pointer"]
 

--- a/crates/scratchpad/RUSTSEC-0000-0000.md
+++ b/crates/scratchpad/RUSTSEC-0000-0000.md
@@ -22,4 +22,4 @@ The `get` and `set` methods of the public trait `scratchpad::Tracking` interact 
 
 This becomes problematic because even safe implementations of `get` and `set`-written without using any unsafe code-can still result in ill-formed raw pointers. These pointers may later be dereferenced within safe APIs of the crate (e.g., `marker::MarkerBack::allocate_slice_copy`), potentially leading to arbitrary memory access or heap buffer overflows.
 
-According to the [penultimate commit](https://github.com/okready/scratchpad/commit/957dee1a3902f48600b06910e8e0b1d5ee7dab83), the crate is in maintenance mode awaiting a cleanup that will reduce the area of unsafe code.
+According to the [penultimate commit](https://github.com/okready/scratchpad/commit/957dee1a3902f48600b06910e8e0b1d5ee7dab83), the crate is in maintenance mode awaiting a cleanup that will reduce the area of unsafe code. Note that the last commits to the repository are from 4 years ago.

--- a/crates/scratchpad/RUSTSEC-0000-0000.md
+++ b/crates/scratchpad/RUSTSEC-0000-0000.md
@@ -21,3 +21,5 @@ patched = []
 The `get` and `set` methods of the public trait `scratchpad::Tracking` interact with unsafe code regions in the crate, and they influence the computation of addresses returned as raw pointers. However, the trait itself is not marked as unsafe, meaning users may provide custom implementations under the assumption that the crate upholds all safety guarantees.
 
 This becomes problematic because even safe implementations of `get` and `set`-written without using any unsafe code-can still result in ill-formed raw pointers. These pointers may later be dereferenced within safe APIs of the crate (e.g., `marker::MarkerBack::allocate_slice_copy`), potentially leading to arbitrary memory access or heap buffer overflows.
+
+According to the [penultimate commit](https://github.com/okready/scratchpad/commit/957dee1a3902f48600b06910e8e0b1d5ee7dab83), the crate is in maintenance mode awaiting a cleanup that will reduce the area of unsafe code.

--- a/crates/scratchpad/RUSTSEC-0000-0000.md
+++ b/crates/scratchpad/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "scratchpad"
+date = "2025-08-14"
+
+url = ["https://github.com/okready/scratchpad/issues/2"]
+categories = ["memory-corruption"]
+keywords = ["memory-safety", "buffer-overflow", "raw-pointer"]
+
+[affected.functions]
+"scratchpad::Tracking::get" = ["<= 1.3.1"]
+"scratchpad::Tracking::set" = ["<= 1.3.1"]
+
+[versions]
+patched = []
+```
+
+# User-defined implementations of the safe trait scratchpad::Tracking can cause heap buffer overflows
+
+The `get` and `set` methods of the public trait `scratchpad::Tracking` interact with unsafe code regions in the crate, and they influence the computation of addresses returned as raw pointers. However, the trait itself is not marked as unsafe, meaning users may provide custom implementations under the assumption that the crate upholds all safety guarantees.
+
+This becomes problematic because even safe implementations of `get` and `set`-written without using any unsafe code-can still result in ill-formed raw pointers. These pointers may later be dereferenced within safe APIs of the crate (e.g., `marker::MarkerBack::allocate_slice_copy`), potentially leading to arbitrary memory access or heap buffer overflows.


### PR DESCRIPTION
The public trait `scratchpad::Tracking` in the `scratchpad` crate is not marked as unsafe, even though its methods interact with unsafe code within the crate and influence the computation of raw pointers. As a result, even safe user-defined implementations of the trait—written without using any unsafe code—can still result in ill-formed raw pointers being dereferenced, leading to heap buffer overflows.

This issue was reported to the crate's GitHub repository ([issue #2](https://github.com/okready/scratchpad/issues/2)) 11 days ago, but there has been no response from the maintainers as of yet.