### PR TITLE
Advisory for malicious and removed crate polymarket-client-sdks

### DIFF
--- a/crates/polymarket-client-sdks/RUSTSEC-0000-0000.md
+++ b/crates/polymarket-client-sdks/RUSTSEC-0000-0000.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "polymarket-client-sdks"
+date = "2026-02-13"
+expect-deleted = true
+
+[versions]
+patched = []
+```
+
+# `polymarket-client-sdks` was removed from crates.io for malicious code
+
+It appeared to be typosquatting existing crate
+[`polymarket-client-sdk`](https://crates.io/crates/polymarket-client-sdk) (`sdks` vs `sdk`)
+and attempting to steal credentials from local files.
+
+The malicious crate had 1 version published on 2026-02-09 and had been downloaded only 33 times.
+There were no crates depending on this crate on crates.io.
+
+Thanks to Roland Peelen for finding and reporting this to the crates.io team!


### PR DESCRIPTION
Note `sdks` vs `sdk`; this is distinct from, but similar to, https://github.com/rustsec/advisory-db/pull/2631