### PR TITLE
Add retrospective advisory for several malicious report by phylum in …

### DIFF
--- a/crates/envlogger/RUSTSEC-0000-0000.md
+++ b/crates/envlogger/RUSTSEC-0000-0000.md
@@ -1,7 +1,7 @@
 ```toml
 [advisory]
-id = "RUSTSEC-2023-0101"
-package = "oncecell"
+id = "RUSTSEC-0000-0000"
+package = "envlogger"
 date = "2023-08-16"
 expect-deleted = true
 references = ["https://www.veracode.com/blog/rust-malware-staged-on-crates-io/"]
@@ -11,7 +11,7 @@ categories = ["malicious"]
 patched = []
 ```
 
-# `oncecell` was removed from crates.io for malicious code
+# `envlogger` was removed from crates.io for malicious code
 
 This crate was part of a typosquatting malware cluster published by the malicious user `amaperf` and contained a malware payload in build.rs to exfiltrate host information to the attacker.
 

--- a/crates/if-cfg/RUSTSEC-0000-0000.md
+++ b/crates/if-cfg/RUSTSEC-0000-0000.md
@@ -1,7 +1,7 @@
 ```toml
 [advisory]
-id = "RUSTSEC-2023-0097"
-package = "xrvrv"
+id = "RUSTSEC-0000-0000"
+package = "if-cfg"
 date = "2023-08-16"
 expect-deleted = true
 references = ["https://www.veracode.com/blog/rust-malware-staged-on-crates-io/"]
@@ -11,7 +11,7 @@ categories = ["malicious"]
 patched = []
 ```
 
-# `xrvrv` was removed from crates.io for malicious code
+# `if-cfg` was removed from crates.io for malicious code
 
 This crate was part of a typosquatting malware cluster published by the malicious user `amaperf` and contained a malware payload in build.rs to exfiltrate host information to the attacker.
 

--- a/crates/lazystatic/RUSTSEC-0000-0000.md
+++ b/crates/lazystatic/RUSTSEC-0000-0000.md
@@ -1,7 +1,7 @@
 ```toml
 [advisory]
-id = "RUSTSEC-2023-0099"
-package = "if-cfg"
+id = "RUSTSEC-0000-0000"
+package = "lazystatic"
 date = "2023-08-16"
 expect-deleted = true
 references = ["https://www.veracode.com/blog/rust-malware-staged-on-crates-io/"]
@@ -11,7 +11,7 @@ categories = ["malicious"]
 patched = []
 ```
 
-# `if-cfg` was removed from crates.io for malicious code
+# `lazystatic` was removed from crates.io for malicious code
 
 This crate was part of a typosquatting malware cluster published by the malicious user `amaperf` and contained a malware payload in build.rs to exfiltrate host information to the attacker.
 

--- a/crates/oncecell/RUSTSEC-0000-0000.md
+++ b/crates/oncecell/RUSTSEC-0000-0000.md
@@ -1,7 +1,7 @@
 ```toml
 [advisory]
-id = "RUSTSEC-2023-0098"
-package = "postgress"
+id = "RUSTSEC-0000-0000"
+package = "oncecell"
 date = "2023-08-16"
 expect-deleted = true
 references = ["https://www.veracode.com/blog/rust-malware-staged-on-crates-io/"]
@@ -11,7 +11,7 @@ categories = ["malicious"]
 patched = []
 ```
 
-# `postgress` was removed from crates.io for malicious code
+# `oncecell` was removed from crates.io for malicious code
 
 This crate was part of a typosquatting malware cluster published by the malicious user `amaperf` and contained a malware payload in build.rs to exfiltrate host information to the attacker.
 

--- a/crates/postgress/RUSTSEC-0000-0000.md
+++ b/crates/postgress/RUSTSEC-0000-0000.md
@@ -1,7 +1,7 @@
 ```toml
 [advisory]
-id = "RUSTSEC-2023-0103"
-package = "envlogger"
+id = "RUSTSEC-0000-0000"
+package = "postgress"
 date = "2023-08-16"
 expect-deleted = true
 references = ["https://www.veracode.com/blog/rust-malware-staged-on-crates-io/"]
@@ -11,7 +11,7 @@ categories = ["malicious"]
 patched = []
 ```
 
-# `envlogger` was removed from crates.io for malicious code
+# `postgress` was removed from crates.io for malicious code
 
 This crate was part of a typosquatting malware cluster published by the malicious user `amaperf` and contained a malware payload in build.rs to exfiltrate host information to the attacker.
 

--- a/crates/serd/RUSTSEC-0000-0000.md
+++ b/crates/serd/RUSTSEC-0000-0000.md
@@ -1,7 +1,7 @@
 ```toml
 [advisory]
-id = "RUSTSEC-2023-0102"
-package = "lazystatic"
+id = "RUSTSEC-0000-0000"
+package = "serd"
 date = "2023-08-16"
 expect-deleted = true
 references = ["https://www.veracode.com/blog/rust-malware-staged-on-crates-io/"]
@@ -11,7 +11,7 @@ categories = ["malicious"]
 patched = []
 ```
 
-# `lazystatic` was removed from crates.io for malicious code
+# `serd` was removed from crates.io for malicious code
 
 This crate was part of a typosquatting malware cluster published by the malicious user `amaperf` and contained a malware payload in build.rs to exfiltrate host information to the attacker.
 

--- a/crates/xrvrv/RUSTSEC-0000-0000.md
+++ b/crates/xrvrv/RUSTSEC-0000-0000.md
@@ -1,7 +1,7 @@
 ```toml
 [advisory]
-id = "RUSTSEC-2023-0100"
-package = "serd"
+id = "RUSTSEC-0000-0000"
+package = "xrvrv"
 date = "2023-08-16"
 expect-deleted = true
 references = ["https://www.veracode.com/blog/rust-malware-staged-on-crates-io/"]
@@ -11,7 +11,7 @@ categories = ["malicious"]
 patched = []
 ```
 
-# `serd` was removed from crates.io for malicious code
+# `xrvrv` was removed from crates.io for malicious code
 
 This crate was part of a typosquatting malware cluster published by the malicious user `amaperf` and contained a malware payload in build.rs to exfiltrate host information to the attacker.
 


### PR DESCRIPTION
These advisories are used to retrospectively document the 7 malware packages reported by phylum in 2023.
Related [blog](https://www.veracode.com/blog/rust-malware-staged-on-crates-io/).

Since these incidents occurred in 2023, and the largest RUSTSEC advisory number for 2023 was 96, I started numbering with 97.