### PR TITLE
Update RUSTSEC-2025-0126 with a patched version / mitigation suggestion

### DIFF
--- a/crates/nftnl/RUSTSEC-2025-0126.md
+++ b/crates/nftnl/RUSTSEC-2025-0126.md
@@ -8,7 +8,7 @@ categories = ["memory-corruption"]
 aliases = ["GHSA-2fjw-whxm-9v4q"]
 
 [versions]
-patched = [">= 0.8.0"]
+patched = [">= 0.9.0"]
 ```
 
 # Heap-buffer-overflow in nftnl::Batch::with_page_size (nftnl-rs)
@@ -21,3 +21,7 @@ batch_page_size
     .checked_add(crate::nft_nlmsg_maxsize())
     .expect("batch_page_size is too large and would overflow");
 ```
+
+## Mitigation
+
+Upgrade to version `0.9.0` or later, which aborts instead.


### PR DESCRIPTION
Add patched version number to RUSTSEC-2025-0126 - a fix for the CVE was released in `nftnl 0.9.0`: https://github.com/mullvad/nftnl-rs/blob/v0.9.0/CHANGELOG.md#fixed.