### PR TITLE
cap-primitives: add information about CVE-2024-51756

### DIFF
--- a/crates/cap-primitives/RUSTSEC-0000-0000.md
+++ b/crates/cap-primitives/RUSTSEC-0000-0000.md
@@ -1,0 +1,46 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "cap-primitives"
+date = "2024-11-05"
+url = "https://github.com/bytecodealliance/cap-std/security/advisories/GHSA-hxf5-99xg-86hw"
+references = ["https://github.com/bytecodealliance/cap-std/pull/371", "https://nvd.nist.gov/vuln/detail/CVE-2024-51756"]
+# See https://docs.rs/rustsec/latest/rustsec/advisory/enum.Category.html
+cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N"
+keywords = ["path traversal"]
+aliases = ["CVE-2024-51756", "GHSA-hxf5-99xg-86hw"]
+license = "CC-BY-4.0"
+
+[affected]
+os = ["windows"]
+
+[versions]
+patched = [">= 3.4.1"]
+```
+
+# cap-primitives doesn't fully sandbox all the Windows device filenames
+
+## Impact
+
+cap-primitives's filesystem sandbox implementation on Windows blocks
+access to special device filenames such as "COM1", "COM2",
+"LPT0", "LPT1", and so on, however it did not block access
+to the special device filenames which use superscript digits,
+such as "COM¹", "COM²", "LPT⁰", "LPT¹", and so on. Untrusted
+filesystem paths could bypass the sandbox and access devices
+through those special device filenames with superscript
+digits, and through them provide access peripheral devices
+connected to the computer, or network resources mapped to
+those devices. This can include modems, printers, network
+printers, and any other device connected to a serial or
+parallel port, including emulated USB serial ports.
+
+## Patches
+
+The bug is fixed in #371, which is published in
+cap-primitives 3.4.1, cap-std 3.4.1, and cap-async-std 3.4.1.
+
+## Workarounds
+
+There are no known workarounds for this issue.
+Affected Windows users are recommended to upgrade.


### PR DESCRIPTION
Information taken from: https://github.com/bytecodealliance/cap-std/security/advisories/GHSA-hxf5-99xg-86hw

@sunfishcode Ok if this gets published in rustsec?