### PR TITLE
Add vulnerability advisory for nftnl

### DIFF
--- a/crates/nftnl/RUSTSEC-0000-0000.md
+++ b/crates/nftnl/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "nftnl"
+date = "2025-10-18"
+url = "https://github.com/mullvad/nftnl-rs/issues/76#issue-3528876468"
+categories = ["memory-corruption"]
+
+[versions]
+patched = [">= 0.8.0"]
+```
+
+# Heap-buffer-overflow in nftnl::Batch::with_page_size (nftnl-rs)
+
+A heap-buffer-overflow vulnerability exists in the Rust wrapper for libnftnl, triggered via the nftnl::Batch::with_page_size constructor. When a small or malformed page size is provided, the underlying C code allocates an insufficient buffer, leading to out-of-bounds writes during batch initialization.
+
+The flaw was fixed in commit 94a286f by adding an overflow check:
+```Rust
+batch_page_size
+    .checked_add(crate::nft_nlmsg_maxsize())
+    .expect("batch_page_size is too large and would overflow");
+```


### PR DESCRIPTION
A heap-buffer-overflow vulnerability exists in the Rust wrapper for libnftnl, triggered via the nftnl::Batch::with_page_size constructor. When a small or malformed page size is provided, the underlying C code allocates an insufficient buffer, leading to out-of-bounds writes during batch initialization. 

Issue is [here](https://github.com/mullvad/nftnl-rs/issues/76). 
The fix information can be found [here](https://github.com/mullvad/nftnl-rs/pull/82).