### PR TITLE
crates/rkyv/RUSTSEC-2026-0001.md:  Add v0.7 version with issue patched

### DIFF
--- a/crates/rkyv/RUSTSEC-2026-0001.md
+++ b/crates/rkyv/RUSTSEC-2026-0001.md
@@ -8,7 +8,7 @@ categories = ["memory-corruption"]
 keywords = ["oom", "undefined-behavior"]
 
 [versions]
-patched = [">= 0.7.46", ">= 0.8.13"]
+patched = [">= 0.7.46, < 0.8.0", ">= 0.8.13"]
 ```
 
 # Potential Undefined Behaviors in `Arc<T>`/`Rc<T>` impls of `from_value` on OOM


### PR DESCRIPTION
Patched in https://github.com/rkyv/rkyv/pull/645; released with https://github.com/rkyv/rkyv/commit/2e47d8d9e027d7584f16c476bb698b0a35bc0b82