### PR TITLE
odoh-rs: add information about CVE-2023-3766

### DIFF
--- a/crates/odoh-rs/RUSTSEC-0000-0000.md
+++ b/crates/odoh-rs/RUSTSEC-0000-0000.md
@@ -1,0 +1,35 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "odoh-rs"
+date = "2023-08-03"
+url = "https://github.com/cloudflare/odoh-rs/security/advisories/GHSA-gpcv-p28p-fv2p"
+references = ["https://github.com/cloudflare/odoh-rs/pull/28"]
+# See https://docs.rs/rustsec/latest/rustsec/advisory/enum.Category.html
+categories = ["denial-of-service"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
+aliases = ["CVE-2023-3766","GHSA-gpcv-p28p-fv2p"]
+license = "CC-BY-4.0"
+
+[versions]
+patched = [">= 1.0.2"]
+```
+
+# Invalid Slice Split Results in Server Panic
+
+A vulnerability was discovered in the odoh-rs rust crate that stems
+from faulty logic during the parsing of encrypted queries. This
+issue specifically occurs when processing encrypted query data
+received from remote clients.
+
+## Impact
+
+An attacker with knowledge of this vulnerability could craft and send
+specially designed encrypted queries to targeted ODOH servers running
+with odoh-rs. Upon successful exploitation, the server will crash
+abruptly, disrupting its normal operation and rendering the service
+temporarily unavailable.
+
+## Patches
+
+Users are encouraged to update their odoh-rs's rust crate to v1.0.2.


### PR DESCRIPTION
Information taken from https://github.com/cloudflare/odoh-rs/security/advisories/GHSA-gpcv-p28p-fv2p

@xofyarg is it ok if this gets added to rustsec?