### PR TITLE
tough: add information about CVE-2025-2885

### DIFF
--- a/crates/tough/RUSTSEC-0000-0000.md
+++ b/crates/tough/RUSTSEC-0000-0000.md
@@ -1,0 +1,59 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tough"
+date = "2025-03-27"
+url = "https://github.com/awslabs/tough/security/advisories/GHSA-5vmp-m5v2-hx47"
+references = ["https://aws.amazon.com/security/security-bulletins/AWS-2025-007/"]
+
+cvss = "CVSS:4.0/AV:N/AC:H/AT:N/PR:H/UI:P/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N"
+aliases = ["CVE-2025-2885","GHSA-5vmp-m5v2-hx47"]
+license = "CC-BY-4.0"
+
+[versions]
+patched = [">= 0.20.0"]
+```
+
+# Summary
+
+When updating the root role, a TUF client must establish a trusted
+line of continuity to the latest set of keys. While sequentially
+downloading new versions of the root metadata file, tough will not
+check that the root object version it received was the next
+sequential version from the previously trusted root metadata.
+
+# Impact
+
+The tough client will trust an outdated or rotated root role in
+the event that an actor with control of the storage medium of a
+trusted TUF repository inappropriately replaced the contents of
+one of the root metadata files with an adequately signed previous
+version. As a result, tough could trust content associated with
+a previous root role.
+
+Impacted versions: < v0.20.0
+
+# Patches
+
+A fix for this issue is available in tough version 0.20.0 and later.
+Customers are advised to upgrade to version 0.20.0 or later and
+ensure any forked or derivative code is patched to incorporate the new fixes.
+
+# Workarounds
+
+There is no recommended work around. Customers are advised to upgrade
+to version 0.20.0 or the latest version.
+
+# References
+
+If you have any questions or comments about this advisory we ask that you contact
+AWS/Amazon Security via our vulnerability reporting page [1] or directly via
+email to aws-security@amazon.com. Please do not create a public GitHub issue.
+
+[1] Vulnerability reporting page: https://aws.amazon.com/security/vulnerability-reporting
+
+# Acknowledgement
+
+These issues were identified by the TUF-Conformance project. We
+would like to thank Google for collaborating on this issue
+through the coordinated vulnerability disclosure process.


### PR DESCRIPTION
information comes from https://nvd.nist.gov/vuln/detail/CVE-2025-2885 and https://github.com/awslabs/tough/security/advisories/GHSA-5vmp-m5v2-hx47