### PR TITLE
Add CVE-2022-24988

### DIFF
--- a/crates/galois_2p8/RUSTSEC-0000-0000.md
+++ b/crates/galois_2p8/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "galois_2p8"
+date = "2022-11-21"
+url = "https://github.com/djsweet/galois_2p8/blob/master/CHANGELOG.md#012---2022-02-13"
+categories = ["memory-corruption"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+aliases = ["CVE-2022-24988"]
+
+[affected.functions]
+"galois_2p8::PrimitivePolynomialField::new" = ["< 0.1.2"]
+
+[versions]
+patched = [">= 0.1.2"]
+```
+
+# Buffer overflow in PrimitivePolynomialField::new
+
+PrimitivePolynomialField::new no longer writes one
+byte past its allocated vec (thanks to
+@thejohncrafter for finding and fixing the issue).


### PR DESCRIPTION
Information taken from: https://nvd.nist.gov/vuln/detail/CVE-2022-24988

@djsweet any objections to adding this to rustsec?