### PR TITLE
Recommend Rust std alternative to unic-char-range

### DIFF
--- a/crates/unic-char-range/RUSTSEC-2025-0075.md
+++ b/crates/unic-char-range/RUSTSEC-2025-0075.md
@@ -14,3 +14,7 @@ unaffected = []
 # `unic-char-range` is unmaintained
 
 All Unicode crates that are part of https://github.com/open-i18n/rust-unic are unmaintained.
+
+## Recommended alternatives
+
+- Since version [1.45.0](https://releases.rs/docs/1.45.0/#libraries) Rust [supports](https://github.com/rust-lang/rust/pull/72413/) using `char` with `ops::{Range, RangeFrom, RangeFull, RangeInclusive, RangeTo}` to iterate over a range of codepoints.


### PR DESCRIPTION
Part of #2414 