### PR TITLE
fix: RUSTSEC-2025-0073 (`alloy-dyn-abi`), update to description and credit

### DIFF
--- a/crates/alloy-dyn-abi/RUSTSEC-2025-0073.md
+++ b/crates/alloy-dyn-abi/RUSTSEC-2025-0073.md
@@ -26,4 +26,4 @@ The vulnerability was patched by adding a check to ensure the element is not emp
 
 There is no known workaround that mitigates the vulnerability. Upgrading to a patched version is the recommended course of action.
 
-Reported by [Christian Reitter](https://github.com/cr-tk) & [Zeke Mostov](https://github.com/emostov) from from [Turnkey](https://www.turnkey.com/).
+Reported by [Christian Reitter](https://github.com/cr-tk) & [Zeke Mostov](https://github.com/emostov) from [Turnkey](https://www.turnkey.com/).


### PR DESCRIPTION
If possible I would like update the description to be more accurate. The update to the text was decided after aligning with the reporter.

I have updated the description on: https://github.com/alloy-rs/core/security/advisories/GHSA-pgp9-98jm-wwq2

The previous PR for context: https://github.com/rustsec/advisory-db/pull/2421

I hope this is not too much trouble.