### PR TITLE
Use CVSS 3.1 for RUSTSEC-2025-0125

### DIFF
--- a/crates/thread-amount/RUSTSEC-2025-0125.md
+++ b/crates/thread-amount/RUSTSEC-2025-0125.md
@@ -7,7 +7,7 @@ url = "https://github.com/jzeuzs/thread-amount/pull/29"
 categories = ["denial-of-service"]
 keywords = ["memory-leak", "handle-leak", "resource-exhaustion", "windows", "macos"]
 aliases = ["GHSA-jf9p-2fv9-2jp2", "CVE-2025-65947"]
-cvss = "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N/E:P/AU:Y/R:U/V:D/RE:L/U:Green"
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 
 [affected]
 os = ["windows", "macos", "ios"]


### PR DESCRIPTION
c.f. https://github.com/EmbarkStudios/cargo-deny/issues/804

Fixes RUSTSEC raised in https://github.com/rustsec/advisory-db/pull/2476 by crate maintainer, and assigned by GHA in https://github.com/rustsec/advisory-db/pull/2477 