### PR TITLE
Add `io-safety` keyword to `xcb`

### DIFF
--- a/crates/xcb/RUSTSEC-2025-0051.md
+++ b/crates/xcb/RUSTSEC-2025-0051.md
@@ -9,6 +9,7 @@ references = [
   "https://github.com/rust-x-bindings/rust-xcb/pull/283"
 ]
 informational = "unsound"
+keywords = [ "io-safety" ]
 
 [versions]
 patched = [">= 1.6.0"]


### PR DESCRIPTION
Thanks for getting back quickly to my response. Honestly was not expecting the quick turn-around.

Since it being merged makes issues like these within RustSec's purview, I would like to add `io-safety` as a free-form keyword, hopefully to set a precedent that I/O safety violations are problems which should be reported.