### PR TITLE
Fix crate name in RUSTSEC-2026-0103.md

### DIFF
--- a/crates/thin-vec/RUSTSEC-2026-0103.md
+++ b/crates/thin-vec/RUSTSEC-2026-0103.md
@@ -16,7 +16,7 @@ patched = [">= 0.2.16"]
 # Use-After-Free and Double Free in IntoIter::drop When Element Drop Panics
 
 A Double Free / Use-After-Free (UAF) vulnerability has been identified in the
-`IntoIter::drop` and `ThinVec::clear` implementations of the `thin_vec` crate.
+`IntoIter::drop` and `ThinVec::clear` implementations of the `thin-vec` crate.
 Both vulnerabilities share the same root cause and can trigger memory
 corruption using only safe Rust code - no unsafe blocks required. Undefined
 Behavior has been confirmed via Miri and AddressSanitizer (ASAN).


### PR DESCRIPTION
Corrected the crate name from 'thin_vec' to 'thin-vec' in the vulnerability report.