### PR TITLE
Fix list formatting for alternatives to bincode (RUSTSEC-2025-0141.md)

### DIFF
--- a/crates/bincode/RUSTSEC-2025-0141.md
+++ b/crates/bincode/RUSTSEC-2025-0141.md
@@ -18,10 +18,7 @@ The team considers version 1.3.3 a complete version of bincode that is not in ne
 
 ## Alternatives to consider
 
-    * [wincode](https://crates.io/crates/wincode)
-
-    * [postcard](https://crates.io/crates/postcard)
-
-    * [bitcode](https://crates.io/crates/bitcode)
-
-    * [rkyv](https://crates.io/crates/rkyv)
+* [wincode](https://crates.io/crates/wincode)
+* [postcard](https://crates.io/crates/postcard)
+* [bitcode](https://crates.io/crates/bitcode)
+* [rkyv](https://crates.io/crates/rkyv)


### PR DESCRIPTION
Due to the indentation this was rendered as code, not as a list with proper links