### PR TITLE
fix: comment out CVSS with unsupported version for RUSTSEC-2024-0445

### DIFF
--- a/crates/cap-primitives/RUSTSEC-2024-0445.md
+++ b/crates/cap-primitives/RUSTSEC-2024-0445.md
@@ -6,7 +6,7 @@ date = "2024-11-05"
 url = "https://github.com/bytecodealliance/cap-std/security/advisories/GHSA-hxf5-99xg-86hw"
 references = ["https://github.com/bytecodealliance/cap-std/pull/371", "https://nvd.nist.gov/vuln/detail/CVE-2024-51756"]
 # See https://docs.rs/rustsec/latest/rustsec/advisory/enum.Category.html
-cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N"
+# cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:L/VI:L/VA:L/SC:N/SI:N/SA:N"
 keywords = ["path traversal"]
 aliases = ["CVE-2024-51756", "GHSA-hxf5-99xg-86hw"]
 license = "CC-BY-4.0"


### PR DESCRIPTION
CVSS v4 isn't supported yet, so this causes parsing errors when running `cargo deny`. I commented out the line for parity with other advisories ([examples](https://github.com/search?q=repo%3Arustsec%2Fadvisory-db%20%22CVSS%3A4%22&type=code)).

Seems to be the same issue as #2477