### PR TITLE
Update affected versions in RUSTSEC-2026-0097

### DIFF
--- a/crates/rand/RUSTSEC-2026-0097.md
+++ b/crates/rand/RUSTSEC-2026-0097.md
@@ -31,4 +31,4 @@ It has been reported (by @lopopolo) that the `rand` library is [unsound](https:/
 
 `TryRng` (previously `RngCore`) methods for `ThreadRng` use `unsafe` code to cast `*mut BlockRng<ReseedingCore>` to `&mut BlockRng<ReseedingCore>`. When all the above conditions are met this results in an aliased mutable reference, violating the Stacked Borrows rules. Miri is able to detect this violation in sample code. Since construction of [aliased mutable references is Undefined Behaviour](https://doc.rust-lang.org/stable/nomicon/references.html), the behaviour of optimized builds is hard to predict.
 
-Affected versions of `rand` are `>= 0.7, < 0.9.3` and `0.10.0`.
+Affected versions of `rand` are `>= 0.7, < 0.8.6`, >= `0.9.0, < 0.9.3`, and `0.10.0`.


### PR DESCRIPTION
Update the advisory to confirm version 0.8.6 is not affected.

Follow-up to https://github.com/rustsec/advisory-db/pull/2795

For details, please see https://github.com/rust-random/rand/pull/1772 and https://github.com/rust-random/rand/issues/1770 .