### PR TITLE
add CVE-2025-58160 details to tracing-subscriber

### DIFF
--- a/crates/tracing-subscriber/RUSTSEC-0000-0000.md
+++ b/crates/tracing-subscriber/RUSTSEC-0000-0000.md
@@ -5,7 +5,7 @@ package = "tracing-subscriber"
 date = "2025-08-29"
 url = "https://github.com/advisories/GHSA-xwfj-jgwm-7wp5"
 categories = ["format-injection"]
-aliases = ["CVE-2025-58160"]
+aliases = ["CVE-2025-58160", "GHSA-xwfj-jgwm-7wp5"]
 
 [versions]
 patched = [">=0.3.20"]


### PR DESCRIPTION
advisory-db is currently missing [this item](https://github.com/advisories/GHSA-xwfj-jgwm-7wp5) from the GitHub Advisory Database, which was reported last week. This vulnerability seems to have been added directly to the GitHub Advisory Database by the tokio-rs team, so it was missed here.

Fixes #2375.