### PR TITLE
ruint: add patched version for RUSTSEC-2025-0137

### DIFF
--- a/crates/ruint/RUSTSEC-2025-0137.md
+++ b/crates/ruint/RUSTSEC-2025-0137.md
@@ -12,7 +12,7 @@ aliases = ["GHSA-9fjq-45qv-pcm7"]
 "ruint::algorithms::div::reciprocal_mg10" = ["< 1.17.0"]
 
 [versions]
-patched = []
+patched = [">= 1.17.1"]
 ```
 
 # Unsoundness of safe `reciprocal_mg10`


### PR DESCRIPTION
Fixed in https://github.com/recmo/uint/commit/8090e7f9393e7481a20d2e61dac04e78efcc90dd, released in 1.17.1.