### PR TITLE
Remove unaffected from RUSTSEC-2020-0095.md

### DIFF
--- a/crates/difference/RUSTSEC-2020-0095.md
+++ b/crates/difference/RUSTSEC-2020-0095.md
@@ -8,7 +8,6 @@ informational = "unmaintained"
 
 [versions]
 patched = []
-unaffected = ["> 2.0.0"]
 ```
 
 # difference is unmaintained


### PR DESCRIPTION
There are no releases that are maintained https://crates.io/crates/difference

https://github.com/rustsec/advisory-db/edit/osv/crates/RUSTSEC-2020-0095.json says it is fixed in 2.0.1