### PR TITLE
Update affected versions in RUSTSEC-2025-0140

### DIFF
--- a/crates/gix-date/RUSTSEC-2025-0140.md
+++ b/crates/gix-date/RUSTSEC-2025-0140.md
@@ -9,7 +9,7 @@ keywords = ["utf8", "undefined-behavior"]
 aliases = ["CVE-2026-0810", "GHSA-6mw6-mj76-grwc"]
 
 [affected.functions]
-"gix_date::parse::TimeBuf::as_str" = ["<= 0.11.1"]
+"gix_date::parse::TimeBuf::as_str" = ["<= 0.11.1, >= 0.10.0"]
 
 [versions]
 patched = [">= 0.12.0"]


### PR DESCRIPTION
`TimeBuf` was first introduced in `gix-date v0.10.0`, including this vulnerability: <https://github.com/GitoxideLabs/gitoxide/commit/57366d3ebd622af8927bb0e199ab8a3c0eafee99>

```
$ git describe --contains 57366d3ebd622af8927bb0e199ab8a3c0eafee99
gix-date-v0.10.0~2^2~5
```