### PR TITLE
Add multiple advisories against hickory-proto/hickory-net

### DIFF
--- a/crates/hickory-net/RUSTSEC-0000-0000.2.md
+++ b/crates/hickory-net/RUSTSEC-0000-0000.2.md
@@ -1,0 +1,44 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "hickory-net"
+date = "2026-05-01"
+url = "https://github.com/hickory-dns/hickory-dns/security/advisories/GHSA-3v94-mw7p-v465"
+categories = ["denial-of-service"]
+keywords = ["dns", "dnssec", "nsec3"]
+license = "CC-BY-4.0"
+
+[versions]
+patched = [">= 0.26.1"]
+```
+
+# NSEC3 closest-encloser proof validation enters unbounded loop on cross-zone responses
+
+The NSEC3 closest-encloser proof validation in `hickory-net`'s
+`DnssecDnsHandle` walks from the QNAME up to the SOA owner name, building a
+list of candidate encloser names. The iterator used assumes the
+QNAME is a descendant of the SOA owner, terminating only when the current
+candidate equals the SOA name. When the SOA in a response's authority section
+is not an ancestor of the QNAME, the loop stalls at the DNS root and never
+terminates, repeatedly calling `Name::base_name()` and pushing newly allocated
+`Name` and hashed-name entries into the candidate `Vec`.
+
+The bug is reachable by any caller of `DnssecDnsHandle` — including the
+resolver, recursor, and client — when built with the `dnssec-ring` or
+`dnssec-aws-lc-rs` feature and configured to perform DNSSEC validation. It is
+triggered while validating a NoData or NXDomain response whose authority
+section contains an SOA record from a zone other than an ancestor of the
+QNAME, on a code path that requires NSEC3 closest-encloser proof. In practice
+this can be reached through an insecure CNAME chain that crosses zone
+boundaries into a DNSSEC-signed zone returning NoData, but the minimum
+condition is just a mismatched SOA owner on a response requiring NSEC3
+validation.
+
+A `debug_assert_ne!(name, Name::root())` guards the loop body, so debug builds
+abort with a panic on the first iteration past the root. Release builds
+compile the assertion out and run the loop unbounded, allocating until the
+process exhausts available memory (OOM). A reachable upstream attacker who
+can return such a response can therefore crash a debug-built validator or
+exhaust memory on a release-built one.
+
+We recommend all affected users update to `hickory-net` 0.26.1 for the fix.

--- a/crates/hickory-proto/RUSTSEC-0000-0000.0.md
+++ b/crates/hickory-proto/RUSTSEC-0000-0000.0.md
@@ -1,0 +1,30 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "hickory-proto"
+date = "2026-05-01"
+url = "https://github.com/hickory-dns/hickory-dns/security/advisories/GHSA-q2qq-hmj6-3wpp"
+categories = ["denial-of-service"]
+keywords = ["dns"]
+related = ["CVE-2024-8508"]
+license = "CC-BY-4.0"
+
+[versions]
+patched = [">= 0.26.1"]
+unaffected = ["< 0.3.1"]
+```
+
+# CPU exhaustion during message encoding due to O(n²) name compression
+
+During message encoding, `hickory-proto`'s `BinEncoder` stores pointers to
+labels that are candidates for name compression in a `Vec<(usize, Vec<u8>)>`.
+The name compression logic then searches for matches with a linear scan.
+
+A malicious message with many records can both introduce many candidate labels,
+and invoke this linear scan many times. This can amplify CPU exhaustion in DoS
+attacks.
+
+This is similar to
+[CVE-2024-8508](https://www.nlnetlabs.nl/downloads/unbound/CVE-2024-8508.txt).
+
+We recommend all affected users update to `hickory-proto` 0.26.1 for the fix.

--- a/crates/hickory-proto/RUSTSEC-0000-0000.1.md
+++ b/crates/hickory-proto/RUSTSEC-0000-0000.1.md
@@ -1,0 +1,47 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "hickory-proto"
+date = "2026-05-01"
+url = "https://github.com/hickory-dns/hickory-dns/security/advisories/GHSA-3v94-mw7p-v465"
+categories = ["denial-of-service"]
+keywords = ["dns", "dnssec", "nsec3"]
+license = "CC-BY-4.0"
+
+[versions]
+patched = []
+unaffected = ["< 0.25.0-alpha.3"]
+```
+
+# NSEC3 closest-encloser proof validation enters unbounded loop on cross-zone responses
+
+The NSEC3 closest-encloser proof validation in `hickory-proto`'s
+`DnssecDnsHandle` walks from the QNAME up to the SOA owner name, building a
+list of candidate encloser names. The iterator used assumes the
+QNAME is a descendant of the SOA owner, terminating only when the current
+candidate equals the SOA name. When the SOA in a response's authority section
+is not an ancestor of the QNAME, the loop stalls at the DNS root and never
+terminates, repeatedly calling `Name::base_name()` and pushing newly allocated
+`Name` and hashed-name entries into the candidate `Vec`.
+
+The bug is reachable by any caller of `DnssecDnsHandle` — including the
+resolver, recursor, and client — when built with the `dnssec-ring` or
+`dnssec-aws-lc-rs` feature and configured to perform DNSSEC validation. It is
+triggered while validating a NoData or NXDomain response whose authority
+section contains an SOA record from a zone other than an ancestor of the
+QNAME, on a code path that requires NSEC3 closest-encloser proof. In practice
+this can be reached through an insecure CNAME chain that crosses zone
+boundaries into a DNSSEC-signed zone returning NoData, but the minimum
+condition is just a mismatched SOA owner on a response requiring NSEC3
+validation.
+
+A `debug_assert_ne!(name, Name::root())` guards the loop body, so debug builds
+abort with a panic on the first iteration past the root. Release builds
+compile the assertion out and run the loop unbounded, allocating until the
+process exhausts available memory (OOM). A reachable upstream attacker who
+can return such a response can therefore crash a debug-built validator or
+exhaust memory on a release-built one.
+
+The affected code was migrated from `hickory-proto` to `hickory-net` as part of
+the 0.26.0 release. We recommend all affected users update to `hickory-net`
+0.26.1 for the fix.


### PR DESCRIPTION
* [CPU exhaustion during message encoding due to O(n²) name compression](https://github.com/hickory-dns/hickory-dns/security/advisories/GHSA-q2qq-hmj6-3wpp) in `hickory-proto`.
* [NSEC3 closest-encloser proof validation enters unbounded loop on cross-zone responses](https://github.com/hickory-dns/hickory-dns/security/advisories/GHSA-3v94-mw7p-v465) in `hickory-proto`/`hickory-net`.