### PR TITLE
report vulnerabilities in aho-corasick crate

### DIFF
--- a/crates/aho-corasick/RUSTSEC-0000-0000.md
+++ b/crates/aho-corasick/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "aho-corasick"
+date = "2025-12-20"
+categories = ["DenialOfService"]
+aliases = ["CVE-2025-70351"]
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# Out-of-bounds access
+
+Out-of-bounds access in the "find_in()" function of "Searcher" struct in "src/packed/api.rs:537", where "haystack[len]" does not check the user-provided value "len". Setting "len" to be greater than the length of 'haystack" causes denial of service.
+
+The vulnerability can be explited by setting "len" to be greater than the size of "haystack". Rust's bounds checking prevents further undefined behaviours, but it can still cause denial of service.
+
+The flaw can be corrected by adding a boundary checking in `aho_corasick::packed::Searcher::find_in`.

--- a/crates/aho-corasick/RUSTSEC-0000-0001.md
+++ b/crates/aho-corasick/RUSTSEC-0000-0001.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "aho-corasick"
+date = "2025-12-20"
+categories = ["DenialOfService"]
+aliases = ["CVE-2025-70350"]
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# Integer overflow in the offset()
+
+Integer overflow in the `offset()` function of Span struct in "src/util/search.rs:714". The addition of two usize variables without range checking at `Span { start: self.start + offset, end: self.end + offset }` may cause denial of service.
+
+The vulnerability can be exploited by setting `start` and `end` variables of a `Span` instance to large numbers, such as usize::MAX - 10, and then setting `offset` variables to a large number as well. The vulnerability can be triggered by calling "offset()".
+
+This flaw can be corrected by adding a range checking in the `offset()` function.


### PR DESCRIPTION
Add two cves: CVE-2025-70350 and CVE-2025-70351. CVE IDs are assigned, but details are not updated online.