### PR TITLE
Null Pointer Dereference and Index Out of Bounds Panics in moonfire-ffmpeg

### DIFF
--- a/crates/moonfire-ffmpeg/RUSTSEC-0000-0000.md
+++ b/crates/moonfire-ffmpeg/RUSTSEC-0000-0000.md
@@ -1,0 +1,47 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "moonfire-ffmpeg"
+date = "2025-09-27"
+url = "https://github.com/scottlamb/moonfire-ffmpeg/issues/4"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Null Pointer Dereference and Index Out of Bounds Panics in moonfire-ffmpeg
+
+Found two critical safety issues in moonfire-ffmpeg that can cause panics when handling invalid input data during fuzzing:
+
+First, Null Pointer Dereference in VideoFrame::plane()
+Location: src/avutil.rs
+Panic Message:null pointer dereference occurred
+Problematic Code:
+```Rust
+impl VideoFrame {
+    pub fn plane(&self, plane: usize) -> Plane {
+        assert!(plane < 8);
+        let plane_off = isize::try_from(plane).unwrap();
+        let d = unsafe { *self.stuff.data.offset(plane_off) };  // <- NULL POINTER DEREFERENCE
+        let l = unsafe { *self.stuff.linesizes.offset(plane_off) };
+        assert!(!d.is_null());
+        assert!(l > 0);
+        // ...
+    }
+}
+```
+Issue:The code directly dereferences self.stuff.data.offset(plane_off) without checking if self.stuff.data is null. When data is null, calling offset() and then dereferencing with * causes a null pointer dereference panic.
+
+Second, Index Out of Bounds in Streams::get()
+Location: src/avformat.rs
+Panic Message:index out of bounds: the len is 1 but the index is 3617292328856139833
+Problematic Code:
+```Rust
+impl<'owner> Streams<'owner> {
+    pub fn get(&self, i: usize) -> InputStream<'owner> {
+        InputStream(unsafe { self.0[i].as_ref() }.unwrap())  // <- INDEX OUT OF BOUNDS
+    }
+}
+```
+Issue: The code directly indexes into self.0[i] without bounds checking. The fuzzer generated an extremely large index value (3617292328856139833) which is far beyond the actual array length (1), causing an index out of bounds panic.


### PR DESCRIPTION
Found two critical safety issues in moonfire-ffmpeg that can cause panics when handling invalid input data during fuzzing:

1. Null Pointer Dereference in VideoFrame::plane()
    **Location**: src/avutil.rs:197
    **Panic Message**:null pointer dereference occurred
    **Problematic Code**:
    ```Rust
    impl VideoFrame {
        pub fn plane(&self, plane: usize) -> Plane {
            assert!(plane < 8);
            let plane_off = isize::try_from(plane).unwrap();
            let d = unsafe { *self.stuff.data.offset(plane_off) };  // <- NULL POINTER DEREFERENCE
            let l = unsafe { *self.stuff.linesizes.offset(plane_off) };
            assert!(!d.is_null());
            assert!(l > 0);
            // ...
        }
    }
    ```
    **Issue**:The code directly dereferences self.stuff.data.offset(plane_off) without checking if self.stuff.data is null. When data is null, calling offset() and then dereferencing with * causes a null pointer dereference panic.

2. Index Out of Bounds in Streams::get()
    **Location**: src/avformat.rs:443
    **Panic Message**:index out of bounds: the len is 1 but the index is 3617292328856139833
    **Problematic Code**:
    ```Rust
    impl<'owner> Streams<'owner> {
        pub fn get(&self, i: usize) -> InputStream<'owner> {
            InputStream(unsafe { self.0[i].as_ref() }.unwrap())  // <- INDEX OUT OF BOUNDS
        }
    }
    ```
    **Issue**: The code directly indexes into self.0[i] without bounds checking. The fuzzer generated an extremely large index value (3617292328856139833) which is far beyond the actual array length (1), causing an index out of bounds panic.