### PR TITLE
Add advisory for remoteprocess soundness issues

### DIFF
--- a/crates/remoteprocess/RUSTSEC-0000-0000.md
+++ b/crates/remoteprocess/RUSTSEC-0000-0000.md
@@ -1,0 +1,27 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "remoteprocess"
+date = "2025-10-21"
+url = "https://github.com/benfred/remoteprocess/issues/105"
+references = ["https://github.com/benfred/remoteprocess/pull/109"]
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["double-free", "soundness"]
+
+[affected.functions]
+"remoteprocess::ProcessMemory::copy_struct" = ["< 0.5.1"]
+"remoteprocess::ProcessMemory::copy_pointer" = ["< 0.5.1"]
+"remoteprocess::ProcessMemory::copy_vec" = ["< 0.5.1"]
+
+[versions]
+patched = [">= 0.5.1"]
+```
+
+# Multiple soundness issues in ProcessMemory trait
+
+Safe methods in the `ProcessMemory` trait can cause double-free and use-after-free bugs when used with non-Copy types.
+
+The methods `copy_struct`, `copy_pointer`, and `copy_vec` perform bitwise copies of memory without enforcing that the copied type is safe to duplicate. This allows creating multiple owned copies of non-POD types (e.g., types containing `String` or `Vec`), leading to double-free when both copies are dropped.
+
+Fixed by adding `Copy` trait bounds to ensure only trivially copyable types can be used with these methods.


### PR DESCRIPTION
This PR adds an advisory for soundness issues in remoteprocess.

## Summary
Safe methods in the `ProcessMemory` trait can cause double-free and use-after-free bugs when used with non-Copy types.

## Details
- **Vulnerability**: Methods perform bitwise copies without enforcing Copy trait
- **Impact**: Double-free when copying non-POD types (e.g., String, Vec)
- **Affected functions**: `copy_struct`, `copy_pointer`, `copy_vec`
- **Affected versions**: < 0.5.1
- **Status**: ✅ **Confirmed and fixed by maintainer**
- **Fix**: Added Copy trait bounds to ensure only trivially copyable types can be used
- **Fixed in**: 0.5.1