### PR TITLE
RustSec Advisories for hpke-rs and libcrux-psq

### DIFF
--- a/crates/hpke-rs/RUSTSEC-0000-0000.1.md
+++ b/crates/hpke-rs/RUSTSEC-0000-0000.1.md
@@ -10,7 +10,7 @@ keywords = ["x25519", "hpke", "validation"]
 references = ["https://datatracker.ietf.org/doc/rfc9180/"]
 
 [versions]
-patched = [">0.6.0"]
+patched = [">=0.6.0"]
 ```
 
 # Missing mandatory X25519 all-zero output validation in HPKE

--- a/crates/hpke-rs/RUSTSEC-0000-0000.md
+++ b/crates/hpke-rs/RUSTSEC-0000-0000.md
@@ -10,7 +10,7 @@ keywords = ["nonce-reuse", "integer-overflow", "hpke"]
 references = ["https://datatracker.ietf.org/doc/rfc9180/"]
 
 [versions]
-patched = [">0.6.0"]
+patched = [">=0.6.0"]
 ```
 
 # Nonce reuse via HPKE sequence number overflow

--- a/crates/libcrux-psq/RUSTSEC-0000-0000.md
+++ b/crates/libcrux-psq/RUSTSEC-0000-0000.md
@@ -10,7 +10,7 @@ keywords = ["aes-gcm", "panic", "unwrap"]
 references = ["https://github.com/cryspen/libcrux"]
 
 [versions]
-patched = [">0.0.7"]
+patched = [">=0.0.7"]
 ```
 
 # Denial of service via AES-GCM decryption panic in PSQ transport layer


### PR DESCRIPTION
This PR proposes three RustSec advisories for cryptographic vulnerabilities discovered during research (["Verification Theatre: False Assurance in Formally Verified Cryptographic Libraries"](https://eprint.iacr.org/2026/192)). The upstream maintainers (Cryspen) have patched these issues but have not filed RustSec advisories, which means `cargo audit` does not currently flag affected versions.

Cryspen has published GitHub Security Advisories (GHSAs) for some of these issues. However, we believe RustSec advisories are still warranted for the reasons outlined below.

### Proposed Advisories

**1. hpke-rs: Nonce reuse via sequence number overflow**

The library stores HPKE encryption context sequence numbers as `u32` (max 2^32 - 1) rather than enforcing the RFC 9180 limit of 2^96 - 1. The overflow guard is ineffective in release builds due to Rust's default wrapping behavior for integer overflow, allowing silent counter wrap-around. This enables nonce reuse in AES-GCM, which permits plaintext recovery and authentication key compromise, a critical vulnerability.

**2. hpke-rs: Missing X25519 zero-check validation**

RFC 9180, Section 7.1.4 requires that implementations check whether the Diffie-Hellman shared secret is the all-zero value. hpke-rs omits this check in both its RustCrypto and libcrux backends. An attacker supplying low-order points can force a zero shared secret, enabling session key prediction and message decryption.

**3. libcrux-psq: AES-GCM decryption panic on malformed ciphertext**

The `decrypt_out` method calls `.unwrap()` on AES-GCM 128 decryption results, causing a process crash when presented with malformed ciphertexts. Nine of eighteen supported ciphersuites are affected. An unauthenticated attacker can trigger denial of service by sending corrupted data, rendering the entire implementation not IND-CCA secure, a critical vulnerability.

### Why RustSec advisories are needed alongside the existing GHSAs

Cryspen published GHSA-g433-pq76-6cmf for hpke-rs and GHSA-435g-fcv3-8j26 for libcrux-psq. While we appreciate that an advisory was issued, there are several gaps that leave downstream users without the information they need:

- **Severity classification**: The hpke-rs GHSA rates the nonce-reuse vulnerability as "moderate." Nonce reuse in AES-GCM enables full plaintext recovery and authentication key compromise, which is generally considered a critical or high-severity issue in cryptographic contexts. Similarly, the libcrux-psq GHSA rates the IND-CCA-breaking bug as "moderate" only.
- **Missing impact analysis**: The GHSAs does not include a details or impact section explaining what an attacker can achieve by exploiting these vulnerabilities, making it difficult for downstream consumers to assess their risk.
- **Bundled vulnerabilities**: Multiple distinct vulnerabilities with different root causes and impacts are grouped into a single advisory, which makes it harder for users to evaluate which issues affect their use case.
- **No RustSec coverage**: The GHSAs are not mirrored in RustSec, so `cargo audit` — the standard tool Rust developers rely on to check for known vulnerabilities — does not surface these issues.

### Prior discussion

These advisories were previously proposed in PR #2637, which was closed. We sought an explanation in #2646. We are resubmitting with the hope of a productive path forward. We are happy to incorporate feedback on advisory wording, severity ratings, or any other aspect of these filings, and to work with both RustSec reviewers and the upstream maintainers to ensure the advisories are accurate and fair.

Thank you for your time and for maintaining this important resource for the Rust ecosystem.