### PR TITLE
tokio-boring: add information about CVE-2023-6180

### DIFF
--- a/crates/tokio-boring/RUSTSEC-0000-0000.md
+++ b/crates/tokio-boring/RUSTSEC-0000-0000.md
@@ -1,0 +1,26 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tokio-boring"
+date = "2023-12-05"
+url = "https://nvd.nist.gov/vuln/detail/CVE-2023-6180"
+references = ["https://github.com/cloudflare/boring/security/advisories/GHSA-pjrj-h4fg-6gm4"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L"
+keywords = ["memory leak"]
+aliases = ["CVE-2023-6180", "GHSA-pjrj-h4fg-6gm4"]
+
+[versions]
+patched = [">= 4.1.0"]
+unaffected = ["< 4.0.0"]
+```
+
+# Memory Leak
+
+The tokio-boring library in version 4.0.0 is affected by
+a memory leak issue that can lead to excessive resource
+consumption and potential DoS by resource exhaustion.
+The set_ex_data function used by the library did not
+deallocate memory used by pre-existing data in memory
+each time after completing a TLS connection causing
+the program to consume more resources with each new
+connection.


### PR DESCRIPTION
Information taken from: https://nvd.nist.gov/vuln/detail/CVE-2023-6180

@nox Ok if this is published in rustsec?