### PR TITLE
Add advisory for the malicious `chrono_anchor` crate

### DIFF
--- a/crates/chrono_anchor/RUSTSEC-0000-0000.md
+++ b/crates/chrono_anchor/RUSTSEC-0000-0000.md
@@ -1,0 +1,27 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "chrono_anchor"
+date = "2026-03-10"
+expect-deleted = true
+
+[versions]
+patched = []
+```
+
+# `chrono_anchor` was removed from crates.io due to malicious code
+
+The `chrono_anchor` crate attempted to exfiltrate `.env` files to a server that
+was in turn impersonating the legitimate `timeapi.io` service.
+
+The malicious crate had 1 version published on 2026-03-04 approximately 6 days
+before removal and had no evidence of actual downloads. There were no crates
+depending on this crate on crates.io.
+
+Thanks to [Socket][socket] for reporting this crate. They have published
+[a blog post][blog] about this recent campaign, and we advise users of
+`timeapi.io` to exercise caution when using crates to interact with that
+service.
+
+[socket]: https://socket.dev
+[blog]: https://socket.dev/blog/5-malicious-rust-crates-posed-as-time-utilities-to-exfiltrate-env-files


### PR DESCRIPTION
The blog post technically hasn't been published yet as I write this PR description, but it should be up shortly, I've seen a draft, and I'm comfortable linking to it.