### PR TITLE
Integer overflow in pcre2

### DIFF
--- a/crates/pcre2/RUSTSEC-0000-0000.md
+++ b/crates/pcre2/RUSTSEC-0000-0000.md
@@ -1,0 +1,32 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "pcre2"
+date = "2025-09-24"
+url = "https://github.com/BurntSushi/rust-pcre2/issues/50"
+
+
+[versions]
+patched = [">= 0.2.11"]
+```
+
+# Integer overflow in CaptureLocations::get method
+
+The CaptureLocations::get method in rust-pcre2/src/bytes.rs:815:32 may panic due to an integer overflow when calculating i * 2. This issue occurs when the input i is large enough to cause the multiplication to exceed the maximum value of usize.
+
+```Rust
+pub fn get(&self, i: usize) -> Option<(usize, usize)> {
+        let ovec = self.data.ovector();
+        let s = match ovec.get(i * 2) {
+            None => return None,
+            Some(&s) if s == PCRE2_UNSET => return None,
+            Some(&s) => s,
+        };
+        let e = match ovec.get(i * 2 + 1) {
+            None => return None,
+            Some(&e) if e == PCRE2_UNSET => return None,
+            Some(&e) => e,
+        };
+        Some((s, e))
+    }
+```


### PR DESCRIPTION
The `CaptureLocations::get` method in `rust-pcre2/src/bytes.rs` may panic due to an integer overflow when calculating `i * 2`. This issue occurs when the input `i` is large enough to cause the multiplication to exceed the maximum value of `usize`.

```Rust
pub fn get(&self, i: usize) -> Option<(usize, usize)> {
        let ovec = self.data.ovector();
        let s = match ovec.get(i * 2) {
            None => return None,
            Some(&s) if s == PCRE2_UNSET => return None,
            Some(&s) => s,
        };
        let e = match ovec.get(i * 2 + 1) {
            None => return None,
            Some(&e) if e == PCRE2_UNSET => return None,
            Some(&e) => e,
        };
        Some((s, e))
    }
```
The issue is [here](https://github.com/BurntSushi/rust-pcre2/issues/50).
The fix is [here](https://github.com/BurntSushi/rust-pcre2/pull/51).