### PR TITLE
Add unmaintained advisory for tandem crates

### DIFF
--- a/crates/tandem/RUSTSEC-0000-0000.md
+++ b/crates/tandem/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tandem"
+date = "2025-11-10"
+url = "https://github.com/sine-fdn/tandem/commit/4b3fe27190f20602dc3d9dbfcf36f72ca8b2c538"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# tandem is unmaintained
+
+The tandem crates in [https://github.com/sine-fdn](github.com/sine-fdn) are no longer maintained by the SINE Foundation. The repository has been archived.
+
+## Recommended alternative
+We are continuing our work on SMPC by implementing our secure multi-party computation engine [Polytune](https://github.com/sine-fdn/polytune).

--- a/crates/tandem_garble_interop/RUSTSEC-0000-0000.md
+++ b/crates/tandem_garble_interop/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tandem_garble_interop"
+date = "2025-11-10"
+url = "https://github.com/sine-fdn/tandem/commit/4b3fe27190f20602dc3d9dbfcf36f72ca8b2c538"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# tandem_garble_interop is unmaintained
+
+The tandem crates in [https://github.com/sine-fdn](github.com/sine-fdn) are no longer maintained by the SINE Foundation. The repository has been archived.
+
+## Recommended alternative
+We are continuing our work on SMPC by implementing our secure multi-party computation engine [Polytune](https://github.com/sine-fdn/polytune).

--- a/crates/tandem_http_client/RUSTSEC-0000-0000.md
+++ b/crates/tandem_http_client/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tandem_http_client"
+date = "2025-11-10"
+url = "https://github.com/sine-fdn/tandem/commit/4b3fe27190f20602dc3d9dbfcf36f72ca8b2c538"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# tandem_http_client is unmaintained
+
+The tandem crates in [https://github.com/sine-fdn](github.com/sine-fdn) are no longer maintained by the SINE Foundation. The repository has been archived.
+
+## Recommended alternative
+We are continuing our work on SMPC by implementing our secure multi-party computation engine [Polytune](https://github.com/sine-fdn/polytune).

--- a/crates/tandem_http_server/RUSTSEC-0000-0000.md
+++ b/crates/tandem_http_server/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tandem_http_server"
+date = "2025-11-10"
+url = "https://github.com/sine-fdn/tandem/commit/4b3fe27190f20602dc3d9dbfcf36f72ca8b2c538"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# tandem_http_server is unmaintained
+
+The tandem crates in [https://github.com/sine-fdn](github.com/sine-fdn) are no longer maintained by the SINE Foundation. The repository has been archived.
+
+## Recommended alternative
+We are continuing our work on SMPC by implementing our secure multi-party computation engine [Polytune](https://github.com/sine-fdn/polytune).


### PR DESCRIPTION
We, the SINE Foundation, are no longer maintaining the tandem crates in https://github.com/sine-fdn/tandem.

Crates:
- tandem
- tandem_garble_interop
- tandem_http_client
- tandem_http_server