### PR TITLE
ci: fix create-pull-request permissions

### DIFF
--- a/.github/workflows/assign-ids.yml
+++ b/.github/workflows/assign-ids.yml
@@ -11,7 +11,8 @@ jobs:
     name: Assign IDs
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write # needed to create pull requests
+      contents: write # for create-pull-request
+      pull-requests: write # for create-pull-request
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:

--- a/.github/workflows/sync-ids.yml
+++ b/.github/workflows/sync-ids.yml
@@ -13,7 +13,8 @@ jobs:
     name: Synchronize IDs
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write # needed to create pull requests
+      content: write # for create-pull-request
+      pull-requests: write # for create-pull-request
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:


### PR DESCRIPTION
This fixes two jobs that use the `create-pull-request` action. This action requires both `contents: write` and `pull-requests: write`, since it creates and pushes a branch before opening the PR. 

Documented here: https://github.com/marketplace/actions/create-pull-request#token