### PR TITLE
IdMap::from_iter may lead to uninitialized memory being freed on drop

### DIFF
--- a/crates/id-map/RUSTSEC-0000-0000.md
+++ b/crates/id-map/RUSTSEC-0000-0000.md
@@ -22,4 +22,8 @@ Due to a flaw in the constructor `id_map::IdMap::from_iter`, ill-formed objects 
 
 In such cases, when the resulting `IdMap` is dropped, its destructor incorrectly assumes that `values` contains `ids.len() == values.capacity()` initialized elements and attempts to iterate over and drop them. This leads to dereferencing and attempting to free uninitialized memory, resulting in undefined behavior and potential segmentation faults.
 
-The bug was fixed in commit `fab6922`, and all unsafe code was removed from the crate. Note that better-optimized alternatives are [slab](https://crates.io/crates/slab) and [slotmap](https://crates.io/crates/slotmap).
+The bug was fixed in commit `fab6922`, and all unsafe code was removed from the crate.
+
+Note that the maintainer recommends using the following alternatives:
+- [slab](https://crates.io/crates/slab)
+- [slotmap](https://crates.io/crates/slotmap)


### PR DESCRIPTION
The constructor `IdMap::from_iter` in the crate `id-map` can create objects where the amount of actually initialized memory is less than what can be accessed through the resulting data structure. This can lead to an attempt to free uninitialized memory during the dropping of such objects, resulting in undefined behavior and potential segmentation faults.

This issue was reported to the crate's GitHub repository ([issue #4](https://github.com/andrewhickman/id-map/issues/4)) 10 days ago, but there has been no response from the maintainers as of yet.