### PR TITLE
Add blog post urls to RUSTSEC-2026-{0033-0035}

### DIFF
--- a/crates/pingora-cache/RUSTSEC-2026-0035.md
+++ b/crates/pingora-cache/RUSTSEC-2026-0035.md
@@ -3,7 +3,7 @@
 id = "RUSTSEC-2026-0035"
 package = "pingora-cache"
 date = "2026-03-04"
-# url = "https://blog.cloudflare.com/TBD" # More details to come in an upcoming Cloudflare blog post
+url = "https://blog.cloudflare.com/pingora-oss-smuggling-vulnerabilities/"
 references = ["https://nvd.nist.gov/vuln/detail/CVE-2026-2836"]
 keywords = ["http", "cache-poisoning"]
 aliases = ["CVE-2026-2836", "GHSA-f93w-pcj3-rggc"]

--- a/crates/pingora-core/RUSTSEC-2026-0033.md
+++ b/crates/pingora-core/RUSTSEC-2026-0033.md
@@ -3,7 +3,7 @@
 id = "RUSTSEC-2026-0033"
 package = "pingora-core"
 date = "2026-03-04"
-# url = "https://blog.cloudflare.com/TBD" # More details to come in an upcoming Cloudflare blog post
+url = "https://blog.cloudflare.com/pingora-oss-smuggling-vulnerabilities/"
 references = ["https://nvd.nist.gov/vuln/detail/CVE-2026-2833"]
 keywords = ["http", "request-smuggling"]
 aliases = ["CVE-2026-2833", "GHSA-xq2h-p299-vjwv"]

--- a/crates/pingora-core/RUSTSEC-2026-0034.md
+++ b/crates/pingora-core/RUSTSEC-2026-0034.md
@@ -3,7 +3,7 @@
 id = "RUSTSEC-2026-0034"
 package = "pingora-core"
 date = "2026-03-04"
-# url = "https://blog.cloudflare.com/TBD" # More details to come in an upcoming Cloudflare blog post
+url = "https://blog.cloudflare.com/pingora-oss-smuggling-vulnerabilities/"
 references = ["https://nvd.nist.gov/vuln/detail/CVE-2026-2835"]
 keywords = ["http", "request-smuggling"]
 aliases = ["CVE-2026-2835", "GHSA-hj7x-879w-vrp7"]


### PR DESCRIPTION
The blog adds more detail regarding how the vulnerabilties work for the pingora-core and pingora-cache RUSTSECs.

Mostly for completeness / informative value.

(I noticed that the GHSA advisory numbers had been added to the aliases, thanks!)