### PR TITLE
Add RUSTSEC advisory for git2

### DIFF
--- a/crates/git2/RUSTSEC-0000-0000.md
+++ b/crates/git2/RUSTSEC-0000-0000.md
@@ -4,6 +4,7 @@ id = "RUSTSEC-0000-0000"
 package = "git2"
 date = "2026-02-02"
 url = "https://github.com/rust-lang/git2-rs/pull/1213"
+informational = "unsound"
 categories = ["memory-corruption"]
 keywords = ["undefined-behavior"]
 


### PR DESCRIPTION
Have confirmed with the maintainer and fixed the bug in latest release