### PR TITLE
Remove duplicative info in RUSTSEC-2026-0097

### DIFF
--- a/crates/rand/RUSTSEC-2026-0097.md
+++ b/crates/rand/RUSTSEC-2026-0097.md
@@ -30,5 +30,3 @@ It has been reported (by @lopopolo) that the `rand` library is [unsound](https:/
 - Trace-level logging is enabled or warn-level logging is enabled and the random source (the `getrandom` crate) is unable to provide a new seed
 
 `TryRng` (previously `RngCore`) methods for `ThreadRng` use `unsafe` code to cast `*mut BlockRng<ReseedingCore>` to `&mut BlockRng<ReseedingCore>`. When all the above conditions are met this results in an aliased mutable reference, violating the Stacked Borrows rules. Miri is able to detect this violation in sample code. Since construction of [aliased mutable references is Undefined Behaviour](https://doc.rust-lang.org/stable/nomicon/references.html), the behaviour of optimized builds is hard to predict.
-
-Affected versions of `rand` are `>= 0.7, < 0.8.6`, >= `0.9.0, < 0.9.3`, and `0.10.0`.


### PR DESCRIPTION
Update the advisory to remove text that is duplicate of the `patched` field in the metadata.
