### PR TITLE
add advisory for time_calibrator

### DIFF
--- a/crates/time_calibrator/RUSTSEC-0000-0000.md
+++ b/crates/time_calibrator/RUSTSEC-0000-0000.md
@@ -14,9 +14,9 @@ patched = []
 It was reported `time_calibrator` contained malicious code, that would try to
 upload `.env` files to a server.
 
-The malicious crate had only 1 version published at 2026-02-28 no evidence of 
-actual usage. The crate was removed from crates.io and the user account was locked.
-There were no crates depending on this crate on crates.io.
+The malicious crate had only 1 version published at 2026-02-28 and no evidence
+of actual usage. The crate was removed from crates.io and the user account was
+locked. There were no crates depending on this crate on crates.io.
 
 Thanks to Gabriel Silva for finding and reporting this to the Rust security response
 working group, and thanks to Emily Albini for co-ordinating with the crates.io and


### PR DESCRIPTION
Hi there! I'm a new [Infra Engineer](https://rust-lang.org/governance/teams/infra/#team-infra) working for the Rust Foundation. 

This crate was reported as malicious and taken down. Please let me know if I missed anything regarding this advisory.

