### PR TITLE
Add advisory for tokio-tar PAX mis-parsing (CVE-2025-62518)

### DIFF
--- a/crates/tokio-tar/RUSTSEC-0000-0000.md
+++ b/crates/tokio-tar/RUSTSEC-0000-0000.md
@@ -1,0 +1,34 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tokio-tar"
+date = "2025-10-21"
+url = "https://edera.dev/stories/tarmageddon"
+categories = ["format-injection"]
+keywords = ["unsound", "parsing", "smuggling", "file-smuggling", "unmaintained"]
+related = ["CVE-2025-62518", "GHSA-j5gw-2vrg-8fgx"]
+
+[affected.functions]
+"tokio_tar::Archive::new" = ["<= 0.3.1"]
+"tokio_tar::ArchiveBuilder::new" = ["<= 0.3.1"]
+
+[versions]
+patched = []
+```
+
+# `tokio-tar` parses PAX extended headers incorrectly, allows file smuggling
+
+The archive reader incorrectly handles PAX extended headers, when the ustar
+header incorrectly specifies zero size (`size=000000000000`), while a PAX
+header specifies a non-zero size, `tokio-tar::Archive` is going to read the
+file content as tar entry header.
+
+This can be used by a tar file to present different content to `tokio-tar`
+compared to other tar reader implementations.
+
+This bug is also known as `CVE-2025-62518` and `GHSA-j5gw-2vrg-8fgx`, as those
+crates share a common ancestor codebase.
+
+The `tokio-tar` crate is archived and no longer maintained, we recommend you
+switch to an alternative crate such as:
+- [`astral-tokio-tar`](https://crates.io/crates/astral-tokio-tar)


### PR DESCRIPTION
Related to #2435 (doesn't fully fix).

I'm not sure if "format-injection" is the correct category, but there aren't many to pick from for logic bugs.

The advisory can be used for the other crates too (with minor changes), I'm not sure if adding multiple advisories to the same pull request is the correct workflow though.

cc @woodruffw