### PR TITLE
RUSTSEC-2024-0436: add `with_builtin_macros` as alternative

### DIFF
--- a/crates/paste/RUSTSEC-2024-0436.md
+++ b/crates/paste/RUSTSEC-2024-0436.md
@@ -18,7 +18,7 @@ that this project is not longer maintained as well as archived the repository
 ## Possible Alternative(s)
 
 - [`pastey`]: a fork of paste and is aimed to be a drop-in replacement with additional features for paste crate
-- [`with_builtin_macros`]: crate providing a superset of `paste`'s functionality including general `macro_rules!` eager expansions and `concat!`/`concat_idents!` macros
+- [`with_builtin_macros`]: crate providing a [superset of `paste`'s functionality including general `macro_rules!` eager expansions](https://docs.rs/with_builtin_macros/0.1.0/with_builtin_macros/macro.with_eager_expansions.html)  and `concat!`/`concat_idents!` macros
 
 [`pastey`]: https://crates.io/crates/pastey
-[`with_builtin_macros`]: https://docs.rs/with_builtin_macros/0.1.0/with_builtin_macros/macro.with_eager_expansions.html
+[`with_builtin_macros`]: https://crates.io/crates/with_builtin_macros


### PR DESCRIPTION
This crate provides a superset of functionality present in `paste`, including general eager expansion support for `macro_rules!` (implemented as a proc macro), and `concat!` and `concat_idents!` macros which can be used with eager expansions.

At 3.6 million downloads, people seem to like it.

https://crates.io/crates/with_builtin_macros