### PR TITLE
RUSTSEC-2026-0078.md: remove reference link already set as URL

### DIFF
--- a/crates/intaglio/RUSTSEC-2026-0078.md
+++ b/crates/intaglio/RUSTSEC-2026-0078.md
@@ -5,7 +5,6 @@ package = "intaglio"
 date = "2026-03-30"
 url = "https://github.com/artichoke/intaglio/issues/359"
 references = [
-  "https://github.com/artichoke/intaglio/issues/359",
   "https://github.com/artichoke/intaglio/pull/360",
 ]
 


### PR DESCRIPTION
Otherwise results in the same link rendering twice