### PR TITLE
ncurses is unsound and unmaintained

### DIFF
--- a/crates/ncurses/RUSTSEC-0000-0000.md
+++ b/crates/ncurses/RUSTSEC-0000-0000.md
@@ -1,0 +1,33 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "ncurses"
+date = "2025-10-21"
+url = "https://github.com/RustSec/advisory-db/pull/2427"
+informational = "unsound"
+categories = ["memory-exposure"]
+keywords = ["memory-safety", "soundness"]
+
+[affected.functions]
+"ncurses::inchnstr" = ["<=6.0.1"]
+"ncurses::inchstr" = ["<=6.0.1"]
+"ncurses::innstr" = ["<=6.0.1"]
+"ncurses::mvwinchnstr" = ["<=6.0.1"]
+"ncurses::mvwinchstr" = ["<=6.0.1"]
+"ncurses::mvwinnstr" = ["<=6.0.1"]
+"ncurses::winchnstr" = ["<=6.0.1"]
+"ncurses::winchstr" = ["<=6.0.1"]
+"ncurses::winnstr" = ["<=6.0.1"]
+"ncurses::winstr" = ["<=6.0.1"]
+
+[versions]
+patched = []
+```
+
+# Uninitialized memory exposure in string reading functions
+
+Multiple string reading functions expose uninitialized memory by setting length to capacity when no null terminator is found.
+
+This allows reading uninitialized memory which may contain sensitive data from previous allocations.
+
+The ncurses-rs repository is archived and unmaintained.


### PR DESCRIPTION
The crate's repository is archived and unmaintained, but it retains several unsound APIs that expose uninitialized memory.

## Overview

The ncurses-rs library contains a set of critical memory safety vulnerabilities affecting **11 functions**. These functions improperly use `Vec::set_len()` and `String::set_len()` when handling string reads, leading to:

### Primary Security Issues

**Uninitialized Memory Exposure** - Sets Vec/String length to capacity instead of actual data read

### Vulnerability Pattern

All affected functions follow the same flawed pattern:

```rust
// Flawed implementation pattern
unsafe {
    // Call underlying C function to read data
    let ret = ll::some_read_function(...);
    
    let capacity = s.capacity();
    match s.iter().position(|x| *x == 0) {  // or s.find('\0')
        Some(index) => s.set_len(index),
        None => s.set_len(capacity),  // Exposes uninitialized memory
    }
    
    ret
}
```


## Example

```rust
pub fn inchnstr(s: &mut Vec<chtype>, n: i32) -> i32
{

  s.clear();
  s.reserve(n as usize);
  unsafe
  {
    let ret = ll::inchnstr(s.as_ptr(), n);

    let capacity = s.capacity();
    match s.iter().position(|x| *x == 0)
    {
      Some(index) => s.set_len(index as usize),
      None => s.set_len(capacity),
    }

    ret
  }
}
```

POC:
```rust
fn main() {
    initscr();

    let test_str = "0123456789";
    let _ = mvaddstr(5, 5, test_str);
    let _ = refresh();

    let mut buffer: Vec<chtype> = Vec::with_capacity(100);

    let _ = mv(5, 5);
    inchnstr(&mut buffer, test_str.len() as i32);

    endwin();
    println!("Buffer length: {}", buffer.len());
    println!("Buffer capacity: {}", buffer.capacity());
    println!("Buffer contents (first 20): {:?}", buffer);
}
```
Output:
```
Buffer's incorrect length (should be 10): 100
Buffer's capacity: 100
Buffer contents (raw chtype values): [48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
```