### PR TITLE
libsecp256k1 is unmaintained

### DIFF
--- a/crates/libsecp256k1/RUSTSEC-0000-0000.md
+++ b/crates/libsecp256k1/RUSTSEC-0000-0000.md
@@ -1,0 +1,15 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libsecp256k1"
+date = "2025-01-14"
+url = "https://github.com/paritytech/libsecp256k1/pull/159"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# libsecp256k1 is unmaintained
+
+The maintainers recommend using [k256](https://crates.io/crates/k256) instead.


### PR DESCRIPTION
See

- https://github.com/paritytech/libsecp256k1/pull/159

Fixes #2780.