### PR TITLE
Add advisory for borrowck_sacrifices uninitialized memory

### DIFF
--- a/crates/borrowck_sacrifices/RUSTSEC-0000-0000.md
+++ b/crates/borrowck_sacrifices/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "borrowck_sacrifices"
+date = "2025-10-21"
+url = "https://github.com/alexpyattaev/borrowck_sacrifices/issues/1"
+informational = "unsound"
+categories = ["memory-exposure"]
+keywords = ["uninitialized-memory", "soundness"]
+
+[affected.functions]
+"borrowck_sacrifices::unsafe_casts::any_as_u8_slice" = ["< 0.2.0"]
+
+[versions]
+patched = [">= 0.2.0"]
+```
+
+# Uninitialized memory exposure in any_as_u8_slice
+
+The safe function `any_as_u8_slice` can create byte slices that reference uninitialized memory when used with types containing padding bytes.
+
+The function uses `slice::from_raw_parts` to create a `&[u8]` covering the entire size of a type, including padding bytes. According to Rust's documentation, `from_raw_parts` requires all bytes to be properly initialized, but padding bytes in structs are not guaranteed to be initialized. This violates the safety contract and causes undefined behavior.


### PR DESCRIPTION
This PR adds an advisory for a soundness issue in borrowck_sacrifices.

## Summary
The safe function `any_as_u8_slice` exposes uninitialized memory when used with types containing padding bytes.

## Details
- **Vulnerability**: Creates `&[u8]` including uninitialized padding bytes via `from_raw_parts`
- **Impact**: Violates safety contract of `from_raw_parts`, causing undefined behavior
- **Affected versions**: < 0.2.0
- **Status**: ✅ **Confirmed and fixed by maintainer**
- **Fixed in**: 0.2.0