### PR TITLE
aes-gcm: Add information about CVE-2023-42811

### DIFF
--- a/crates/aes-gcm/RUSTSEC-0000-0000.md
+++ b/crates/aes-gcm/RUSTSEC-0000-0000.md
@@ -1,0 +1,82 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "aes-gcm"
+date = "2023-11-22"
+#withdrawn = "YYYY-MM-DD"
+url = "https://github.com/RustCrypto/AEADs/security/advisories/GHSA-423w-p2w9-r7vq"
+# See https://docs.rs/rustsec/latest/rustsec/advisory/enum.Category.html
+categories = ["crypto-failure"]
+cvss = "CVSS:3.1/AV:L/AC:H/PR:H/UI:N/S:U/C:L/I:H/A:N"
+aliases = ["CVE-2023-42811","GHSA-423w-p2w9-r7vq"]
+license = "CC-BY-4.0"
+
+[affected.functions]
+"aes_gcm::AeadInPlace::decrypt_in_place_detached" = [">= 0.10.0, < 0.10.3"]
+"aes_gcm::AesGcm::decrypt_in_place_detached" = [">= 0.10.0, < 0.10.3"]
+
+[versions]
+patched = [">= 0.10.3"]
+unaffected = ["< 0.10.0"]
+```
+
+# Plaintext exposed in decrypt_in_place_detached even on tag verification failure
+
+## Summary
+
+In the AES GCM implementation of decrypt_in_place_detached,
+the decrypted ciphertext (i.e. the correct plaintext) is
+exposed even if tag verification fails.
+
+## Impact
+
+If a program using the aes-gcm crate's decrypt_in_place*
+APIs accesses the buffer after decryption failure, it will
+contain a decryption of an unauthenticated input. Depending
+on the specific nature of the program this may enable
+Chosen Ciphertext Attacks (CCAs) which can cause a
+catastrophic breakage of the cipher including full
+plaintext recovery.
+
+## Details
+
+As seen in the implementation of decrypt_in_place_detached for
+AES GCM, if the tag verification fails, an error is returned.
+Because the decryption of the ciphertext is done in place,
+the plaintext contents are now exposed via buffer.
+
+This should ideally not be the case - as noted in page 17 of
+NIST's publication Recommendation for Block Cipher Modes of
+Operation: Galois/Counter Mode (GCM) and GMAC:
+
+In Step 8, the result of Step 7 is compared with the
+authentication tag that was received as an input: if
+they are identical, then the plaintext is returned;
+otherwise,FAIL is returned.
+
+This is seems correctly addressed in the AES GCM SIV
+implementation, where the decrypted buffer is encrypted
+again before the error is returned - this fix is
+straightforward to implement in AES GCM. To ensure that
+these types of cases are covered during testing, it
+would be valuable to add test cases like 23, 24 etc
+from project wycheproof to ensure that when a bad tag
+is used, there is an error on decryption and that the
+plaintext value is not exposed.
+
+## PoC
+
+To reproduce this issue, I'm using test case 23 from
+project wycheproof.
+
+```
+    let key = GenericArray::from_slice(&hex!("000102030405060708090a0b0c0d0e0f"));
+    let nonce = GenericArray::from_slice(&hex!("505152535455565758595a5b"));
+    let tag = GenericArray::from_slice(&hex!("d9847dbc326a06e988c77ad3863e6083")); // bad tag
+    let mut ct = hex!("eb156d081ed6b6b55f4612f021d87b39");
+    let msg = hex!("202122232425262728292a2b2c2d2e2f");
+    let aad = hex!("");
+    let cipher = Aes128Gcm::new(&key);
+    let _plaintext = cipher.decrypt_in_place_detached(&nonce, &aad, &mut ct, &tag);
+    assert_eq!(ct, msg);
+```


### PR DESCRIPTION
Information taken from: https://github.com/RustCrypto/AEADs/security/advisories/GHSA-423w-p2w9-r7vq

Note that this have a slightly different version range than the github advisory, and marks version 0.10.0 as vulnerable also.

Based on running the PoC against 0.10.0 and also reading the code here:

https://docs.rs/aes-gcm/0.10.0/src/aes_gcm/lib.rs.html#247
https://docs.rs/aes-gcm/0.10.2/src/aes_gcm/lib.rs.html#287-311
https://docs.rs/aes-gcm/0.10.3/src/aes_gcm/lib.rs.html#287-311

I think that 0.10.0 is also vulnerable.

@tarcieri is it ok if this gets published in rustsec?