### PR TITLE
ci: bump rustsec commit to use

### DIFF
--- a/.github/workflows/assign-ids.yml
+++ b/.github/workflows/assign-ids.yml
@@ -23,11 +23,11 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/bin
-          key: rustsec-admin-c7f56c474e01619b78b9c39bdb626d982f3bee90
+          key: rustsec-admin-4f949d61d9ed2ef59f8c4448b5ab96e6eef0d6ed
 
       - name: Install rustsec-admin
         if: steps.admin-cache.outputs.cache-hit != 'true'
-        run: cargo install --git https://github.com/rustsec/rustsec rustsec-admin --rev c7f56c474e01619b78b9c39bdb626d982f3bee90
+        run: cargo install --git https://github.com/rustsec/rustsec rustsec-admin --rev 4f949d61d9ed2ef59f8c4448b5ab96e6eef0d6ed
 
       - name: Assign IDs
         id: assign

--- a/.github/workflows/export-osv.yml
+++ b/.github/workflows/export-osv.yml
@@ -21,11 +21,11 @@ jobs:
         id: admin-cache
         with:
           path: ~/.cargo/bin
-          key: rustsec-admin-c7f56c474e01619b78b9c39bdb626d982f3bee90
+          key: rustsec-admin-4f949d61d9ed2ef59f8c4448b5ab96e6eef0d6ed
 
       - name: Install rustsec-admin
         if: steps.admin-cache.outputs.cache-hit != 'true'
-        run: cargo install --git https://github.com/rustsec/rustsec rustsec-admin --rev c7f56c474e01619b78b9c39bdb626d982f3bee90
+        run: cargo install --git https://github.com/rustsec/rustsec rustsec-admin --rev 4f949d61d9ed2ef59f8c4448b5ab96e6eef0d6ed
 
       - run: |
           mkdir -p crates

--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -21,11 +21,11 @@ jobs:
         id: admin-cache
         with:
           path: ~/.cargo/bin
-          key: rustsec-admin-c7f56c474e01619b78b9c39bdb626d982f3bee90
+          key: rustsec-admin-4f949d61d9ed2ef59f8c4448b5ab96e6eef0d6ed
 
       - name: Install rustsec-admin
         if: steps.admin-cache.outputs.cache-hit != 'true'
-        run: cargo install --git https://github.com/rustsec/rustsec rustsec-admin --rev c7f56c474e01619b78b9c39bdb626d982f3bee90
+        run: cargo install --git https://github.com/rustsec/rustsec rustsec-admin --rev 4f949d61d9ed2ef59f8c4448b5ab96e6eef0d6ed
 
       - run: |
           rustsec-admin web .

--- a/.github/workflows/sync-ids.yml
+++ b/.github/workflows/sync-ids.yml
@@ -25,11 +25,11 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/bin
-          key: rustsec-admin-c7f56c474e01619b78b9c39bdb626d982f3bee90
+          key: rustsec-admin-4f949d61d9ed2ef59f8c4448b5ab96e6eef0d6ed
 
       - name: Install rustsec-admin
         if: steps.admin-cache.outputs.cache-hit != 'true'
-        run: cargo install --git https://github.com/rustsec/rustsec rustsec-admin --rev c7f56c474e01619b78b9c39bdb626d982f3bee90
+        run: cargo install --git https://github.com/rustsec/rustsec rustsec-admin --rev 4f949d61d9ed2ef59f8c4448b5ab96e6eef0d6ed
 
       - name: Synchronize IDs
         id: sync_ids

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -21,11 +21,11 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/bin
-          key: rustsec-admin-c7f56c474e01619b78b9c39bdb626d982f3bee90
+          key: rustsec-admin-4f949d61d9ed2ef59f8c4448b5ab96e6eef0d6ed
 
       - name: Install rustsec-admin
         if: steps.admin-cache.outputs.cache-hit != 'true'
-        run: cargo install --git https://github.com/rustsec/rustsec rustsec-admin --rev c7f56c474e01619b78b9c39bdb626d982f3bee90
+        run: cargo install --git https://github.com/rustsec/rustsec rustsec-admin --rev 4f949d61d9ed2ef59f8c4448b5ab96e6eef0d6ed
 
       - name: Lint advisories
         run: rustsec-admin lint --skip-namecheck rustdecimal,vec-const


### PR DESCRIPTION
Pulls in

- https://github.com/rustsec/rustsec/pull/1409
- https://github.com/rustsec/rustsec/pull/1423
- https://github.com/rustsec/rustsec/pull/1421
- https://github.com/rustsec/rustsec/pull/1452

In particular, apparently this means we can now parse OSV files containing CVSS 4.