### PR TITLE
Add rust-sec for triton-vm

### DIFF
--- a/crates/triton-vm/RUSTSEC-0000-0000.md
+++ b/crates/triton-vm/RUSTSEC-0000-0000.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "triton-vm"
+date = "2026-01-21"
+categories = ["crypto-failure"]
+keywords = ["proof-system", "unsound", "fiat-shamir", "fri"]
+
+[affected.functions]
+"triton_vm::verify" = ["< 2.0.0, >= 0.41.0"]
+
+[versions]
+patched = [">= 2.0.0"]
+unaffected = ["< 0.41.0"]
+```
+
+# Triton VM Soundness Vulnerability due to Improper Sampling of Randomness
+
+In affected versions of Triton VM, the verifier failed to correctly sample randomness in the FRI sub-protocol.
+
+Malicious provers can exploit this to craft proofs for arbitrary statements that this verifier accepts as valid, undermining soundness.
+
+Protocols that rely on proofs and the supplied verifier of the affected versions of Triton VM are completely broken. Protocols implementing their own verifier might be unaffected.
+
+The flaw was corrected in commit 3a045d63, where the relevant randomness is sampled correctly.


### PR DESCRIPTION
For some versions, the verifier of the Triton VM proof system failed to complete all steps necessary to guarantee that a given proof was, in fact, a proof. 