### PR TITLE
Add advisory for zipora undefined behavior

### DIFF
--- a/crates/zipora/RUSTSEC-0000-0000.md
+++ b/crates/zipora/RUSTSEC-0000-0000.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "zipora"
+date = "2025-10-21"
+url = "https://github.com/infinilabs/zipora/issues/10"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["undefined-behavior", "soundness"]
+
+[affected.functions]
+"zipora::memory::simd_ops::fast_prefetch_range" = ["< 2.0.1"]
+
+[versions]
+patched = [">= 2.0.1"]
+```
+
+# Undefined behavior in fast_prefetch_range
+
+The safe function `fast_prefetch_range` accepts a raw pointer and size without validation, allowing safe code to trigger undefined behavior.
+
+The function passes these inputs directly to internal pointer arithmetic (`start.add(size)`) without checking whether the resulting pointer would wrap around the address space or point outside the original allocation. Computing such invalid pointers violates Rust's safety guarantees and causes immediate undefined behavior.
+
+Fixed in v2.0.1 by changing the API to accept a safe slice reference (`&[u8]`) instead of raw pointer and size.


### PR DESCRIPTION
The safe function `fast_prefetch_range` accepts raw pointer without validation, allowing undefined behavior through pointer wraparound.

## Details
- Affects versions < 2.0.1
- **Fixed in v2.0.1** by changing API to accept `&[u8]` instead of raw pointer
- Maintainer confirmed and patched: https://github.com/infinilabs/zipora/issues/10