### PR TITLE
Add advisory for direct_ring_buffer uninitialized memory

### DIFF
--- a/crates/direct_ring_buffer/RUSTSEC-0000-0000.md
+++ b/crates/direct_ring_buffer/RUSTSEC-0000-0000.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "direct_ring_buffer"
+date = "2025-10-21"
+url = "https://github.com/ain1084/direct_ring_buffer/issues/1"
+references = ["https://github.com/ain1084/direct_ring_buffer/pull/2"]
+informational = "unsound"
+categories = ["memory-exposure"]
+keywords = ["uninitialized-memory", "soundness"]
+
+[affected.functions]
+"direct_ring_buffer::create_ring_buffer" = ["<= 0.2.1"]
+
+[versions]
+patched = [">= 0.2.2"]
+```
+
+# Uninitialized memory exposure in create_ring_buffer
+
+The safe function `create_ring_buffer` allocates a buffer using `Vec::with_capacity` followed by `set_len`, creating a `Box<[T]>` containing uninitialized memory.
+
+This leads to undefined behavior when functions like `write_slices` create typed slices (e.g., `&mut [bool]`) over the uninitialized memory, violating Rust's validity invariants. The issue has been confirmed using Miri.
+
+Fixed in version 0.2.2 by using `resize_with` to properly initialize the buffer with `T::default()`, adding a `T: Default` bound to ensure sound initialization.


### PR DESCRIPTION
## Summary
The safe function `create_ring_buffer` creates typed slices over uninitialized memory, violating Rust's validity invariants and causing undefined behavior.

## Details
- **Vulnerability**: Using `Vec::with_capacity` + `set_len` to create `Box<[T]>` with uninitialized memory
- **Impact**: Creating typed slices (e.g., `&mut [bool]`) over uninitialized memory causes immediate UB
- **Affected versions**: <= 0.2.1
- **Status**: ✅ **Confirmed and fixed by maintainer**
- **Fix**: Use `resize_with` to properly initialize buffer with `T::default()` (adds `T: Default` bound)
- **Fixed in**: 0.2.2