### PR TITLE
Add advisory for capnp unsoundness

### DIFF
--- a/crates/capnp/RUSTSEC-0000-0000.md
+++ b/crates/capnp/RUSTSEC-0000-0000.md
@@ -1,0 +1,42 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "capnp"
+date = "2025-12-24"
+url = "https://github.com/capnproto/capnproto-rust/issues/605"
+categories = ["memory-corruption"]
+keywords = ["unsoundness", "undefined-behavior"]
+
+[affected.functions]
+"capnp::constant::Reader::get" = ["< 0.24.0"]
+"capnp::schema::StructSchema::new" = ["< 0.24.0"]
+
+[versions]
+patched = [">= 0.24.0"]
+```
+
+# Unsound APIs of public `constant::Reader` and `StructSchema`
+
+The safe API functions `constant::Reader::get` and `StructSchema::new` rely on `PointerReader::get_root_unchecked`, which can cause undefined behavior (UB) by constructing arbitrary words or schemas.
+
+## `Reader::get`
+
+```rust
+pub fn get(&self) -> Result<<T as Owned>::Reader<'static>> {
+    // ...
+    // UNSAFE: access `words` without validation
+}
+```
+
+## `StructSchema::new`
+
+```rust
+pub fn new(builder: RawBrandedStructSchema) -> StructSchema {
+    // ...
+    // UNSAFE: access encoded nodes without validation
+}
+```
+
+This vulnerability allows safe Rust code to trigger UB, which violates Rust's safety guarantees.
+
+The issue is resolved in version `0.24.0` by making constructor functions unsafe and mark the fields of struct as visible only in the crate.


### PR DESCRIPTION
The unsoundness issue has been verified and patched in the latest version of crate: https://github.com/capnproto/capnproto-rust/issues/605

I would like to confirm for the maintainer that whether the advisory will break any normal use cases. 

From my understanding, this will only alarm in the `cargo audit` so it might not be bothering. Also, the users of the crate should still be notified the potential UB can be triggered with the safe function in affected versions.