### PR TITLE
Fix candidate advisory ID

### DIFF
--- a/crates/matrix-sdk-base/RUSTSEC-0000-0000.md
+++ b/crates/matrix-sdk-base/RUSTSEC-0000-0000.md
@@ -1,6 +1,6 @@
 ```toml
 [advisory]
-id = "RUSTSEC-2025-0000"
+id = "RUSTSEC-0000-0000"
 package = "matrix-sdk-base"
 date = "2025-09-11"
 url = "https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-qhj8-q5r6-8q6j"
@@ -13,7 +13,7 @@ aliases = ["CVE-2025-59047", "GHSA-qhj8-q5r6-8q6j"]
 patched = [">= 0.14.1"]
 ```
 
-# matrix-sdk-base: Panic in the `RoomMember::normalized_power_level()` method 
+# matrix-sdk-base: Panic in the `RoomMember::normalized_power_level()` method
 
 In matrix-sdk-base before 0.14.1, calling the
 `RoomMember::normalized_power_level()` method can cause a panic if a room member


### PR DESCRIPTION
#2401 added an advisory with ID RUSTSEC-2025-0000 (instead of the customary RUSTSEC-0000-0000) which seems to have broken the ID assignment workflow. Let's try to fix it up before we address the root cause.