### PR TITLE
Add an advisory for Diesels UTF-8 issue

### DIFF
--- a/crates/diesel/RUSTSEC-0000-0000.md
+++ b/crates/diesel/RUSTSEC-0000-0000.md
@@ -1,0 +1,28 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "diesel"
+date = "2026-04-24"
+url = "https://github.com/diesel-rs/diesel/pull/5042"
+informational = "unsound"
+
+[affected.functions]
+"diesel::sqlite::SqliteValue::read_str" = ["<2.3.8"]
+"diesel::deserialize::FromSql::<Text,Sqlite>::from_sql" = ["<2.3.8"]
+
+[versions]
+patched = [">= 2.3.8"]
+```
+
+# Possible UTF-8 corruption in Diesels SQLite backend
+
+Diesel uses the `sqlite3_value_text` function to receive strings from SQLite while deserializing query results. We misinterpreted the corresponding [SQLite](https://sqlite.org/c3ref/value_blob.html) documentation that this function always returns a UTF-8 encoded string values as `*const c_char`. Based on that we used `str::from_utf8_unchecked` to construct a Rust string slice without any additional UTF-8 checks in place. It turned out that this function doesn't always return correct UTF-8 strings. For field of the SQLite side storage type `BLOB` this pointer can contain arbitrary bytes, which makes the usage of `str::from_utf8_unchecked` unsound as this violates the safety contract of `str` to only contain valid UTF-8 encoded Strings.
+
+## Mitigation
+
+The preferred mitigation to the outlined problem is to update to a Diesel version 2.3.8 or newer, which includes fixes for the problem.
+
+## Resolution
+
+Diesel now correctly checks whether the provides byte buffer is actually valid UTF-8, instead of relying on SQLite's documentation. This fix is included in the `2.3.8` release.
+


### PR DESCRIPTION
# Possible UTF-8 corruption in Diesels SQLite backend

Diesel uses the `sqlite3_value_text` function to receive strings from SQLite while deserializing query results. We misinterpreted the corresponding [SQLite](https://sqlite.org/c3ref/value_blob.html) documentation that this function always returns a UTF-8 encoded string values as `*const c_char`. Based on that we used `str::from_utf8_unchecked` to construct a Rust string slice without any additional UTF-8 checks in place. It turned out that this function doesn't always return correct UTF-8 strings. For field of the SQLite side storage type `BLOB` this pointer can contain arbitrary bytes, which makes the usage of `str::from_utf8_unchecked` unsound as this violates the safety contract of `str` to only contain valid UTF-8 encoded Strings.

---

That's fixed with https://github.com/diesel-rs/diesel/releases/tag/v2.3.8. The release contains also fixes for a number of different issues. While in theory the other issues are also unsoundness issues, I guess they are too obscure to have an advisory for them. I still would value a second or third opinion on that.

---

EDIT: For the CI failure: I'm unsure how to express the right trait method call otherwise. Are there any guidelines for this?