### PR TITLE
Add advisories for the second finch attack in December

### DIFF
--- a/crates/finch-rst/RUSTSEC-0000-0000.md
+++ b/crates/finch-rst/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "finch-rst"
+date = "2025-12-09"
+expect-deleted = true
+
+[versions]
+patched = []
+```
+
+# `finch-rst` was removed from crates.io for malicious code
+
+This attempts to typosquat the existing crate
+[`finch`](https://crates.io/crates/finch) to steal credentials from local
+files.
+
+The malicious crate had 1 version published on 2025-12-08 and had been
+downloaded 21 times. There were no crates depending on this crate on crates.io.
+
+Thanks to Matthias Zepper of [NGI Sweden](https://ngisweden.scilifelab.se/) for
+reporting this to the crates.io team!

--- a/crates/finch_cli_rust/RUSTSEC-0000-0000.md
+++ b/crates/finch_cli_rust/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "finch_cli_rust"
+date = "2025-12-09"
+expect-deleted = true
+
+[versions]
+patched = []
+```
+
+# `finch_cli_rust` was removed from crates.io for malicious code
+
+This attempts to typosquat the existing crate
+[`finch_cli`](https://crates.io/crates/finch_cli) to steal credentials from
+local files.
+
+The malicious crate had 1 version published on 2025-12-08 and had been
+downloaded 18 times. There were no crates depending on this crate on crates.io.
+
+Thanks to Matthias Zepper of [NGI Sweden](https://ngisweden.scilifelab.se/) for
+reporting this to the crates.io team!

--- a/crates/sha-rst/RUSTSEC-0000-0000.md
+++ b/crates/sha-rst/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "sha-rst"
+date = "2025-12-09"
+expect-deleted = true
+
+[versions]
+patched = []
+```
+
+# `sha-rst` was removed from crates.io for malicious code
+
+This crate was used as a dependency by `finch_cli_rust` and `finch-rst` and
+contained a malware payload to exfiltrate credentials.
+
+The malicious crate had 1 version published on 2025-12-08 and had been
+downloaded 22 times. Other than the other crates above that were part of the
+attack, no other crates depedended on this crate.
+
+Thanks to Matthias Zepper of [NGI Sweden](https://ngisweden.scilifelab.se/) for
+reporting this to the crates.io team!


### PR DESCRIPTION
Just realised these slipped through the cracks, which is unfortunate, since I want to link to the advisories from the Rust blog!