### PR TITLE
lucet-runtime: add information about CVE-2021-43790

### DIFF
--- a/crates/lucet-runtime/RUSTSEC-0000-0000.md
+++ b/crates/lucet-runtime/RUSTSEC-0000-0000.md
@@ -1,0 +1,65 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "lucet-runtime"
+date = "2021-11-30"
+url = "https://github.com/bytecodealliance/lucet/security/advisories/GHSA-hf79-8hjp-rrvq"
+# Valid categories: "code-execution", "crypto-failure", "denial-of-service", "file-disclosure"
+# "format-injection", "memory-corruption", "memory-exposure", "privilege-escalation"
+keywords = ["use after free"]
+aliases = ["CVE-2021-43790","GHSA-hf79-8hjp-rrvq"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:C/C:H/I:H/A:H"
+license = "CC-BY-4.0"
+
+[versions]
+patched = []
+unaffected = []
+
+[affected]
+```
+
+# Use After Free in lucet-runtime
+
+There is a bug in the main branch of Lucet's lucet-runtime
+that allows a use-after-free in an Instance object that could
+result in memory corruption, data race, or other related
+issues. This bug was introduced early in the development
+of Lucet and is present in all releases. As a result of
+this bug, and dependent on the memory backing for the
+Instance objects, it is possible to trigger a
+use-after-free when the Instance is dropped.
+
+## Patches
+
+Users should upgrade to the main branch of the Lucet
+repository. Lucet does not provide versioned releases on
+crates.io.
+
+## Workarounds
+
+There is no way to remediate this vulnerability without
+upgrading.
+
+## Description
+
+Lucet uses a "pool" allocator for new WebAssembly
+instances that are created. This pool allocator manages
+everything from the linear memory of the wasm instance,
+the runtime stack for async switching, as well as the
+memory behind the Instance itself. Instances are referred
+to via an InstanceHandle type which will, on drop,
+release the memory backing the Instance back to the pool.
+
+When an Instance is dropped, the fields of the Instance
+are destructed top-to-bottom, however when the alloc:
+Alloc field is destructed, the memory backing the
+Instance is released back to the pool before the
+destructors of the remaining fields are run. If another
+thread allocates the same memory from the pool while
+these destructors are still running, a race condition
+occurs that can lead to use-after-free errors.
+
+The bug was corrected by changing how the InstanceHandle
+destructor operates to ensure that the memory backing an
+Instance is only returned to the pool once the Instance
+has been completely destroyed.


### PR DESCRIPTION
information taken from: https://github.com/bytecodealliance/lucet/security/advisories/GHSA-hf79-8hjp-rrvq

@boxdot any objections to adding this to rustsec?