### PR TITLE
obfstr: add information about CVE-2024-58253

### DIFF
--- a/crates/obfstr/RUSTSEC-0000-0000.md
+++ b/crates/obfstr/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "obfstr"
+date = "2024-10-04"
+url = "https://github.com/CasualX/obfstr/issues/60"
+cvss = "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N"
+keywords = ["type confusion"]
+aliases = ["CVE-2024-58253"]
+
+[affected.functions]
+"obfstr::obfstr" = ["< 0.4.4"]
+
+[versions]
+patched = [">= 0.4.4"]
+```
+
+# Unsound issue while converting bytes to utf8 str
+
+In the obfstr crate before 0.4.4 for Rust, the
+obfstr! argument type is not restricted to string
+slices, leading to invalid UTF-8 conversion that
+produces an invalid value.


### PR DESCRIPTION
Information taken from: https://nvd.nist.gov/vuln/detail/CVE-2024-58253

@CasualX Is it ok if this is added to rustsec?