### PR TITLE
withdraw RUSTSEC-2025-0120: json5 is now maintained

### DIFF
--- a/crates/json5/RUSTSEC-2025-0120.md
+++ b/crates/json5/RUSTSEC-2025-0120.md
@@ -5,6 +5,7 @@ package = "json5"
 date = "2025-11-16"
 url = "https://github.com/callum-oakley/json5-rs/issues/51"
 informational = "unmaintained"
+withdrawn = "2025-11-29"
 
 [versions]
 patched = []


### PR DESCRIPTION
Withdrawing advisory marking json5 as unmaintained because it [is now maintained again](https://github.com/callum-oakley/json5-rs/issues/51#issuecomment-3591976216). :)