### PR TITLE
mark `martin-mbtiles` as unmaintained due to being renamed to `mbtiles`

### DIFF
--- a/crates/martin-mbtiles/RUSTSEC-0000-0000.md
+++ b/crates/martin-mbtiles/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "martin-mbtiles"
+date = "2023-10-30"
+informational = "unmaintained"
+url = "https://github.com/maplibre/martin/commit/8a8814e7cc97d44f4d194586b3e9deb904c99488"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# `martin-mbtiles` has been renamed to `mbtiles`
+
+Please use the `mbtiles` crate going forward.


### PR DESCRIPTION
I am one of the maintainers of `mbtiles`, so no issue nessesary.