### PR TITLE
Add advisory for reqwest SSRF via default redirect policy

### DIFF
--- a/crates/reqwest/RUSTSEC-0000-0000.md
+++ b/crates/reqwest/RUSTSEC-0000-0000.md
@@ -1,0 +1,26 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "reqwest"
+date = "2026-02-23"
+url = "https://github.com/seanmonstar/reqwest/issues/2344"
+categories = ["code-execution"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:N/A:N"
+keywords = ["ssrf", "redirect", "private-network", "metadata", "cloud"]
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# Default redirect policy follows redirects to private/internal networks (SSRF)
+
+`reqwest`'s default redirect policy (`redirect::Policy::default()`) follows up to 10 redirects without filtering redirect targets against private or internal IP ranges. This enables Server-Side Request Forgery (SSRF) when a server-side application fetches user-controlled URLs.
+
+An attacker who controls a URL fetched by a `reqwest`-based server application can redirect requests to:
+
+- Cloud metadata endpoints (e.g., `http://169.254.169.254/latest/meta-data/iam/security-credentials/`) to steal IAM credentials
+- Localhost services (e.g., databases, caches, admin panels on `127.0.0.1`)
+- Internal network hosts (RFC 1918 addresses like `10.x.x.x`, `192.168.x.x`)
+
+This is CWE-918. Browsers mitigate this with private network access controls, but `reqwest` provides no equivalent built-in protection.


### PR DESCRIPTION
This advisory reports an SSRF vulnerability in `reqwest` due to its default redirect policy following redirects to private/internal IP ranges.

**Vulnerability:** `reqwest::redirect::Policy::default()` follows up to 10 redirects without filtering targets against private IP ranges (RFC 1918, link-local, loopback, cloud metadata endpoints).

**Impact:** Server-side applications using `reqwest` to fetch user-controlled URLs are vulnerable to SSRF (CWE-918), allowing attackers to access internal services, cloud metadata (169.254.169.254), and localhost services via redirect chains.

**Upstream issue:** https://github.com/seanmonstar/reqwest/issues/2344

**CVSS:** 8.6 (High) - CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:N/A:N