### PR TITLE
Add advisory for the malicious `tracing-ethers` crate.

### DIFF
--- a/crates/tracing-ethers/RUSTSEC-0000-0000.md
+++ b/crates/tracing-ethers/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tracing-ethers"
+date = "2026-03-14"
+expect-deleted = true
+
+[versions]
+patched = []
+```
+
+# `tracing-ethers` was removed from crates.io due to malicious code
+
+The `tracing-ethers` crate attempted to exfiltrate ssh keys to an app hosted on `vercel.app`
+
+The malicious crate had 9 version published on 2026-03-09 approximately 5 days
+before removal and had no evidence of actual downloads. There were no crates
+depending on this crate on crates.io.
+
+Thanks to the user `killa` for reporting this malicious crate.


### PR DESCRIPTION
Advisory for malicious crate removal on crates.io just processed.