### PR TITLE
Add unsoundness advisory for rand with a custom logger

### DIFF
--- a/crates/rand/RUSTSEC-0000-0000.md
+++ b/crates/rand/RUSTSEC-0000-0000.md
@@ -1,0 +1,33 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rand"
+date = "2026-04-09"
+url = "https://github.com/rust-random/rand/pull/1763"
+informational = "unsound"
+categories = []
+keywords = []
+
+[affected]
+[affected.functions]
+"rand::rng" = [">= 0.9.0"]
+"rand::thread_rng" = ["< 0.10.0, >= 0.7.0"]
+
+[versions]
+patched = [">= 0.10.1", "< 0.10.0, >= 0.9.3"]
+unaffected = ["< 0.7.0"]
+```
+
+# Rand is unsound with a custom logger using `rand::rng()`
+
+It has been reported (by @lopopolo) that the `rand` library is [unsound](https://rust-lang.github.io/unsafe-code-guidelines/glossary.html#soundness-of-code--of-a-library) (i.e. that safe code using the public API can cause Undefined Behaviour) when all the following conditions are met:
+
+- The `log` and `thread_rng` features are enabled
+- A [custom logger](https://docs.rs/log/latest/log/#implementing-a-logger) is defined
+- The custom logger accesses `rand::rng()` (previously `rand::thread_rng()`) and calls any `TryRng` (previously `RngCore`) methods on `ThreadRng`
+- The `ThreadRng` (attempts to) reseed while called from the custom logger (this happens every 64 kB of generated data)
+- Trace-level logging is enabled or warn-level logging is enabled and the random source (the `getrandom` crate) is unable to provide a new seed
+
+`TryRng` (previously `RngCore`) methods for `ThreadRng` use `unsafe` code to cast `*mut BlockRng<ReseedingCore>` to `&mut BlockRng<ReseedingCore>`. When all the above conditions are met this results in an aliased mutable reference, violating the Stacked Borrows rules. Miri is able to detect this violation in sample code. Since construction of [aliased mutable references is Undefined Behaviour](https://doc.rust-lang.org/stable/nomicon/references.html), the behaviour of optimized builds is hard to predict.
+
+Affected versions of `rand` are `>= 0.7, < 0.9.3` and `0.10.0`.


### PR DESCRIPTION
See https://github.com/rust-random/rand/pull/1763