### PR TITLE
advisory linter requires affected functions to start with package rather than crate name

### DIFF
--- a/EXAMPLE_ADVISORY.md
+++ b/EXAMPLE_ADVISORY.md
@@ -2,6 +2,7 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "crate-name"
+#crate_name = "crate_name"
 date = "2020-01-31"
 #withdrawn = "YYYY-MM-DD"
 url = "https://example.com"

--- a/README.md
+++ b/README.md
@@ -53,8 +53,11 @@ Below is the schema of the [TOML] "front matter" section of an advisory:
 # identifier e.g. RUSTSEC-2018-0001. Please use "RUSTSEC-0000-0000" in PRs.
 id = "RUSTSEC-0000-0000"
 
-# Name of the affected crate (mandatory)
+# Name of the affected crates.io package (mandatory)
 package = "mycrate"
+
+# Override crate name if it differs from normalized package name (optional)
+#crate_name = "mycrate"
 
 # Disclosure date of the advisory as an RFC 3339 date (mandatory)
 date = "2021-01-31"


### PR DESCRIPTION
- allow to override crate name derived from crates.io package name
- fixes rustsec/rustsec#1575 (also see https://github.com/rustsec/rustsec/pull/1582)