### PR TITLE
ci: ratchet down permissions, pin all actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7

--- a/.github/workflows/assign-ids.yml
+++ b/.github/workflows/assign-ids.yml
@@ -4,16 +4,22 @@ on:
   push:
     branches: main
 
+permissions: {}
+
 jobs:
   assign-ids:
     name: Assign IDs
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # needed to create pull requests
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Cache cargo bin
         id: admin-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/bin
           key: rustsec-admin-c7f56c474e01619b78b9c39bdb626d982f3bee90
@@ -35,7 +41,7 @@ jobs:
           ls -R ./crates/ ./rust/ | sha256sum >> .duplicate-id-guard
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: ${{ steps.assign.outputs.commit_message }}

--- a/.github/workflows/export-osv.yml
+++ b/.github/workflows/export-osv.yml
@@ -4,15 +4,20 @@ on:
   push:
     branches: main
 
+permissions: {}
+
 jobs:
   publish-web:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # needed for pushing back to the repo
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: osv
+          persist-credentials: true # persists the token for git push below
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: admin-cache
         with:
           path: ~/.cargo/bin

--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -4,15 +4,20 @@ on:
   push:
     branches: main
 
+permissions: {}
+
 jobs:
   publish-web:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # needed for pushing back to the repo
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: gh-pages
+          persist-credentials: true # persists the token for git push below
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: admin-cache
         with:
           path: ~/.cargo/bin

--- a/.github/workflows/sync-ids.yml
+++ b/.github/workflows/sync-ids.yml
@@ -6,16 +6,22 @@ on:
     # daily run on default "main" branch
     - cron: "30 1 * * *"
 
+permissions: {}
+
 jobs:
   sync-ids:
     name: Synchronize IDs
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # needed to create pull requests
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Cache cargo bin
         id: admin-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/bin
           key: rustsec-admin-c7f56c474e01619b78b9c39bdb626d982f3bee90
@@ -35,7 +41,7 @@ jobs:
           echo "commit_message=${message}" >> $GITHUB_OUTPUT
 
       - name: Create pull request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: ${{ steps.sync_ids.outputs.commit_message }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,16 +5,20 @@ on:
   push:
     branches: main
 
+permissions: {}
+
 jobs:
   lint:
     name: Lint advisories
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Cache cargo bin
         id: admin-cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/bin
           key: rustsec-admin-c7f56c474e01619b78b9c39bdb626d982f3bee90


### PR DESCRIPTION
[zizmor](https://docs.zizmor.sh) flagged these while I was doing #2443 🙂 

This fixes a handful of mostly minor security issues in the workflows/Dependabot configurations used in this repo. Namely:

* All actions are now fully hash-pinned, to make runs more hermetic/make it impossible for an external tag overwrite to modify CI behavior here.
* All `actions/checkout` usage now either explicitly disables credential persistence *or* explicitly enables it if the job previously implicitly required it (e.g. for `git push`).
* All workflows now drop their default permissions to the empty set (`permissions: {}`), and only give each internal job the specific permissions its needs.
* Dependabot now includes a `cooldown` on its updates (of 7 days), making it harder for an opportunistic compromise of an action dependency to impact this repo (since it'd need to survive in the wild for longer).

Hopefully these changes are welcome! If not, please feel free to close this.