### PR TITLE
add-rustsec-for-virt1

### DIFF
--- a/crates/virt/RUSTSEC-2025-0126.md
+++ b/crates/virt/RUSTSEC-2025-0126.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "virt"
+date = "2025-09-25"
+url = "https://gitlab.com/libvirt/libvirt-rust/-/issues/31"
+
+[versions]
+patched = []
+```
+
+# NulError Panic in Connect::open_read_only
+The Connect::open_read_only method in the Connect implementation is causing a panic due to a NulError. The NulError indicates that the CString conversion failed due to the presence of a null byte (\0) in the input string.
+
+The issue originates from the following methods in connect.rs:
+```Rust
+pub fn open_read_only(uri: Option<&str>) -> Result<Connect, Error> {
+    let uri_buf = some_string_to_cstring!(uri);
+    let c = unsafe { sys::virConnectOpenReadOnly(some_cstring_to_c_chars!(uri_buf)) };
+    if c.is_null() {
+        return Err(Error::last_error());
+    }
+    Ok(unsafe { Connect::from_ptr(c) })
+}
+```


### PR DESCRIPTION
The `Connect::open_read_only` method in the `Connect` implementation is causing a panic due to a NulError. The NulError indicates that the `CString` conversion failed due to the presence of a null byte (`\0`) in the input string.