### PR TITLE
Add advisory for pingora-core MadeYouReset http/2 vuln

### DIFF
--- a/crates/pingora-core/RUSTSEC-0000-0000.md
+++ b/crates/pingora-core/RUSTSEC-0000-0000.md
@@ -8,7 +8,7 @@ references = ["https://nvd.nist.gov/vuln/detail/CVE-2025-8671", "https://blog.cl
 categories = ["denial-of-service"]
 keywords = ["http", "http2", "h2"]
 aliases = ["CVE-2025-8671"]
-cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:L"
+# cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:L"
 
 [versions]
 patched = [">= 0.6.0"]

--- a/crates/pingora-core/RUSTSEC-0000-0000.md
+++ b/crates/pingora-core/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "pingora-core"
+date = "2025-09-17"
+url = "https://github.com/cloudflare/pingora/security/advisories/GHSA-393w-9x6h-8gc7"
+references = ["https://nvd.nist.gov/vuln/detail/CVE-2025-8671", "https://blog.cloudflare.com/madeyoureset-an-http-2-vulnerability-thwarted-by-rapid-reset-mitigations/"]
+categories = ["denial-of-service"]
+keywords = ["http", "http2", "h2"]
+aliases = ["CVE-2025-8671"]
+cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:L"
+
+[versions]
+patched = [">= 0.6.0"]
+```
+
+# Pingora MadeYouReset HTTP/2 vulnerability
+
+Pingora deployments using versions prior to 0.6.0 that include HTTP/2 server support may be affected by the vulnerability described in CVE-2025-8671. Under certain conditions, Pingora applications may allocate buffers before the HTTP/2 reset and resulting stream cancellation is processed by the server. Repeated resets can force excessive memory consumption and lead to denial-of-service.
+
+On affected versions, malicious clients could trigger unusually high memory consumption, which may result in service instability or process termination.
+
+This issue is addressed by ensuring Pingora uses patched versions of HTTP/2 dependencies that include reset-handling safeguards to release connection resources before excessive memory buildup. Users are requested to upgrade to versions >= 0.6.0, which incorporates the required fixes.


### PR DESCRIPTION
Adding advisory for pre 0.6.0 pingora-core versions specific to [MadeYouReset](https://nvd.nist.gov/vuln/detail/CVE-2025-8671) as a potential denial-of-service attack.

More details in the [GitHub advisory](https://github.com/cloudflare/pingora/security/advisories/GHSA-393w-9x6h-8gc7) and note in the [CF blog](https://blog.cloudflare.com/madeyoureset-an-http-2-vulnerability-thwarted-by-rapid-reset-mitigations/), as well as the [general CVE](https://nvd.nist.gov/vuln/detail/CVE-2025-8671).