### PR TITLE
Add advisory for oxidize-pdf — GHSA-88q9-cmp2-c2vq (DoS via NaN/inf colour emission)

### DIFF
--- a/crates/oxidize-pdf/RUSTSEC-0000-0000.md
+++ b/crates/oxidize-pdf/RUSTSEC-0000-0000.md
@@ -1,0 +1,91 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "oxidize-pdf"
+date = "2026-05-06"
+url = "https://github.com/bzsanti/oxidizePdf/security/advisories/GHSA-88q9-cmp2-c2vq"
+references = [
+    "https://github.com/bzsanti/oxidizePdf/issues/220",
+    "https://github.com/bzsanti/oxidizePdf/issues/221",
+    "https://github.com/bzsanti/oxidizePdf/pull/225",
+    "https://github.com/bzsanti/oxidizePdf/pull/226",
+]
+categories = ["denial-of-service"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L"
+keywords = ["pdf", "content-stream", "color", "nan", "infinity", "dos"]
+aliases = ["GHSA-88q9-cmp2-c2vq"]
+license = "CC-BY-4.0"
+
+[versions]
+patched = [">= 2.6.0"]
+```
+
+# Non-finite floats in colour content-stream emission produce malformed PDFs (DoS)
+
+`oxidize-pdf` exposes `Color` as a `pub enum` with public tuple-struct variants
+`Rgb(f64, f64, f64)`, `Gray(f64)`, and `Cmyk(f64, f64, f64, f64)`. The
+constructors `Color::rgb`, `Color::gray`, and `Color::cmyk` clamp incoming
+components to `[0.0, 1.0]`, but because the variants are `pub`, callers can
+construct values directly without going through the constructors:
+
+```rust
+let safe   = Color::rgb(f64::NAN, 0.5, 0.5);   // clamps NaN to 0.0
+let attack = Color::Rgb(f64::NAN, 0.5, 0.5);   // bypasses clamp
+```
+
+`Color: Copy` allows the non-finite value to propagate freely through API
+surfaces. When such a value reaches a content-stream emitter, the writer
+formats it via `format!("{:.3}", v)`. The Rust standard library renders
+`f64::NAN` as `NaN`, `f64::INFINITY` as `inf`, and `f64::NEG_INFINITY` as
+`-inf` — none of which are valid PDF numeric tokens per ISO 32000-1 §7.3.3:
+
+> A numeric object shall be represented by one or more decimal digits with
+> an optional sign and a leading, trailing, or embedded PERIOD.
+
+The resulting content stream contains an invalid token sequence
+(e.g. `NaN 0.500 0.500 rg`). Conformant PDF viewers (Adobe Acrobat, Foxit,
+PDF.js, Apple Preview) reject the content stream, the affected page, or the
+entire document depending on parser strictness.
+
+## Impact
+
+Any application that uses `oxidize-pdf` to generate PDFs and accepts
+user-influenced colour values without validation can produce documents that
+conformant viewers refuse to render — a denial-of-service against downstream
+consumers. Server-side PDF generators that take arbitrary `f64` colour
+parameters from upstream services are the most exposed surface.
+
+## Patches
+
+The fix introduces a sanitising helper at the emission boundary in
+`graphics/color.rs`:
+
+```rust
+pub(crate) fn finite_or_zero(val: f64) -> f64 {
+    if val.is_finite() { val } else { 0.0 }
+}
+```
+
+Every colour-operator emitter (~50 sites across 17 files) routes through
+`fill_color_op` / `stroke_color_op` / `write_fill_color` /
+`write_stroke_color`, which apply `finite_or_zero` before formatting.
+Non-finite components are substituted with `0.0`, so the wire format remains
+ISO 32000-1 conformant regardless of the input.
+
+Upgrade to `oxidize-pdf >= 2.6.0`.
+
+## Workarounds
+
+For users who cannot upgrade immediately:
+
+- Always construct colours via the safe constructors `Color::rgb()`,
+  `Color::gray()`, `Color::cmyk()`, which clamp components to `[0.0, 1.0]`
+  (no `NaN`/`inf` survives clamping).
+- Never use direct enum construction (`Color::Rgb(...)`, `Color::Gray(...)`,
+  `Color::Cmyk(...)`) when components originate from untrusted input.
+- Validate untrusted `f64` colour inputs with `f64::is_finite()` before
+  passing them to any `oxidize-pdf` API.
+
+These mitigations are partial — they cover the application layer but not
+other code paths that may construct `Color` values internally. The full fix
+is the upgrade to the patched version.


### PR DESCRIPTION
Adds an advisory for the [oxidize-pdf](https://crates.io/crates/oxidize-pdf) crate covering [GHSA-88q9-cmp2-c2vq](https://github.com/bzsanti/oxidizePdf/security/advisories/GHSA-88q9-cmp2-c2vq).

## Summary

`Color` is exposed as a `pub enum` whose tuple-struct variants (`Rgb`, `Gray`, `Cmyk`) bypass the clamping done by the `Color::rgb` / `Color::gray` / `Color::cmyk` constructors. This allows non-finite `f64` values (`NaN`, `±inf`) to reach the content-stream emitter, where `format!(\"{:.3}\", v)` renders them as `NaN`, `inf`, `-inf` — none of which are valid PDF numeric tokens per ISO 32000-1 §7.3.3. Conformant viewers (Adobe Acrobat, Foxit, PDF.js, Apple Preview) reject the affected pages or the whole document.

## Affected versions

`<= 2.5.7`. Patched in `2.6.0`.

## Disclosure

I am the crate author. The vulnerability has been published as a GitHub Security Advisory (link above) and the fix has been released to crates.io. CVE has been requested via GitHub's CNA — once assigned I will follow up with a PR to add it to the `aliases` field.

## Notes for reviewers

- Severity: medium (CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L = 4.3).
- Category: denial-of-service (downstream consumers can't render the produced PDF).
- The same root cause affects two FFI-binding distributions (NuGet `OxidizePdf.NET`, PyPI `oxidize-pdf`); they are listed in the GHSA but out of scope for RustSec.