### PR TITLE
cmov: add advisory for non-constant-time code generation

### DIFF
--- a/crates/cmov/RUSTSEC-0000-0000.md
+++ b/crates/cmov/RUSTSEC-0000-0000.md
@@ -1,0 +1,65 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "cmov"
+date = "2026-01-14"
+url = "https://github.com/RustCrypto/utils/security/advisories/GHSA-2gqc-6j2q-83qp"
+categories = ["crypto-failure"]
+cvss = "CVSS:4.0/AV:N/AC:H/AT:N/PR:N/UI:N/VC:H/VI:N/VA:N/SC:H/SI:N/SA:N"
+aliases = ["CVE-2026-23519", "GHSA-2gqc-6j2q-83qp"]
+license = "CC-BY-4.0"
+
+[versions]
+patched = [">= 0.4.4"]
+```
+
+# Non-constant-time code generation on ARM32 targets
+
+## Summary
+
+While the `cmov` crate has a special backend for `aarch64` which uses special
+CSEL instructions, on 32-bit ARM it uses a portable pure Rust fallback
+implementation. This implementation uses a combination of bitwise arithmetic
+and `core::hint::black_box` to attempt to coerce constant-time code generation
+out of the optimizer, but the implementation in v0.4.3 and earlier failed to
+do this on 32-bit ARM targets.
+
+## Impact
+
+Branch instructions inserted by the LLVM optimizer on 32-bit targets can be
+leveraged using various microarchitectural sidechannels like cache timing
+attacks to learn secret information that `cmov` is designed to protect.
+
+## Details
+
+The following assembly was emitted when using `Cmov::cmovnz`, a function which
+implements a conditional move when a provided value is non-zero:
+
+```asm
+    bne  .LBB0_2
+    mvns r3, r3
+```
+
+This includes a branch instruction `bne`: Branch if Not Equal.
+
+## PoC
+
+The following code reproduces the issue:
+
+```rust
+#![no_std]
+use cmov::Cmov;
+
+#[inline(never)]
+pub fn test_ct_cmov(a: &mut u8, b: u8, c: u8) {
+    a.cmovnz(&b, c);
+}
+```
+
+## Resolution
+
+`cmov` v0.4.4 includes a portable `black_box`-based tactical mitigation for the
+issue which coerced the compiler into producing the expected codegen, and
+additionally v0.4.5 added an `asm!` reimplementation of the problematic mask
+generation function for ARM32 targets which should guarantee that particular
+function never contains a branch on such targets.


### PR DESCRIPTION
This vulnerability is has also been reported as CVE-2026-23519 and GHSA-2gqc-6j2q-83qp