### PR TITLE
NulError Panic in virt::Connect::open and virt::Connect::open_read_only

### DIFF
--- a/crates/virt/RUSTSEC-0000-0000.md
+++ b/crates/virt/RUSTSEC-0000-0000.md
@@ -2,8 +2,12 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "virt"
-date = "2025-9-25"
+date = "2025-09-25"
 url = "https://gitlab.com/libvirt/libvirt-rust/-/issues/31"
+
+[affected.functions]
+"virt::Connect::open" = ["<= 0.4.3"]
+"virt::Connect::open_read_only" = ["<= 0.4.3"]
 
 [versions]
 patched = []


### PR DESCRIPTION
The Connect::open and Connect::open_read_only methods in the Connect implementation are causing a panic due to a NulError. The NulError indicates that the CString conversion failed due to the presence of a null byte (\0) in the input string.

The issue is [here](https://gitlab.com/libvirt/libvirt-rust/-/issues/31).