### PR TITLE
Add libcrux-intrinsics entry

### DIFF
--- a/crates/libcrux-intrinsics/RUSTSEC-0000-0000.md
+++ b/crates/libcrux-intrinsics/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libcrux-intrinsics"
+date = "2025-12-04"
+url = "https://github.com/cryspen/libcrux/issues/1220"
+categories = ["crypto-failure"]
+
+[versions]
+patched = [">= 0.0.4"]
+unaffected = ["<= 0.0.3"]
+
+[affected]
+arch = ["aarch64"]
+```
+
+# Incorrect calculation on aarch64
+
+On platforms without the `core::arch::aarch64::vxarq_u64` intrinsic, an unverified fallback in `libcrux-intrinsics` v0.0.3
+passed incorrect arguments and produced wrong results. This corrupted SHA-3 digests and caused `libcrux-ml-kem` and
+`libcrux-ml-dsa` to sample incorrectly, yielding incorrect shared secrets and invalid signatures.
+
+The issue has been fixed in v0.0.4.


### PR DESCRIPTION
This is for https://github.com/cryspen/libcrux/issues/1220 but also affects libcrux-ml-kem.

Ideally these can be updated by the maintainers if they do analysis on the relationship between the incorrect signatures/shared secrets and the correct output.