### PR TITLE
process_lock: add information about CVE-2025-48751

### DIFF
--- a/crates/process_lock/RUSTSEC-0000-0000.md
+++ b/crates/process_lock/RUSTSEC-0000-0000.md
@@ -1,0 +1,61 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "process_lock"
+date = "2025-05-16"
+url = "https://github.com/tickbh/ProcessLock/issues/1"
+informational = "unsound"
+# See https://docs.rs/rustsec/latest/rustsec/advisory/enum.Category.html
+cvss = "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L"
+keywords = ["data race"]
+aliases = ["CVE-2025-48751"]
+
+[affected.functions]
+"process_lock::ProcessLock::unlock" = [">= 0.1.0"]
+
+[versions]
+patched = []
+unaffected = []
+
+[affected]
+```
+
+# Unsound issue in unlock
+
+Our static analyzer find a potential unsound issue
+(data races) in ProcessLock, where the unlock fuction
+needs to be marked as unsafe explicitly, otherwise
+safe Rust can have data races when user unlock
+unexpectedly, you can check lock-api for details.
+
+## PoC
+
+A potentail PoC code is like:
+
+```
+#[deny(unsafe_code)]
+use std::sync::Arc;
+use process_lock::*;
+use std::thread;
+use std::time::Duration;
+
+
+fn main() {
+    let mut s1 = Arc::new(ProcessLock::new("test".parse().unwrap(), None).unwrap());
+    let mut s2 = s1.clone();
+    let h = std::thread::spawn(move || {
+        if let Ok(mut guard) = s2.lock() {
+            thread::sleep(Duration::from_secs(1));
+            // data race 1
+        }
+    });
+    thread::sleep(Duration::from_secs(1));
+    if let Ok(_) = s1.unlock(){
+      if let Ok(guard2) = s1.lock(){
+          println!("data races");
+          // data race 2
+      }
+    }
+    h.join().unwrap();
+}
+```


### PR DESCRIPTION
information taken from: https://github.com/tickbh/ProcessLock/issues/1

@tickbh ok if this gets added to rustsec? 