### PR TITLE
fix GHSA alias on RUSTSEC-2023-0082

### DIFF
--- a/crates/phonenumber/RUSTSEC-2023-0082.md
+++ b/crates/phonenumber/RUSTSEC-2023-0082.md
@@ -9,7 +9,7 @@ references = ["https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-42444"]
 categories = ["denial-of-service"]
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:N/I:N/A:H"
 keywords = ["panic", "untrusted input", "parsing"]
-aliases = ["CVE-2023-42444", "whhr-7f2w-qqj2"]
+aliases = ["CVE-2023-42444", "GHSA-whhr-7f2w-qqj2"]
 
 [affected]
 functions = { "phonenumber::parse" = ["*"] }


### PR DESCRIPTION
Fix a GitHub Security Advisory alias that was missing the GHSA- prefix on RUSTSEC-2023-0082