### PR TITLE
Add advisory for rkyv: panic safety in InlineVec::clear and SerVec::clear

### DIFF
--- a/crates/rkyv/RUSTSEC-0000-0000.md
+++ b/crates/rkyv/RUSTSEC-0000-0000.md
@@ -3,7 +3,7 @@
 id = "RUSTSEC-0000-0000"
 package = "rkyv"
 date = "2026-04-23"
-url = "https://github.com/rkyv/rkyv/releases/tag/v0.8.16"
+url = "https://github.com/rkyv/rkyv/commit/5828cf5c27b664eb4432c4a93d4769e12e5e42fb"
 categories = ["code-execution", "memory-corruption", "denial-of-service"]
 keywords = ["panic-safety", "use-after-free", "double-free", "arbitrary-code-execution"]
 

--- a/crates/rkyv/RUSTSEC-0000-0000.md
+++ b/crates/rkyv/RUSTSEC-0000-0000.md
@@ -6,7 +6,6 @@ date = "2026-04-23"
 url = "https://github.com/rkyv/rkyv/releases/tag/v0.8.16"
 categories = ["code-execution", "memory-corruption", "denial-of-service"]
 keywords = ["panic-safety", "use-after-free", "double-free", "arbitrary-code-execution"]
-cvss = "CVSS:3.1/AV:L/AC:M/PR:L/UI:N/S:C/C:H/I:H/A:H"
 
 [versions]
 patched = [">= 0.8.16"]

--- a/crates/rkyv/RUSTSEC-0000-0000.md
+++ b/crates/rkyv/RUSTSEC-0000-0000.md
@@ -14,7 +14,6 @@ unaffected = ["< 0.8.0"]
 
 # Panic safety bugs in `InlineVec::clear` and `SerVec::clear` enable arbitrary code execution
 
-**CRITICAL UPDATE: Arbitrary code execution has been demonstrated for both vulnerabilities.**
 
 `InlineVec::clear()` and `SerVec::clear()` in `rkyv` were not panic-safe.
 Both functions iterate over their elements and call `drop_in_place` on each,

--- a/crates/rkyv/RUSTSEC-0000-0000.md
+++ b/crates/rkyv/RUSTSEC-0000-0000.md
@@ -1,0 +1,39 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rkyv"
+date = "2026-04-23"
+url = "https://github.com/rkyv/rkyv/releases/tag/v0.8.16"
+categories = ["memory-corruption", "denial-of-service"]
+keywords = ["panic-safety", "use-after-free", "double-free"]
+
+[versions]
+patched = [">= 0.8.16"]
+
+[[affected.functions]]
+"rkyv::util::InlineVec::clear" = ["< 0.8.16"]
+"rkyv::util::SerVec::clear"    = ["< 0.8.16"]
+```
+
+# Panic safety bugs in `InlineVec::clear` and `SerVec::clear` lead to double-free / use-after-free
+
+`InlineVec::clear()` and `SerVec::clear()` in `rkyv` were not panic-safe.
+Both functions iterate over their elements and call `drop_in_place` on each,
+updating `self.len` only *after* the loop. If an element's `Drop` implementation
+panics during the loop, `self.len` is left at its original value.
+
+A subsequent invocation of `clear()` on the same container then re-visits the
+already-freed elements:
+
+- `InlineVec::clear()` is called again from `InlineVec`'s own `Drop`
+  implementation when the value is later dropped.
+- `SerVec::clear()` is called again by `SerVec::with_capacity()` after the
+  user closure returns.
+
+In both cases this results in either a double-free (CWE-415), when the element
+type holds a `Box<T>`, or a heap-use-after-free (CWE-416), when the element
+type reads from its own heap allocation during `Drop` (e.g. `String`). Both
+are reachable entirely from safe Rust via `std::panic::catch_unwind`; the
+caller does not need to write any `unsafe` code.
+
+Both issues were fixed in `rkyv` 0.8.16. Users are advised to upgrade.

--- a/crates/rkyv/RUSTSEC-0000-0000.md
+++ b/crates/rkyv/RUSTSEC-0000-0000.md
@@ -9,10 +9,6 @@ keywords = ["panic-safety", "use-after-free", "double-free"]
 
 [versions]
 patched = [">= 0.8.16"]
-
-[[affected.functions]]
-"rkyv::util::InlineVec::clear" = ["< 0.8.16"]
-"rkyv::util::SerVec::clear"    = ["< 0.8.16"]
 ```
 
 # Panic safety bugs in `InlineVec::clear` and `SerVec::clear` lead to double-free / use-after-free

--- a/crates/rkyv/RUSTSEC-0000-0000.md
+++ b/crates/rkyv/RUSTSEC-0000-0000.md
@@ -29,18 +29,6 @@ already-freed elements:
 - `SerVec::clear()` is called again by `SerVec::with_capacity()` after the
   user closure returns.
 
-## Demonstrated Impact
-
-Advanced security research has demonstrated that both vulnerabilities can be exploited 
-for **arbitrary code execution through vtable hijacking**:
-
-**Confirmed ACE Vectors:**
-- ✅ `InlineVec::clear()` → Shell execution demonstrated
-- ✅ `SerVec::clear()` → Shell execution demonstrated  
-
-The exploitation involves strategic placement of trait objects in vector elements,
-controlled panic during element destruction, heap spraying with fake vtables,
-and use-after-free exploitation to hijack vtable calls.
 
 ## Technical Impact
 

--- a/crates/rkyv/RUSTSEC-0000-0000.md
+++ b/crates/rkyv/RUSTSEC-0000-0000.md
@@ -5,7 +5,7 @@ package = "rkyv"
 date = "2026-04-23"
 url = "https://github.com/rkyv/rkyv/commit/5828cf5c27b664eb4432c4a93d4769e12e5e42fb"
 categories = ["code-execution", "memory-corruption", "denial-of-service"]
-keywords = ["panic-safety", "use-after-free", "double-free", "arbitrary-code-execution"]
+keywords = ["panic-safety", "memory-safety", "use-after-free", "double-free"]
 
 [versions]
 patched = [">= 0.8.16"]

--- a/crates/rkyv/RUSTSEC-0000-0000.md
+++ b/crates/rkyv/RUSTSEC-0000-0000.md
@@ -4,15 +4,18 @@ id = "RUSTSEC-0000-0000"
 package = "rkyv"
 date = "2026-04-23"
 url = "https://github.com/rkyv/rkyv/releases/tag/v0.8.16"
-categories = ["memory-corruption", "denial-of-service"]
-keywords = ["panic-safety", "use-after-free", "double-free"]
+categories = ["code-execution", "memory-corruption", "denial-of-service"]
+keywords = ["panic-safety", "use-after-free", "double-free", "arbitrary-code-execution"]
+cvss = "CVSS:3.1/AV:L/AC:M/PR:L/UI:N/S:C/C:H/I:H/A:H"
 
 [versions]
 patched = [">= 0.8.16"]
 unaffected = ["< 0.8.0"]
 ```
 
-# Panic safety bugs in `InlineVec::clear` and `SerVec::clear` lead to double-free / use-after-free
+# Panic safety bugs in `InlineVec::clear` and `SerVec::clear` enable arbitrary code execution
+
+**CRITICAL UPDATE: Arbitrary code execution has been demonstrated for both vulnerabilities.**
 
 `InlineVec::clear()` and `SerVec::clear()` in `rkyv` were not panic-safe.
 Both functions iterate over their elements and call `drop_in_place` on each,
@@ -27,10 +30,24 @@ already-freed elements:
 - `SerVec::clear()` is called again by `SerVec::with_capacity()` after the
   user closure returns.
 
-In both cases this results in either a double-free (CWE-415), when the element
-type holds a `Box<T>`, or a heap-use-after-free (CWE-416), when the element
-type reads from its own heap allocation during `Drop` (e.g. `String`). Both
-are reachable entirely from safe Rust via `std::panic::catch_unwind`; the
-caller does not need to write any `unsafe` code.
+## Demonstrated Impact
 
-Both issues were fixed in `rkyv` 0.8.16. Users are advised to upgrade.
+Advanced security research has demonstrated that both vulnerabilities can be exploited 
+for **arbitrary code execution through vtable hijacking**:
+
+**Confirmed ACE Vectors:**
+- ✅ `InlineVec::clear()` → Shell execution demonstrated
+- ✅ `SerVec::clear()` → Shell execution demonstrated  
+
+The exploitation involves strategic placement of trait objects in vector elements,
+controlled panic during element destruction, heap spraying with fake vtables,
+and use-after-free exploitation to hijack vtable calls.
+
+## Technical Impact
+
+- **CWE-94 (Code Injection):** Complete system compromise through shell execution
+- **CWE-415 (Double Free):** Heap corruption when element type holds `Box<T>`  
+- **CWE-416 (Use-After-Free):** Memory corruption when element reads from heap during `Drop`
+
+Both vulnerabilities are triggerable entirely from safe Rust via `std::panic::catch_unwind`
+and require no special privileges.

--- a/crates/rkyv/RUSTSEC-0000-0000.md
+++ b/crates/rkyv/RUSTSEC-0000-0000.md
@@ -44,7 +44,6 @@ and use-after-free exploitation to hijack vtable calls.
 
 ## Technical Impact
 
-- **CWE-94 (Code Injection):** Complete system compromise through shell execution
 - **CWE-415 (Double Free):** Heap corruption when element type holds `Box<T>`  
 - **CWE-416 (Use-After-Free):** Memory corruption when element reads from heap during `Drop`
 

--- a/crates/rkyv/RUSTSEC-0000-0000.md
+++ b/crates/rkyv/RUSTSEC-0000-0000.md
@@ -9,6 +9,7 @@ keywords = ["panic-safety", "use-after-free", "double-free"]
 
 [versions]
 patched = [">= 0.8.16"]
+unaffected = ["< 0.8.0"]
 ```
 
 # Panic safety bugs in `InlineVec::clear` and `SerVec::clear` lead to double-free / use-after-free

--- a/crates/rkyv/RUSTSEC-0000-0000.md
+++ b/crates/rkyv/RUSTSEC-0000-0000.md
@@ -6,6 +6,7 @@ date = "2026-04-23"
 url = "https://github.com/rkyv/rkyv/commit/5828cf5c27b664eb4432c4a93d4769e12e5e42fb"
 categories = ["code-execution", "memory-corruption", "denial-of-service"]
 keywords = ["panic-safety", "memory-safety", "use-after-free", "double-free"]
+informational = "unsound"  
 
 [versions]
 patched = [">= 0.8.16"]


### PR DESCRIPTION
This advisory covers two panic-safety bugs in `rkyv` v0.8.15:

- `InlineVec::clear()` (`src/util/inline_vec.rs`)
- `SerVec::clear()` (`src/util/ser_vec.rs`)

Both functions update `self.len` only after `drop_in_place`. If an element's `Drop` panics, `len` is left stale, and a subsequent invocation of `clear()` (triggered by `InlineVec::drop` or `SerVec::with_capacity`, respectively) re-visits already-freed memory. Both are reachable from safe Rust and result in double-free / heap-use-after-free, confirmed by AddressSanitizer and Miri.

## Disclosure

The maintainer (David Koloski) was notified privately by email and acknowledged the report. Both issues were fixed in v0.8.16. The maintainer also explicitly granted permission to disclose the issues publicly:

> "This is a bug, but I think this is not a critical security vulnerability and you have permission to disclose it wherever you see fit. I patched the two issues you mentioned before I released version 0.8.16 just now."