### PR TITLE
Add maintained fork as alternative for daemonize

### DIFF
--- a/crates/daemonize/RUSTSEC-2025-0069.md
+++ b/crates/daemonize/RUSTSEC-2025-0069.md
@@ -19,3 +19,7 @@ Oldest PR sitting around without any interaction from the maintainer: [knsd/daem
 On February 14, 2024, a [PR](https://github.com/knsd/daemonize/pull/57) was made to correct some UB.
 
 Efforts to contact the crate owner via email have been unsuccessful.
+
+## Alternatives
+
+The [`daemonix`](https://crates.io/crates/daemonix) crate is a maintained fork of `daemonize`. `daemonix` v0.1.0 addresses the UB issue reported against the original crate, and can be used as a drop-in replacement for `daemonize` v0.5.0.


### PR DESCRIPTION
I have forked the original `daemonize` crate as `daemonix` and merged changes that fix the UB issue that was reported against the original crate. It can be used as a "safer" / "maintained" drop-in replacement for daemonize.