### PR TITLE
ml-dsa: add "Timing side-channel in ML-DSA decomposition"

### DIFF
--- a/crates/ml-dsa/RUSTSEC-0000-0000.md
+++ b/crates/ml-dsa/RUSTSEC-0000-0000.md
@@ -1,0 +1,49 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "ml-dsa"
+date = "2025-12-12"
+url = "https://github.com/RustCrypto/signatures/security/advisories/GHSA-hcp2-x6j4-29j7"
+categories = ["crypto-failure"]
+cvss = "CVSS:3.1/AV:A/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:N"
+aliases = ["CVE-2026-22705","GHSA-hcp2-x6j4-29j7"]
+license = "CC-BY-4.0"
+
+[versions]
+patched = [">= 0.1.0-rc.3"]
+```
+
+# Timing side-channel in ML-DSA decomposition
+
+### Summary
+
+A timing side-channel was discovered in the Decompose algorithm which is used during ML-DSA signing to generate hints for the signature.
+
+### Details
+
+The analysis was performed using a constant-time analyzer that examines compiled assembly code for instructions with data-dependent timing behavior. The analyzer flags:
+
+- **UDIV/SDIV instructions**: Hardware division instructions have early termination optimizations where execution time depends on operand values.
+
+The `decompose` function used a hardware division instruction to compute `r1.0 / TwoGamma2::U32`. This function is called during signing through `high_bits()` and `low_bits()`, which process values derived from secret key components:
+
+- `(&w - &cs2).low_bits()` where `cs2` is derived from secret key component `s2`
+- `Hint::new()` calls `high_bits()` on values derived from secret key component `t0`
+
+**Original Code**:
+```rust
+fn decompose<TwoGamma2: Unsigned>(self) -> (Elem, Elem) {
+    // ...
+    let mut r1 = r_plus - r0;
+    r1.0 /= TwoGamma2::U32;  // Variable-time division on secret-derived data
+    (r1, r0)
+}
+```
+
+### Impact
+
+The dividend (`r1.0`) is derived from secret key material. An attacker with precise timing measurements could extract information about the signing key by observing timing variations in the division operation.
+
+### Mitigation
+
+Integer division was replaced with a constant-time Barrett reduction.


### PR DESCRIPTION
Previously published as: CVE-2026-22705, GHSA-hcp2-x6j4-29j7