### PR TITLE
fix(fuser): Set correct patched version

### DIFF
--- a/crates/fuser/RUSTSEC-2021-0154.md
+++ b/crates/fuser/RUSTSEC-2021-0154.md
@@ -14,7 +14,7 @@ license = "CC0-1.0"
 "fuser::Session::new" = [">= 0.5.0"]
 
 [versions]
-patched = [">= 1.2.0"]
+patched = [">= 0.16.0"]
 ```
 
 # Uninitalized memory read & leak caused by fuser crate


### PR DESCRIPTION
The patched version was incorrectly set to 1.2.0 where the patch actually landed in 0.16.0