### PR TITLE
Add advisory for vku VMABuffer::set_data unsoundness

### DIFF
--- a/crates/vku/RUSTSEC-0000-0000.md
+++ b/crates/vku/RUSTSEC-0000-0000.md
@@ -1,0 +1,26 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "vku"
+date = "2025-04-23"
+url = "https://github.com/ArrowMaxGithub/vku/issues/5"
+references = ["https://github.com/ArrowMaxGithub/vku/commit/ce02c19"]
+informational = "unsound"
+categories = ["memory-corruption"]
+
+[affected.functions]
+"vku::VMABuffer::set_data" = ["<= 0.3.0"]
+
+[versions]
+patched = [">= 0.4.0"]
+```
+
+# `VMABuffer::set_data` may allow out-of-bounds writes from safe code
+
+`VMABuffer::set_data` was a publicly accessible safe function. It accepted an arbitrary `offset` and a data slice, then used the offset in unsafe pointer arithmetic before copying the slice into a mapped allocation.
+
+Affected versions did not check that the requested write range fit within the allocation before calling `ptr.add(offset)` and `copy_from_nonoverlapping`. Safe Rust code could therefore trigger an out-of-bounds write by passing an offset outside the mapped allocation.
+
+This makes the safe API unsound, since callers can trigger undefined behavior without using `unsafe`.
+
+Version `0.4.0` added a bounds check before performing the pointer arithmetic and copy.

--- a/crates/vku/RUSTSEC-0000-0000.md
+++ b/crates/vku/RUSTSEC-0000-0000.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-0000-0000"
 package = "vku"
 date = "2025-04-23"
 url = "https://github.com/ArrowMaxGithub/vku/issues/5"
-references = ["https://github.com/ArrowMaxGithub/vku/commit/ce02c19"]
+references = ["https://github.com/ArrowMaxGithub/vku/commit/ce02c19ec35e5ee84c00ec5005be9d6d44599b5f"]
 informational = "unsound"
 categories = ["memory-corruption"]
 


### PR DESCRIPTION
This PR adds an informational RustSec advisory for an unsound safe API in `vku`.

`VMABuffer::set_data` accepted an arbitrary offset and used it in unsafe pointer arithmetic before copying data into a mapped allocation. A safe caller could trigger an out-of-bounds write.

Upstream issue: https://github.com/ArrowMaxGithub/vku/issues/5
Fix commit: https://github.com/ArrowMaxGithub/vku/commit/ce02c19ec35e5ee84c00ec5005be9d6d44599b5f
Patched version: 0.4.0