### PR TITLE
wasmtime: Unsound API access to a WebAssembly shared linear memory

### DIFF
--- a/crates/wasmtime/RUSTSEC-0000-0000.md
+++ b/crates/wasmtime/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime"
+date = "2025-11-11"
+url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-hc7m-r6v8-hg9q"
+categories = []
+keywords = []
+aliases = ["CVE-2025-64345", "GHSA-hc7m-r6v8-hg9q"]
+license = "CC0-1.0"
+cvss = "CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:U/C:N/I:L/A:N"
+
+[versions]
+patched = [">= 38.0.4", ">= 37.0.3, < 38.0.0", ">= 36.0.3, < 37.0.0", ">= 24.0.5, < 25.0.0"]
+unaffected = []
+```
+
+# Unsound API access to a WebAssembly shared linear memory
+
+This is an entry in the RustSec database for the Wasmtime security advisory
+located at
+https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-hc7m-r6v8-hg9q
+For more information see the GitHub-hosted security advisory.


### PR DESCRIPTION
Republishing https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-hc7m-r6v8-hg9q here