### PR TITLE
Fix incomplete affected functions for RUSTSEC-2026-0041

### DIFF
--- a/crates/lz4_flex/RUSTSEC-2026-0041.md
+++ b/crates/lz4_flex/RUSTSEC-2026-0041.md
@@ -11,6 +11,14 @@ cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N"
 [affected.functions]
 "lz4_flex::block::decompress_into" = ["<= 0.11.5", "= 0.12.0"]
 "lz4_flex::block::decompress_into_with_dict" = ["<= 0.11.5", "= 0.12.0"]
+"lz4_flex::block::decompress" = ["<= 0.11.5", "= 0.12.0"]
+"lz4_flex::block::decompress_with_dict" = ["<= 0.11.5", "= 0.12.0"]
+"lz4_flex::block::decompress_size_prepended" = ["<= 0.11.5", "= 0.12.0"]
+"lz4_flex::block::decompress_size_prepended_with_dict" = ["<= 0.11.5", "= 0.12.0"]
+# Deprecated re-exports
+"lz4_flex::decompress" = ["<= 0.11.5", "= 0.12.0"]
+"lz4_flex::decompress_into" = ["<= 0.11.5", "= 0.12.0"]
+"lz4_flex::decompress_size_prepended" = ["<= 0.11.5", "= 0.12.0"]
 
 [versions]
 patched = [">= 0.11.6, < 0.12.0", ">= 0.12.1"]
@@ -28,13 +36,12 @@ the initialized portion of the output buffer.
 
 Two scenarios are affected:
 
-- Decompressing with the `unsafe` implementation (`safe-decode` feature flag disabled, which
-  is the default): can leak content of uninitialized memory as part of the decompressed result.
+- Decompressing with the `unsafe` implementation (`safe-decode` feature flag disabled; flag is
+  enabled by default): can leak content of uninitialized memory as part of the decompressed result.
 - Decompressing into a reused, user-supplied output buffer (also affects `safe-decode`): can
   leak the previous contents of the output buffer as part of the decompressed result.
 
-Only the block-based API is affected: `lz4_flex::block::decompress_into` and
-`lz4_flex::block::decompress_into_with_dict`. All frame APIs are unaffected.
+Only the block-based API is affected. All frame APIs are unaffected.
 
 The flaw was corrected in versions 0.11.6 and 0.12.1 by properly validating offset values
 during decompression.


### PR DESCRIPTION
See also https://github.com/PSeitz/lz4_flex/issues/213#issuecomment-4075896791

CC @PSeitz

(Question to the rustsec maintainers mostly) What exact effect does `affected.functions` have though, and can it cause false negatives? E.g. when someone uses an ancient lz4_flex version (quite unlikely though) where the API was different, would that be erroneously be considered safe? Maybe the implementation back then was actually not affected by this vulnerability, though might be better to err on the safe side and flag usage of such old versions as vulnerable?