### PR TITLE
Global-buffer-overflow in special_fun

### DIFF
--- a/crates/special-fun/RUSTSEC-0000-0000.md
+++ b/crates/special-fun/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "special-fun"
+date = "2025-10-18"
+url = "https://github.com/vks/special-fun/issues/17"
+categories = ["memory-corruption"]
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# Global-buffer-overflow in special_fun
+
+A global-buffer-overflow vulnerability exists in the Cephes Math Library's single-precision factorial function facf, as used by the Rust crate special_fun. When an out-of-range integer is passed to facf, the function performs an unsafe array access, resulting in a crash.
+
+Crash Information
+Error Type: Global-buffer-overflow (AddressSanitizer)


### PR DESCRIPTION
A global-buffer-overflow vulnerability exists in the Cephes Math Library's single-precision factorial function `facf`, as used by the Rust crate special_fun. When an out-of-range integer is passed to `facf`, the function performs an unsafe array access, resulting in a crash.

Crash Information
Error Type: `Global-buffer-overflow`

The issue is [here](https://github.com/vks/special-fun/issues/17).