### PR TITLE
Add advisory on use-after-free in `oneshot` library

### DIFF
--- a/crates/oneshot/RUSTSEC-0000-0000.md
+++ b/crates/oneshot/RUSTSEC-0000-0000.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "oneshot"
+date = "2026-01-25"
+url = "https://github.com/faern/oneshot/issues/73"
+informational = "unsound"
+keywords = ["memory-safety", "use-after-free"]
+
+[affected]
+#arch = ["x86"]
+#os = ["windows"]
+
+[versions]
+patched = [">= 0.1.12"]
+unaffected = ["<= 0.1.1"]
+```
+
+# Potential use-after-free in `oneshot` when used asynchronously
+
+There is a race condition that can lead to a use-after-free if a `oneshot::Receiver` is polled but then dropped instead of polled to completion. This could happen if the receiver future was cancelled while receiving, for example by being wrapped in a timeout future or similar.
+
+When the `Receiver` is polled (`Future::poll`) it writes a waker to the channel and sets it to the `RECEIVING` state. If the `Receiver` was then dropped (instead of polled to completion), the `Drop` implementation on `Receiver` unconditionally swapped the channel state to `DISCONNECTED` and only after doing so it read back its waker from the heap allocation and dropped it. The problem is that the `DISCONNECTED` state could be observed by the `Sender`, which would lead to it deallocating the channel heap memory. If the `Sender` manage to free the channel before the `Receiver` managed to proceed to dropping the waker, then the `Receiver` would read from the freed channel memory (use-after-free).
+
+The fix was submitted in https://github.com/faern/oneshot/pull/74 and published as part of `oneshot` version `0.1.12`.


### PR DESCRIPTION
See https://github.com/faern/oneshot/issues/73 for details. I discovered this race just a few days ago. I got the patch working yesterday, and managed to release a patched version (0.1.12) today.

This race exists in all versions of `oneshot`, except by accident not in the initial `0.1.1` release. In the first release this would just cause a panic instead, which would at least not be UB.