### PR TITLE
Add advisory for reqwest: SSRF via default redirect policy

### DIFF
--- a/crates/reqwest/RUSTSEC-0000-0000.md
+++ b/crates/reqwest/RUSTSEC-0000-0000.md
@@ -1,0 +1,45 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "reqwest"
+date = "2026-02-22"
+url = "https://github.com/seanmonstar/reqwest/issues/2260"
+categories = ["denial-of-service"]
+keywords = ["ssrf", "redirect", "private-network", "metadata"]
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# reqwest: SSRF via Default Redirect Policy Following to Private Networks
+
+reqwest follows up to 10 redirects by default via `redirect::Policy::default()`.
+This policy does not filter redirect targets against private/internal IP ranges
+(RFC 1918, link-local, loopback, cloud metadata endpoints).
+
+An attacker who can influence a URL fetched by a server-side application using
+reqwest can redirect the request to internal services (e.g., AWS/GCP/Azure
+metadata at 169.254.169.254, localhost services, internal network hosts),
+enabling Server-Side Request Forgery (SSRF, CWE-918).
+
+This is a well-known SSRF attack class that browsers mitigate with private
+network access controls, but reqwest provides no equivalent built-in protection.
+
+Any server-side application fetching user-controlled URLs with the default
+redirect policy is vulnerable.
+
+## Mitigation
+
+Use a custom redirect policy that validates redirect targets:
+
+```rust
+let policy = reqwest::redirect::Policy::custom(|attempt| {
+    let url = attempt.url();
+    if is_private_ip(url) {
+        attempt.stop()
+    } else {
+        attempt.follow()
+    }
+});
+```


### PR DESCRIPTION
Advisory for reqwest: SSRF via default redirect policy (CWE-918)

The default redirect policy follows redirects to private/internal IPs including cloud metadata endpoints (169.254.169.254). Includes mitigation code example.