### PR TITLE
Segfault and invalid memory read in mnl

### DIFF
--- a/crates/mnl/RUSTSEC-0000-0000.md
+++ b/crates/mnl/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "mnl"
+date = "2025-10-18"
+url = "https://github.com/mullvad/mnl-rs/issues/15"
+categories = ["memory-corruption"]
+
+[versions]
+patched = []
+```
+
+# Segmentation fault and invalid memory read in `mnl::cb_run`
+
+The function `mnl::cb_run` is marked as safe but exhibits unsound behavior when processing malformed Netlink message buffers.
+
+Passing a crafted byte slice to `mnl::cb_run` can trigger memory violations. The function does not sufficiently validate the input buffer structure before processing, leading to out-of-bounds reads.
+
+This vulnerability allows an attacker to cause a Denial of Service (segmentation fault) or potentially read unmapped memory by providing a malformed Netlink message.


### PR DESCRIPTION
# Segmentation fault and invalid memory read in `mnl::cb_run`

The function `mnl::cb_run` is marked as safe but exhibits unsound behavior when processing malformed Netlink message buffers.

Passing a crafted byte slice to `mnl::cb_run` can trigger memory violations. The function does not sufficiently validate the input buffer structure before processing, leading to out-of-bounds reads.

This vulnerability allows an attacker to cause a Denial of Service (segmentation fault) or potentially read unmapped memory by providing a malformed Netlink message.