### PR TITLE
hickory-proto: adjust RUSTSEC-2026-0118 versions

### DIFF
--- a/crates/hickory-proto/RUSTSEC-2026-0118.md
+++ b/crates/hickory-proto/RUSTSEC-2026-0118.md
@@ -10,7 +10,7 @@ license = "CC-BY-4.0"
 
 [versions]
 patched = []
-unaffected = ["< 0.25.0-alpha.3"]
+unaffected = ["< 0.25.0-alpha.3", ">= 0.26.0-beta.1"]
 ```
 
 # NSEC3 closest-encloser proof validation enters unbounded loop on cross-zone responses
@@ -43,5 +43,6 @@ can return such a response can therefore crash a debug-built validator or
 exhaust memory on a release-built one.
 
 The affected code was migrated from `hickory-proto` to `hickory-net` as part of
-the 0.26.0 release. We recommend all affected users update to `hickory-net`
-0.26.1 for the fix.
+the 0.26.0 release. The `hickory-proto` 0.26.x release no longer offers
+`DnssecDnsHandle` and so we recommend all affected users update to `hickory-net`
+0.26.1 when the implementation of that type is required.


### PR DESCRIPTION
This is a bit of a non-standard situation where the `hickory-proto` crate _removed_ the affected type, migrating it to `hickory-net` (which we filed [RUSTSEC-2026-0120](https://rustsec.org/advisories/RUSTSEC-2026-0120.html) for separately). Adjust the affected version range so that `hickory-proto == 0.26.1`, and `hickory-net == 0.26.1` don't surface RUSTSEC-2026-0118.
