### PR TITLE
Push libcrux-psq and hpke-rs advisory proposals

### DIFF
--- a/crates/hpke-rs/RUSTSEC-0000-0000.md
+++ b/crates/hpke-rs/RUSTSEC-0000-0000.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "hpke-rs"
+date = "2026-02-10"
+url = "https://github.com/cryspen/hpke-rs/pull/118"
+categories = ["crypto-failure"]
+keywords = ["nonce-reuse", "integer-overflow", "hpke"]
+references = ["https://datatracker.ietf.org/doc/rfc9180/"]
+
+[versions]
+patched = []
+```
+
+# Nonce reuse via HPKE sequence number overflow
+
+The hpke-rs library stores the HPKE encryption context sequence number as a `u32`, which has a maximum value of 2^32 - 1. RFC 9180 requires that the sequence number be checked against 2^(8*Nn) - 1, where Nn is the nonce length (12 bytes for all standard AEAD algorithms), yielding a maximum of 2^96 - 1.
+
+The overflow guard in `increment_seq()` compares the `u32` sequence number (cast to `u128`) against 2^96 - 1. Since a `u32` can never reach this value, the comparison is always false and the check is dead code.
+
+In debug builds, Rust's default overflow checking causes a panic when the counter wraps past 2^32 - 1. In release builds, the counter silently wraps to zero via `+=`, causing nonce reuse.
+
+Nonce reuse in AES-GCM allows plaintext recovery and leaks the GHASH authentication key, enabling universal forgeries. Nonce reuse in ChaCha20-Poly1305 enables plaintext recovery via XOR of ciphertexts encrypted under the same nonce.
+
+A fix was submitted via pull request but was not merged by the maintainer. The maintainer later copied the same fix and merged it independently, without providing credit or issuing a security advisory.

--- a/crates/hpke-rs/RUSTSEC-0000-0001.md
+++ b/crates/hpke-rs/RUSTSEC-0000-0001.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "hpke-rs"
+date = "2026-02-10"
+url = "https://github.com/cryspen/hpke-rs/pull/117"
+categories = ["crypto-failure"]
+keywords = ["x25519", "hpke", "validation"]
+references = ["https://datatracker.ietf.org/doc/rfc9180/"]
+
+[versions]
+patched = []
+```
+
+# Missing mandatory X25519 all-zero output validation in HPKE
+
+RFC 9180, Section 7.1.4 mandates that HPKE implementations "MUST check whether the Diffie-Hellman shared secret is the all-zero value and abort if so." This check is required because the X25519 function, when given certain low-order points as input (the identity element, points of small order), produces an all-zero output.
+
+The hpke-rs library's Diffie-Hellman implementation, in both the RustCrypto and libcrux provider backends, returns the raw output of the X25519 computation without performing this validation. The result flows directly into `extract_and_expand()`, which derives HPKE session keys from the shared secret.
+
+An attacker who can supply a malicious public key containing a low-order point can force the shared secret to zero, making the HPKE key schedule deterministic and predictable. The attacker can then compute the same session keys as the sender and decrypt all messages.
+
+A fix was submitted via pull request but was not merged by the maintainer. The maintainer later merged their own fix without issuing a security advisory.

--- a/crates/libcrux-psq/RUSTSEC-0000-0000.md
+++ b/crates/libcrux-psq/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libcrux-psq"
+date = "2026-02-10"
+url = "https://github.com/nadimkobeissi/libcrux/commit/96d3d8a751aa536a619476a8b45c7c12b51a74ec"
+categories = ["denial-of-service"]
+keywords = ["aes-gcm", "panic", "unwrap"]
+references = ["https://github.com/cryspen/libcrux"]
+
+[versions]
+patched = []
+```
+
+# Denial of service via AES-GCM decryption panic in PSQ transport layer
+
+The `decrypt_out` method in `src/aead.rs` calls `.unwrap()` on the result of `AesGcm128::decrypt()` in the AES-GCM 128 code path. If decryption fails due to a corrupted, truncated, or maliciously crafted ciphertext, this panics and crashes the process rather than returning an error.
+
+This code path is used by the transport layer's `read_message` function for decrypting post-handshake application data. Any PSQ ciphersuite using AES-GCM 128 (nine of the eighteen supported ciphersuites) is affected: an adversary can send a single malformed ciphertext to crash the responder process. The attack requires no authentication and no knowledge of the session keys.
+
+The corresponding ChaCha20-Poly1305 path in the same method, as well as every other AEAD call site in the file, correctly uses `.map_err(|_| AEADError::CryptoError)?` to propagate decryption failures. The correct error handling was present on the line immediately following the `.unwrap()` but was commented out.
+
+The maintainer blocked the reporter's GitHub account, preventing submission of a fix via pull request. A fix was published as a public commit on a fork. The maintainer later copied this same fix and pushed it independently, without issuing a security advisory.


### PR DESCRIPTION
These are proposals for the more impactful vulnerabilities discovered as part of this research work: 

[_Verification Theatre: False Assurance in Formally Verified Cryptographic Libraries_](https://eprint.iacr.org/2026/192)

Cryspen has not issued any security advisory for any of these bugs despite patching them four days after I initially submitted my fixes.

In November 2025, another serious security issue was discovered in the `libcrux-intrinsics` crate, and Cryspen *also* did not issue a security advisory; other people had to take it upon themselves to [submit one](https://rustsec.org/advisories/RUSTSEC-2025-0133.html) to this database, and hope that a direct announcement from Cryspen would follow (it never did).

Hence, I am doing the same thing here.

The full disclosure timeline, including Cryspen's response, is documented in the paper.

Happy to accept any feedback on the wording of any of the submitted issues. Thanks.