### PR TITLE
 Mark all rust-unic crates as unmaintained 

### DIFF
--- a/crates/unic-bidi/RUSTSEC-0000-0000.md
+++ b/crates/unic-bidi/RUSTSEC-0000-0000.md
@@ -15,5 +15,6 @@ unaffected = []
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
 
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)
+## Recommended alternatives
+
+- [`unicode-bidi`](https://crates.io/crates/unicode-bidi)

--- a/crates/unic-char-basics/RUSTSEC-0000-0000.md
+++ b/crates/unic-char-basics/RUSTSEC-0000-0000.md
@@ -14,6 +14,3 @@ unaffected = []
 # `unic-char-basics` is unmaintained
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
-
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)

--- a/crates/unic-char-property/RUSTSEC-0000-0000.md
+++ b/crates/unic-char-property/RUSTSEC-0000-0000.md
@@ -15,5 +15,6 @@ unaffected = []
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
 
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)
+## Recommended alternatives
+
+- [`icu_properties`](https://crates.io/crates/icu_properties)

--- a/crates/unic-char-range/RUSTSEC-0000-0000.md
+++ b/crates/unic-char-range/RUSTSEC-0000-0000.md
@@ -14,6 +14,3 @@ unaffected = []
 # `unic-char-range` is unmaintained
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
-
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)

--- a/crates/unic-char/RUSTSEC-0000-0000.md
+++ b/crates/unic-char/RUSTSEC-0000-0000.md
@@ -15,5 +15,6 @@ unaffected = []
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
 
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)
+## Recommended alternatives
+
+- [`icu_properties`](https://crates.io/crates/icu_properties)

--- a/crates/unic-cli/RUSTSEC-0000-0000.md
+++ b/crates/unic-cli/RUSTSEC-0000-0000.md
@@ -14,6 +14,3 @@ unaffected = []
 # `unic-cli` is unmaintained
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
-
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)

--- a/crates/unic-common/RUSTSEC-0000-0000.md
+++ b/crates/unic-common/RUSTSEC-0000-0000.md
@@ -14,6 +14,3 @@ unaffected = []
 # `unic-common` is unmaintained
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
-
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)

--- a/crates/unic-emoji-char/RUSTSEC-0000-0000.md
+++ b/crates/unic-emoji-char/RUSTSEC-0000-0000.md
@@ -15,5 +15,6 @@ unaffected = []
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
 
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)
+## Recommended alternatives
+
+- [`icu_properties`](https://crates.io/crates/icu_properties)

--- a/crates/unic-emoji/RUSTSEC-0000-0000.md
+++ b/crates/unic-emoji/RUSTSEC-0000-0000.md
@@ -15,5 +15,6 @@ unaffected = []
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
 
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)
+## Recommended alternatives
+
+- [`icu_properties`](https://crates.io/crates/icu_properties)

--- a/crates/unic-idna-mapping/RUSTSEC-0000-0000.md
+++ b/crates/unic-idna-mapping/RUSTSEC-0000-0000.md
@@ -15,5 +15,6 @@ unaffected = []
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
 
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)
+## Recommended alternatives
+
+- [`idna`](https://crates.io/crates/idna)

--- a/crates/unic-idna-punycode/RUSTSEC-0000-0000.md
+++ b/crates/unic-idna-punycode/RUSTSEC-0000-0000.md
@@ -15,5 +15,6 @@ unaffected = []
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
 
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)
+## Recommended alternatives
+
+- [`idna`](https://crates.io/crates/idna)

--- a/crates/unic-idna/RUSTSEC-0000-0000.md
+++ b/crates/unic-idna/RUSTSEC-0000-0000.md
@@ -15,5 +15,6 @@ unaffected = []
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
 
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)
+## Recommended alternatives
+
+- [`idna`](https://crates.io/crates/idna)

--- a/crates/unic-normal/RUSTSEC-0000-0000.md
+++ b/crates/unic-normal/RUSTSEC-0000-0000.md
@@ -15,5 +15,7 @@ unaffected = []
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
 
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)
+## Recommended alternatives
+
+- [`icu_normalizer`](https://crates.io/crates/icu_normalizer)
+- [`unicode-normalization`](https://crates.io/crates/unicode-normalization)

--- a/crates/unic-segment/RUSTSEC-0000-0000.md
+++ b/crates/unic-segment/RUSTSEC-0000-0000.md
@@ -15,5 +15,7 @@ unaffected = []
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
 
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)
+## Recommended alternatives
+
+- [`icu_segmenter`](https://crates.io/crates/icu_segmenter)
+- [`unicode-segmentation`](https://crates.io/crates/unicode-segmentation)

--- a/crates/unic-ucd-age/RUSTSEC-0000-0000.md
+++ b/crates/unic-ucd-age/RUSTSEC-0000-0000.md
@@ -14,6 +14,3 @@ unaffected = []
 # `unic-ucd-age` is unmaintained
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
-
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)

--- a/crates/unic-ucd-bidi/RUSTSEC-0000-0000.md
+++ b/crates/unic-ucd-bidi/RUSTSEC-0000-0000.md
@@ -15,5 +15,6 @@ unaffected = []
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
 
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)
+## Recommended alternatives
+
+- [`icu_properties`](https://crates.io/crates/icu_properties)

--- a/crates/unic-ucd-block/RUSTSEC-0000-0000.md
+++ b/crates/unic-ucd-block/RUSTSEC-0000-0000.md
@@ -14,6 +14,3 @@ unaffected = []
 # `unic-ucd-block` is unmaintained
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
-
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)

--- a/crates/unic-ucd-case/RUSTSEC-0000-0000.md
+++ b/crates/unic-ucd-case/RUSTSEC-0000-0000.md
@@ -15,5 +15,6 @@ unaffected = []
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
 
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)
+## Recommended alternatives
+
+- [`icu_properties`](https://crates.io/crates/icu_properties)

--- a/crates/unic-ucd-category/RUSTSEC-0000-0000.md
+++ b/crates/unic-ucd-category/RUSTSEC-0000-0000.md
@@ -15,5 +15,6 @@ unaffected = []
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
 
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)
+## Recommended alternatives
+
+- [`icu_properties`](https://crates.io/crates/icu_properties)

--- a/crates/unic-ucd-common/RUSTSEC-0000-0000.md
+++ b/crates/unic-ucd-common/RUSTSEC-0000-0000.md
@@ -15,5 +15,6 @@ unaffected = []
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
 
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)
+## Recommended alternatives
+
+- [`icu_properties`](https://crates.io/crates/icu_properties)

--- a/crates/unic-ucd-core/RUSTSEC-0000-0000.md
+++ b/crates/unic-ucd-core/RUSTSEC-0000-0000.md
@@ -14,6 +14,3 @@ unaffected = []
 # `unic-ucd-core` is unmaintained
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
-
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)

--- a/crates/unic-ucd-hangul/RUSTSEC-0000-0000.md
+++ b/crates/unic-ucd-hangul/RUSTSEC-0000-0000.md
@@ -15,5 +15,7 @@ unaffected = []
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
 
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)
+## Recommended alternatives
+
+- [`icu_normalizer`](https://crates.io/crates/icu_normalizer)
+- [`unicode-normalization`](https://crates.io/crates/unicode-normalization)

--- a/crates/unic-ucd-ident/RUSTSEC-0000-0000.md
+++ b/crates/unic-ucd-ident/RUSTSEC-0000-0000.md
@@ -15,5 +15,7 @@ unaffected = []
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
 
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)
+## Recommended alternatives
+
+- [`icu_properties`](https://crates.io/crates/icu_properties)
+- [`unicode-ident`](https://crates.io/crates/unicode-ident)

--- a/crates/unic-ucd-name/RUSTSEC-0000-0000.md
+++ b/crates/unic-ucd-name/RUSTSEC-0000-0000.md
@@ -14,6 +14,3 @@ unaffected = []
 # `unic-ucd-name` is unmaintained
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
-
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)

--- a/crates/unic-ucd-name_aliases/RUSTSEC-0000-0000.md
+++ b/crates/unic-ucd-name_aliases/RUSTSEC-0000-0000.md
@@ -14,6 +14,3 @@ unaffected = []
 # `unic-ucd-name_aliases` is unmaintained
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
-
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)

--- a/crates/unic-ucd-normal/RUSTSEC-0000-0000.md
+++ b/crates/unic-ucd-normal/RUSTSEC-0000-0000.md
@@ -15,5 +15,6 @@ unaffected = []
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
 
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)
+## Recommended alternatives
+
+- [`icu_normalizer`](https://crates.io/crates/icu_normalizer)

--- a/crates/unic-ucd-segment/RUSTSEC-0000-0000.md
+++ b/crates/unic-ucd-segment/RUSTSEC-0000-0000.md
@@ -15,5 +15,6 @@ unaffected = []
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
 
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)
+## Recommended alternatives
+
+- [`icu_properties`](https://crates.io/crates/icu_properties)

--- a/crates/unic-ucd-version/RUSTSEC-0000-0000.md
+++ b/crates/unic-ucd-version/RUSTSEC-0000-0000.md
@@ -14,6 +14,3 @@ unaffected = []
 # `unic-ucd-version` is unmaintained
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
-
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)

--- a/crates/unic-ucd/RUSTSEC-0000-0000.md
+++ b/crates/unic-ucd/RUSTSEC-0000-0000.md
@@ -15,5 +15,6 @@ unaffected = []
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
 
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)
+## Recommended alternatives
+
+- [`icu_properties`](https://crates.io/crates/icu_properties)

--- a/crates/unic-utils/RUSTSEC-0000-0000.md
+++ b/crates/unic-utils/RUSTSEC-0000-0000.md
@@ -14,6 +14,3 @@ unaffected = []
 # `unic-utils` is unmaintained
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
-
-Maintained alternatives:
-- [`icu`](https://crates.io/crates/icu)

--- a/crates/unic/RUSTSEC-0000-0000.md
+++ b/crates/unic/RUSTSEC-0000-0000.md
@@ -15,5 +15,8 @@ unaffected = []
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
 
-Maintained alternatives:
+## Recommended alternatives
+
 - [`icu`](https://crates.io/crates/icu)
+- [`idna`](https://crates.io/crates/idna)
+- [`unicode-bidi`](https://crates.io/crates/unicode-bidi)


### PR DESCRIPTION
This marks these crates as unmaintained as discussed in #2414:

```
unic
unic-bidi
unic-char
unic-char-basics
unic-char-property
unic-char-range
unic-cli
unic-common
unic-emoji
unic-emoji-char
unic-idna
unic-idna-mapping
unic-idna-punycode
unic-normal
unic-segment
unic-ucd
unic-ucd-age
unic-ucd-bidi
unic-ucd-block
unic-ucd-case
unic-ucd-category
unic-ucd-common
unic-ucd-core
unic-ucd-hangul
unic-ucd-ident
unic-ucd-name
unic-ucd-name_aliases
unic-ucd-normal
unic-ucd-segment
unic-ucd-version
unic-utils
```

[unic-ucd-utils](https://lib.rs/crates/unic-ucd-utils) was already yanked so I ignored it.
[unic-ucd-core](https://lib.rs/crates/unic-ucd-core) and [unic-utils](https://lib.rs/crates/unic-utils) haven't been updated 8 years and weren't even part of the code on GitHub anymore.

I suggested https://crates.io/crates/icu as an alternative, but I am open to suggestions. @hsivonen 