### PR TITLE
Pointer Offset Overflow in onig

### DIFF
--- a/crates/onig/RUSTSEC-0000-0000.md
+++ b/crates/onig/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "onig"
+date = "2025-10-18"
+url = "https://github.com/rust-onig/rust-onig/issues/206"
+
+[versions]
+patched = []
+```
+
+# Pointer Offset Overflow in onig
+
+A pointer offset overflow vulnerability has been discovered in the Region::pos method of the rust-onig library. The method performs an unchecked conversion from usize to isize, which can lead to address calculation overflow in the subsequent ptr::offset operation.
+
+Crash Information:
+Error Type: unsafe precondition(s) violated: ptr::offset requires the address calculation to not overflow
+Location: region.rs in Region::pos
+Root Cause: Conversion of usize values greater than isize::MAX to isize causes integer overflow
+


### PR DESCRIPTION
A pointer offset overflow vulnerability has been discovered in the `Region::pos` method of the rust-onig library. The method performs an unchecked conversion from `usize` to `isize`, which can lead to address calculation overflow in the subsequent `ptr::offset` operation.

**Crash Information:**
**Error Type**: unsafe precondition(s) violated: ptr::offset requires the address calculation to not overflow
**Location**: region.rs in Region::pos
**Root Cause**: Conversion of usize values greater than isize::MAX to isize causes integer overflow

The issue is [here](https://github.com/rust-onig/rust-onig/issues/206).