### PR TITLE
Add CVE-2026-24116 for Wasmtime.

### DIFF
--- a/crates/wasmtime/RUSTSEC-0000-0000.md
+++ b/crates/wasmtime/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime"
+date = "2026-01-26"
+url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-vc8c-j3xm-xj73"
+categories = []
+keywords = []
+aliases = ["CVE-2026-24116"]
+license = "CC0-1.0"
+cvss = "CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:A/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
+
+[versions]
+patched = [">= 41.0.1", ">= 40.0.3, < 41.0.0", ">= 36.0.5, < 37.0.0", "< 29.0.0"]
+unaffected = []
+```
+
+# Wasmtime segfault or unused out-of-sandbox load with `f64.copysign` operator on x86-64 
+
+This is an entry in the RustSec database for the Wasmtime security advisory
+located at
+https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-vc8c-j3xm-xj73
+For more information see the GitHub-hosted security advisory.


### PR DESCRIPTION
This is a database entry for our recent advisory here: https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-vc8c-j3xm-xj73