### PR TITLE
Add maxminddb mmap unsoundness advisory

### DIFF
--- a/crates/maxminddb/RUSTSEC-0000-0000.md
+++ b/crates/maxminddb/RUSTSEC-0000-0000.md
@@ -1,0 +1,26 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "maxminddb"
+date = "2025-11-28"
+url = "https://github.com/oschwald/maxminddb-rust/issues/86"
+references = ["https://github.com/oschwald/maxminddb-rust/commit/98f0e4fff9678c841ed33f3b8a46322f6163c32a"]
+categories = ["memory-corruption"]
+keywords = ["mmap"]
+
+[affected.functions]
+"maxminddb::Reader::open_mmap" = ["< 0.27.0, >= 0.11.0"]
+"maxminddb::Reader::open" = ["< 0.12.0, >= 0.11.0"]
+
+[versions]
+patched = [">= 0.27.0"]
+unaffected = ["< 0.11.0"]
+```
+
+# `Reader::open_mmap` unsoundly marks unsafe memmap operation as safe
+
+maxminddb prior to version 0.27 declared `Reader::open_mmap` as safe 
+despite wrapping an inherently unsafe memmap2 operation with no
+extra step done to guarantee safety. This could have led to undefined
+behaviour if the file were to be modified on disk while the memory map
+was still active.


### PR DESCRIPTION
Adds the advisory for https://github.com/oschwald/maxminddb-rust/issues/86.
Cc @oschwald