### PR TITLE
binary_vec_io is unsound and unmaintained

### DIFF
--- a/crates/binary_vec_io/RUSTSEC-0000-0000.md
+++ b/crates/binary_vec_io/RUSTSEC-0000-0000.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "binary_vec_io"
+date = "2025-10-21"
+url = "https://github.com/RustSec/advisory-db/pull/2428"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["buffer-overflow", "soundness"]
+
+[affected.functions]
+"binary_vec_io::binary_read_to_ref" = ["<= 0.1.12"]
+"binary_vec_io::binary_write_from_ref" = ["<= 0.1.12"]
+
+[versions]
+patched = []
+```
+
+# Out-of-bounds memory access in binary_read_to_ref and binary_write_from_ref
+
+Safe functions accept a single `&T` or `&mut T` but multiply by `n` to create slices extending beyond allocated memory when `n > 1`.
+
+These functions use `from_raw_parts` to create slices larger than the underlying allocation, violating memory safety.
+
+The binary_vec_io repository is archived and unmaintained.


### PR DESCRIPTION
The `binary_vec_io` crate's repository is archived, but it retains several unsound APIs.

## Summary
Safe functions accept a single `&T` or `&mut T` but allow multiplying by `n`, causing stack buffer overflow when `n > 1`.

## Affected Functions
- `binary_read_to_ref<T>(f: &mut File, p: &mut T, n: usize)`
- `binary_write_from_ref<T>(f: &mut File, p: &T, n: usize)`

## Vulnerability

Both functions accept a reference to **one** `T` but create slices for **n** instances:

```rust
pub fn binary_write_from_ref<T>(f: &mut std::fs::File, p: &T, n: usize) -> Result<(), Error> {
    let raw = p as *const T as *const u8;
    unsafe {
        let sli: &[u8] = std::slice::from_raw_parts(raw, n * (std::mem::size_of::<T>()));
        f.write_all(sli)?;
        Ok(())
    }
}
```
```rust
pub fn binary_read_to_ref<T>(f: &mut std::fs::File, p: &mut T, n: usize) -> Result<(), Error> {
    let mut raw = p as *mut T as *mut u8;
    unsafe {
        use std::io::Read;
        let bytes_to_read = n * std::mem::size_of::<T>();
        ...
            let sli: &mut [u8] = std::slice::from_raw_parts_mut(raw, bytes_to_read - bytes_read);
        ...

```
Detailed analysis with additional examples: https://gist.github.com/lewismosciski/57ac3b8b7a861abdd0d7ae6f39de5a9d