### PR TITLE
Add advisory for image: multiple unfixed panics and OOM in decoders

### DIFF
--- a/crates/image/RUSTSEC-0000-0000.md
+++ b/crates/image/RUSTSEC-0000-0000.md
@@ -1,0 +1,29 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "image"
+date = "2026-02-22"
+url = "https://github.com/image-rs/image/issues/2672"
+references = ["https://github.com/image-rs/image/issues/2664"]
+categories = ["denial-of-service"]
+keywords = ["panic", "oom", "image-decoding", "dos"]
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# image: Multiple Unfixed Panics and OOM in Image Decoders
+
+The image crate contains multiple unfixed panics in its image decoder
+implementations (BMP, PNG, TIFF, GIF, WebP, ICO, PNM, DDS, TGA, etc.).
+Crafted image files can trigger panic!/unwrap() failures in various decoders,
+causing process termination.
+
+Open issues #2672 and #2664 document unfixed crash-inducing inputs discovered
+via fuzzing. Additionally, image dimensions from file headers are trusted for
+buffer allocation without configurable limits, enabling OOM-based denial of
+service via crafted headers claiming extreme dimensions.
+
+Any server-side application using the image crate to process user-uploaded
+images can be crashed via crafted input.


### PR DESCRIPTION
Advisory for image crate: Multiple unfixed panics and OOM in image decoders (CWE-248, CWE-400)

Crafted image files crash the process via panic!/unwrap() in BMP, PNG, TIFF, GIF, WebP decoders. References existing open issues #2672 and #2664. No patch exists.