### PR TITLE
Update RUSTSEC-2025-0141.md: Add Speedy as an alternative

### DIFF
--- a/crates/bincode/RUSTSEC-2025-0141.md
+++ b/crates/bincode/RUSTSEC-2025-0141.md
@@ -25,3 +25,5 @@ The team considers version 1.3.3 a complete version of bincode that is not in ne
     * [bitcode](https://crates.io/crates/bitcode)
 
     * [rkyv](https://crates.io/crates/rkyv)
+
+    * [speedy](https://crates.io/crates/speedy)


### PR DESCRIPTION
Add the Speedy crate as an alternative to Bincode.  I find it to be a closer replacement than rkyv or bitcode.