### PR TITLE
Potential NulError Panic in c-ares

### DIFF
--- a/crates/c-ares/RUSTSEC-0000-0000.md
+++ b/crates/c-ares/RUSTSEC-0000-0000.md
@@ -5,11 +5,6 @@ package = "c-ares"
 date = "2025-09-24"
 url = "https://github.com/dimbleby/rust-c-ares/issues/143"
 
-[affected.functions]
-"c-ares::Options::set_lookups" = ["<= 12.0.0"]
-"c-ares::Options::set_resolvconf_path" = ["<= 12.0.0"]
-"c-ares::Options::set_hosts_path" = ["<= 12.0.0"]
-
 [versions]
 patched = []
 ```


### PR DESCRIPTION
The following functions in channel.rs use CString::new().unwrap() to convert a Rust string (&str) into a CString

```Rust
pub fn set_lookups(&mut self, lookups: &str) -> &mut Self {
    let c_lookups = CString::new(lookups).unwrap(); // Potential panic
    self.lookups = Some(c_lookups);
    self.optmask |= c_ares_sys::ARES_OPT_LOOKUPS;
    self
}

pub fn set_resolvconf_path(&mut self, resolvconf_path: &str) -> &mut Self {
    let c_resolvconf_path = CString::new(resolvconf_path).unwrap(); // Potential panic
    self.resolvconf_path = Some(c_resolvconf_path);
    self.optmask |= c_ares_sys::ARES_OPT_RESOLVCONF;
    self
}

pub fn set_hosts_path(&mut self, hosts_path: &str) -> &mut Self {
    let c_hosts_path = CString::new(hosts_path).unwrap(); // Potential panic
    self.hosts_path = Some(c_hosts_path);
    self.optmask |= c_ares_sys::ARES_OPT_HOSTS_FILE;
    self
}
```
If the input string contains a null byte (\0), CString::new will return an Err value (NulError), and calling .unwrap() on it will cause the program to panic.

The issue is [here](https://github.com/dimbleby/rust-c-ares/issues/143).