### PR TITLE
Update RUSTSEC-2026-0001.md

### DIFF
--- a/crates/rkyv/RUSTSEC-2026-0001.md
+++ b/crates/rkyv/RUSTSEC-2026-0001.md
@@ -8,7 +8,7 @@ categories = ["memory-corruption"]
 keywords = ["oom", "undefined-behavior"]
 
 [versions]
-patched = [">= 0.8.13"]
+patched = [">= 0.8.13", ">= 0.7.46"]
 ```
 
 # Potential Undefined Behaviors in `Arc<T>`/`Rc<T>` impls of `from_value` on OOM


### PR DESCRIPTION
Fix was backported and released to the 0.7 branch as well.