### PR TITLE
Add advisory (deprecated) for `google-apis-common`

### DIFF
--- a/crates/google-apis-common/RUSTSEC-0000-0000.md
+++ b/crates/google-apis-common/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "google-apis-common"
+date = "2025-09-09"
+url = "https://crates.io/crates/google-apis-common"
+informational = "unmaintained"
+references = ["https://github.com/Byron/google-apis-rs/discussions/559"]
+
+[versions]
+patched = []
+```
+
+# The `google-apis-rs` project is now unmaintained
+
+Instead, please start using and migrate to the [official Google Rust bindings](https://github.com/googleapis/google-cloud-rust).


### PR DESCRIPTION
All directly dependent crates are superseded by `google-cloud-rust`

Please note that I am not really knowing what I am doing, so apologies if the format is wrong or some fields are missing.
The PR is based on [this answer](https://github.com/rustsec/advisory-db/discussions/2400#discussioncomment-14373422) I received earlier.

Last but not least, I am actually deprecating my `google-*` crates with the goal of stopping maintenance once it's clear this isn't harmful
to the ecosystem. However, since I had to pick, this sets the crates to `unmaintained` right away.

I am definitely open for changes if there are options that better reflect what I trying to do.

Some more context is here: https://github.com/Byron/google-apis-rs/discussions/559
