### PR TITLE
RUSTSEC-2023-0071: Update tracking issue

### DIFF
--- a/crates/rsa/RUSTSEC-2023-0071.md
+++ b/crates/rsa/RUSTSEC-2023-0071.md
@@ -5,8 +5,8 @@ package = "rsa"
 date = "2023-11-22"
 keywords = ["cryptography"]
 categories = ["crypto-failure"]
-url = "https://github.com/RustCrypto/RSA/issues/19#issuecomment-1822995643"
-references = ["https://people.redhat.com/~hkario/marvin/"]
+url = "https://github.com/RustCrypto/RSA/issues/626"
+references = ["https://github.com/RustCrypto/RSA/issues/19#issuecomment-1822995643", "https://people.redhat.com/~hkario/marvin/"]
 cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
 aliases = ["CVE-2023-49092", "GHSA-c38w-74pg-36hr", "GHSA-4grx-2x9w-596c"]
 


### PR DESCRIPTION
This downgrades the old https://github.com/RustCrypto/RSA/issues/19 link to a reference. It has so many replies and references, it's hard to navigate to the followup issues and pull requests it links to.

The issue url is replaced with the current 2026 tracking issue https://github.com/RustCrypto/RSA/issues/626 (bigint fixed, but more problems from the padding implementation).