### PR TITLE
Add advisory for xml-rs Billion Laughs DoS via unbounded entity expansion

### DIFF
--- a/crates/xml-rs/RUSTSEC-0000-0000.md
+++ b/crates/xml-rs/RUSTSEC-0000-0000.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "xml-rs"
+date = "2026-02-22"
+url = "https://github.com/netvl/xml-rs/issues/new"
+categories = ["denial-of-service"]
+keywords = ["xml", "billion-laughs", "entity-expansion", "dos"]
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# Unbounded entity expansion (Billion Laughs) in xml-rs
+
+xml-rs supports internal DTD entity definitions and expands entity references recursively during parsing with no depth limit or expanded-size limit.
+
+An attacker can craft an XML document with recursively defined entities (the "Billion Laughs" attack, CWE-776) that causes exponential memory consumption and CPU exhaustion. A sub-1KB XML payload can expand to gigabytes of text (~3,000,000x amplification ratio), crashing the process or host.
+
+Any application using xml-rs to parse untrusted XML input is vulnerable.


### PR DESCRIPTION
This advisory reports a Denial of Service vulnerability in `xml-rs` due to unbounded entity expansion (Billion Laughs attack).

**Vulnerability:** `xml-rs` expands internal DTD entity references recursively during parsing with no depth or size limit (CWE-776).

**Impact:** A sub-1KB XML payload with recursively defined entities can expand to gigabytes of text (~3,000,000x amplification), causing exponential memory consumption and CPU exhaustion that crashes the process or host.

**Affected:** Any application using `xml-rs` to parse untrusted XML input.

**Upstream issue:** https://github.com/netvl/xml-rs/issues/new