### PR TITLE
Add hickory-recursor report for GHSA-83hf-93m4-rgwq

### DIFF
--- a/crates/hickory-recursor/RUSTSEC-0000-0000.md
+++ b/crates/hickory-recursor/RUSTSEC-0000-0000.md
@@ -1,0 +1,47 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "hickory-recursor"
+date = "2026-04-22"
+url = "https://github.com/hickory-dns/hickory-dns/security/advisories/GHSA-83hf-93m4-rgwq"
+categories = ["privilege-escalation"]
+keywords = ["dns", "cache-poisoning"]
+license = "CC-BY-4.0"
+[versions]
+patched = []
+```
+
+# Record cache accepts AUTHORITY section NS from sibling zone via parent-pool zone-context elevation
+
+The Hickory DNS project's experimental `hickory-recursor` crate's record cache
+(`DnsLru`) stores records from DNS responses keyed by each record's own (name,
+type), not by the query that triggered the response. `cache_response()` in
+`crates/recursor/src/lib.rs` chains `ANSWER`, `AUTHORITY`, and `ADDITIONAL`
+sections into one record iterator before insertion. The bailiwick filter it
+applies uses the zone context of the NS pool that serviced the lookup, not the
+zone being queried.
+
+This creates a cross-zone poisoning path. When Hickory builds the NS pool for
+`attacker.poc.` it uses the parent `poc.` `NS` pool (`ns.zone() = "poc."`). If
+the `poc.` nameserver under the attacker's control includes in its response's
+`AUTHORITY` section a record for a sibling zone like `victim.poc. NS
+ns.evil.poc.`, the bailiwick check `is_subzone("poc.", "victim.poc.")` passes
+(`victim.poc.` is a subdomain of `poc.`). The record is stored under
+`(victim.poc., NS)` in the shared cache.
+
+Subsequently, any client querying a name in `victim.poc`. causes Hickory to
+build its NS pool from the poisoned cache entry, routing queries to the
+attacker's nameserver (`ns.evil.poc.`) rather than to the legitimate nameserver
+for `victim.poc.`. The legitimate `NS` for that zone receives zero queries.
+
+This issue is fixed in `hickory-resolver` 0.26.0 with the `recursor` feature
+through an architectural change to response-level caching: responses are stored
+keyed by the originating query `(name, type)`. A response to `(attacker.poc.
+NS)` is stored only under that key and cannot affect the `(victim.poc., NS)`
+cache entry.
+
+We believe this issue has been present in all published versions of the
+experimental `hickory-recursor` crate, which has now been folded into the
+`hickory-resolver` crate under the non-default `recursor` feature flag. The
+`hickory-recursor` crate will not receive any updates going forward and all
+users should migrate to `hickory-resolver` with the `recursor` feature.


### PR DESCRIPTION
Add an advisory for the `hickory-recursor` crate, for [GHSA-83hf-93m4-rgwq](https://github.com/hickory-dns/hickory-dns/security/advisories/GHSA-83hf-93m4-rgwq).

Note that this is my first time filing a rustsec advisory myself, please let me know if I've messed anything up.