### PR TITLE
Add patched versions to RUSTSEC-2025-0142

### DIFF
--- a/crates/mnl/RUSTSEC-2025-0142.md
+++ b/crates/mnl/RUSTSEC-2025-0142.md
@@ -8,7 +8,7 @@ categories = ["memory-corruption"]
 aliases = ["GHSA-585q-cm62-757j"]
 
 [versions]
-patched = []
+patched = [">= 0.3.1"]
 ```
 
 # Segmentation fault and invalid memory read in `mnl::cb_run`
@@ -18,3 +18,7 @@ The function `mnl::cb_run` is marked as safe but exhibits unsound behavior when 
 Passing a crafted byte slice to `mnl::cb_run` can trigger memory violations. The function does not sufficiently validate the input buffer structure before processing, leading to out-of-bounds reads.
 
 This vulnerability allows an attacker to cause a Denial of Service (segmentation fault) or potentially read unmapped memory by providing a malformed Netlink message.
+
+The underlying issue is a bug in `libmnl` where during validation `nlh->nlmsg_len` is cast to an `int` and becomes negative if `nlmsg_len` is greater than `INT_MAX`. This causes the validation to succeed even if the buffer is too small for the message. This has been fixed in `libmnl` but still affects version 1.0.5.
+
+The issue in `mnl` was fixed in commit `cd51bdc` by checking the validity of netlink messages passed to `mnl::cb_run`.


### PR DESCRIPTION
See https://github.com/mullvad/mnl-rs/issues/15 and https://github.com/mullvad/mnl-rs/pull/21 (the fix).