### PR TITLE
Add advisory for orx-pinned-vec undefined behavior

### DIFF
--- a/crates/orx-pinned-vec/RUSTSEC-0000-0000.md
+++ b/crates/orx-pinned-vec/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "orx-pinned-vec"
+date = "2025-10-21"
+url = "https://github.com/orxfun/orx-pinned-vec/issues/52"
+references = ["https://github.com/orxfun/orx-pinned-vec/pull/53"]
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["undefined-behavior", "soundness"]
+
+[affected.functions]
+"orx_pinned_vec::utils::slice::index_of_ptr" = ["< 3.21.0"]
+
+[versions]
+patched = [">= 3.21.0"]
+```
+
+# Undefined behavior in index_of_ptr with empty slices
+
+The safe function `index_of_ptr` causes undefined behavior when called with an empty slice.
+
+The issue occurs in the line `ptr.add(slice.len() - 1)` which underflows when `slice.len()` is 0, creating a pointer with a massive offset. According to Rust's safety rules, creating such a pointer causes immediate undefined behavior.


### PR DESCRIPTION
This PR adds an advisory for a soundness issue in orx-pinned-vec.

## Summary
The safe function `index_of_ptr` causes undefined behavior when called with an empty slice due to pointer arithmetic overflow.

## Details
- **Vulnerability**: `ptr.add(slice.len() - 1)` underflows when `slice.len()` is 0
- **Impact**: Creates pointer with massive offset, causing immediate undefined behavior
- **Affected versions**: < 3.21.0
- **Status**: ✅ **Confirmed and fixed by maintainer**
- **Fixed in**: 3.21.0