### PR TITLE
Report unsoundness for lmdb-rs

### DIFF
--- a/crates/lmdb-rs/RUSTSEC-0000-0000.md
+++ b/crates/lmdb-rs/RUSTSEC-0000-0000.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "lmdb-rs"
+date = "2025-12-22"
+informational = "unsound"
+url = "https://github.com/vhbit/lmdb-rs/issues/69"
+keywords = ["unsound"]
+references = ["https://github.com/vhbit/lmdb-rs/issues/67"]
+
+[affected.functions]
+"lmdb_rs::FromMdbValue::from_mdb_value" = [">= 0.0.0"]
+
+[versions]
+patched = []
+```
+
+# Undefined Behavior by Safe Function `from_mdb_value`
+
+The implementation of `FromMdbValue` for `Vec<u8>` calls `slice::from_raw_parts` without validating the pointer or length.
+This allows creating a slice from an invalid pointer (e.g. dangling or null), leading to Undefined Behavior even when called from safe code.
+
+The issue was reported in [issue #69](https://github.com/vhbit/lmdb-rs/issues/69) with a PoC demonstrating UB using `miri`.
+
+This vulnerability affects the same function `from_mdb_value` that was previously reported and had a proposed fix in [issue #67](https://github.com/vhbit/lmdb-rs/issues/67). However, the previous attempts did not fully satisfy safety requirements, indicating a necessity for a more systematic patch.


### PR DESCRIPTION
The safe API, which has been reported with undefined behavior, can trigger UB again. It requires a more systematic fix on satisfying safety invariants.