### PR TITLE
Add advisory for astral-tokio-tar (CVE-2025-62518)

### DIFF
--- a/crates/astral-tokio-tar/RUSTSEC-0000-0000.md
+++ b/crates/astral-tokio-tar/RUSTSEC-0000-0000.md
@@ -9,7 +9,6 @@ keywords = ["parser-differential", "smuggling"]
 aliases = ["CVE-2025-62518", "GHSA-j5gw-2vrg-8fgx"]
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N"
 
-"tokio_tar::ArchiveBuilder::new" = ["<= 0.5.6"]
 
 [versions]
 patched = [">= 0.5.6"]


### PR DESCRIPTION
This records CVE-2025-62518 as a RUSTSEC advisory as well.

See also #2442.