### PR TITLE
ci: fix typo in permissions key

### DIFF
--- a/.github/workflows/sync-ids.yml
+++ b/.github/workflows/sync-ids.yml
@@ -13,7 +13,7 @@ jobs:
     name: Synchronize IDs
     runs-on: ubuntu-latest
     permissions:
-      content: write # for create-pull-request
+      contents: write # for create-pull-request
       pull-requests: write # for create-pull-request
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
This went wrong in

- #2448 

but apparently GitHub doesn't complain if the workflow isn't triggered or something?

cc @woodruffw 