### PR TITLE
Improve the text of RUSTSEC-2026-0122

### DIFF
--- a/crates/rkyv/RUSTSEC-2026-0122.md
+++ b/crates/rkyv/RUSTSEC-2026-0122.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2026-0122"
 package = "rkyv"
 date = "2026-04-23"
 url = "https://github.com/rkyv/rkyv/commit/5828cf5c27b664eb4432c4a93d4769e12e5e42fb"
-categories = ["code-execution", "memory-corruption", "denial-of-service"]
+categories = ["code-execution", "memory-corruption"]
 keywords = ["panic-safety", "memory-safety", "use-after-free", "double-free"]
 informational = "unsound"  
 
@@ -13,8 +13,7 @@ patched = [">= 0.8.16"]
 unaffected = ["< 0.8.0"]
 ```
 
-# Panic safety bugs in `InlineVec::clear` and `SerVec::clear` enable arbitrary code execution
-
+# Potential use-after-free due to lack of panic safety in `InlineVec::clear` and `SerVec::clear`
 
 `InlineVec::clear()` and `SerVec::clear()` in `rkyv` were not panic-safe.
 Both functions iterate over their elements and call `drop_in_place` on each,
@@ -29,11 +28,11 @@ already-freed elements:
 - `SerVec::clear()` is called again by `SerVec::with_capacity()` after the
   user closure returns.
 
+## Impact
+- **CWE-415 (Double Free):** heap corruption when the element type is one that
+  owns memory, such as `Box<T>` or `Vec<T>`
+- **CWE-416 (Use-After-Free):** memory corruption when an element is accessed
+  following a caught panic
 
-## Technical Impact
-
-- **CWE-415 (Double Free):** Heap corruption when element type holds `Box<T>`  
-- **CWE-416 (Use-After-Free):** Memory corruption when element reads from heap during `Drop`
-
-Both vulnerabilities are triggerable entirely from safe Rust via `std::panic::catch_unwind`
-and require no special privileges.
+Both types of undefined behavior can be invoked in safe Rust, but only if
+unwinding panics are enabled and `std::panic::catch_unwind` is used.


### PR DESCRIPTION
The present text of the RUSTSEC-2026-0122 record is misleading, uses irrelevant/meaningless phraseology, and contains a glaring falsehood, as use-after-free and arbitrary code execution are different classes of bugs. This PR changes the title of the record to remove the mention of arbitrary code execution, removes confusing phraseology from the record body, and adjusts the wording to better reflect the severity of the unsoundness.