### PR TITLE
Add advisory for steamworks

### DIFF
--- a/crates/steamworks/RUSTSEC-0000-0000.md
+++ b/crates/steamworks/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "steamworks"
+date = "2026-05-05"
+url = "https://github.com/Noxime/steamworks-rs/issues/321"
+categories = ["denial-of-service"]
+keywords = ["panic"]
+
+[affected.functions]
+"steamworks::ValidateAuthTicketResponse::from_raw" = ["< 0.13.1"]
+"steamworks::Server::begin_authentication_session" = ["< 0.13.1"]
+"steamworks::User::begin_authentication_session" = ["< 0.13.1"]
+"steamworks::Client::register_callback" = ["< 0.13.1"]
+"steamworks::Client::process_callbacks" = ["< 0.13.1"]
+
+[versions]
+patched = [">= 0.13.1"]
+```
+
+# Denial of service in Steamworks game clients/servers using P2P authentication
+
+Processing the raw `ValidateAuthTicketResponse_t` callback data panics when the `m_eAuthSessionResponse` field is `k_EAuthSessionResponseAuthTicketNetworkIdentityFailure`. This can lead to denial of service in game clients and servers using the `begin_authentication_session` API to authenticate players if a malicious game client sends an authentication ticket with a network identity that does not match that of the verifier.


### PR DESCRIPTION
This adds a denial of service advisory to the `steamworks` crate (with approval from the maintainer), fixed in the most recent version:
 
https://github.com/Noxime/steamworks-rs/issues/321#issuecomment-4382111001