### PR TITLE
Add advisory for libafl_bolts out-of-bounds access

### DIFF
--- a/crates/libafl_bolts/RUSTSEC-0000-0000.md
+++ b/crates/libafl_bolts/RUSTSEC-0000-0000.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libafl_bolts"
+date = "2025-10-21"
+url = "https://github.com/AFLplusplus/LibAFL/issues/3417"
+references = ["https://github.com/AFLplusplus/LibAFL/pull/3435"]
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["buffer-overflow", "soundness"]
+
+[affected.functions]
+"libafl_bolts::simd::covmap_is_interesting_simd" = ["<= 0.15.3"]
+"libafl_bolts::simd::covmap_is_interesting_naive" = ["<= 0.15.3"]
+
+[versions]
+patched = []
+```
+
+# Out-of-bounds access in covmap_is_interesting functions
+
+The safe functions `covmap_is_interesting_simd` and `covmap_is_interesting_naive` can cause undefined behavior through out-of-bounds memory access.
+
+Both functions use `get_unchecked` to access the `hist` slice with indices based on the `map` slice length. When `hist.len() < map.len()`, this results in out-of-bounds access causing undefined behavior.


### PR DESCRIPTION
This PR adds an advisory for a soundness issue in libafl_bolts.

## Summary
The safe functions `covmap_is_interesting_simd` and `covmap_is_interesting_naive` can cause undefined behavior through out-of-bounds memory access.

## Details
- **Vulnerability**: Use `get_unchecked` on `hist` slice with indices from `map` slice
- **Impact**: Out-of-bounds access when `hist.len() < map.len()`, causing undefined behavior
- **Status**: ✅ **Fixed in main branch, awaiting release**
- **Fix**: Functions marked as `unsafe` with safety documentation