### PR TITLE
trailer: add information about CVE-2025-47737

### DIFF
--- a/crates/trailer/RUSTSEC-0000-0000.md
+++ b/crates/trailer/RUSTSEC-0000-0000.md
@@ -1,0 +1,52 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "trailer"
+date = "2025-05-04"
+url = "https://github.com/Geal/trailer/issues/2"
+aliases = ["CVE-2025-47737"]
+cvss = "CVSS:3.1/AV:L/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:L"
+
+[versions]
+patched = []
+unaffected = []
+
+[affected]
+```
+
+# Unsound issue in Trailer
+
+Our static analyzer find a potential unsound issue
+in the construction of Trailer, where it doesn't
+provide enough check to ensure the soundness.
+
+trailer/src/lib.rs, Lines 18 to 25 in d474984:
+```
+ pub fn new(capacity: usize) -> Trailer<T> { 
+     unsafe { 
+         let trailer = Trailer::allocate(capacity); 
+         let ptr = trailer.ptr as *mut T; 
+         ptr.write(T::default()); 
+         trailer 
+     } 
+ } 
+```
+
+The constructor does not check the T is not a ZST in
+rust, and allocating with size 0 is considered
+as undefined behaviors in Rust. A poc code like
+below can work:
+
+```
+use trailer::Trailer;
+#[derive(Default)]
+struct Zst;
+
+fn main() {
+    let mut a = Trailer::<Zst>::new(0);
+    drop(a);
+}
+```
+
+The trailer crate is unmaintained and this security issue
+will not be fixed.


### PR DESCRIPTION
Information taken from: https://github.com/Geal/trailer/issues/2

@Geal any opposition to adding this to rustsec?