### PR TITLE
Add informational advisory for lru panic safety issue

### DIFF
--- a/crates/lru/RUSTSEC-0000-0000.md
+++ b/crates/lru/RUSTSEC-0000-0000.md
@@ -1,0 +1,29 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "lru"
+date = "2026-05-12"
+categories = ["code-execution", "memory-corruption"]
+keywords = ["panic-safety", "memory-safety", "use-after-free", "double-free"]
+informational = "unsound"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# Potential use-after-free due to lack of panic safety in `LruCache::pop()`
+
+`LruCache::pop()` in `lru` was not panic-safe. If the `Drop` implementation of a stored key panics during `pop()`, `self.detach()` is never called, leaving dangling pointers in the internal doubly-linked list.
+
+A subsequent cache operation that triggers eviction can then dereference these dangling pointers:
+- The node is freed from the map, but remains linked in the LRU list due to the skipped `detach()` call
+- When a new insertion causes eviction, the LRU traversal encounters the dangling pointer
+- This results in a write to already-freed memory during the eviction process
+
+## Impact
+
+- **CWE-416 (Use-After-Free):** memory corruption when subsequent cache operations access freed node pointers in the linked list
+- **CWE-415 (Double Free):** potential heap corruption when the same memory is freed multiple times
+
+Both types of undefined behavior can be invoked in safe Rust, but only if unwinding panics are enabled and `std::panic::catch_unwind` is used with key types that have potentially-panicking `Drop` implementations.

--- a/crates/lru/RUSTSEC-0000-0000.md
+++ b/crates/lru/RUSTSEC-0000-0000.md
@@ -3,6 +3,7 @@
 id = "RUSTSEC-0000-0000"
 package = "lru"
 date = "2026-05-12"
+url = "https://github.com/jeromefroe/lru-rs/issues/235"
 categories = ["memory-corruption"]
 keywords = ["panic-safety", "memory-safety", "use-after-free", "double-free"]
 informational = "unsound"

--- a/crates/lru/RUSTSEC-0000-0000.md
+++ b/crates/lru/RUSTSEC-0000-0000.md
@@ -3,7 +3,7 @@
 id = "RUSTSEC-0000-0000"
 package = "lru"
 date = "2026-05-12"
-url = "https://github.com/jeromefroe/lru-rs/issues/235"
+url = "https://github.com/jeromefroe/lru-rs/pull/238"
 categories = ["memory-corruption"]
 keywords = ["panic-safety", "memory-safety", "use-after-free", "double-free"]
 informational = "unsound"

--- a/crates/lru/RUSTSEC-0000-0000.md
+++ b/crates/lru/RUSTSEC-0000-0000.md
@@ -3,12 +3,12 @@
 id = "RUSTSEC-0000-0000"
 package = "lru"
 date = "2026-05-12"
-categories = ["code-execution", "memory-corruption"]
+categories = ["memory-corruption"]
 keywords = ["panic-safety", "memory-safety", "use-after-free", "double-free"]
 informational = "unsound"
 
 [versions]
-patched = []
+patched = [">= 0.18.2"]
 unaffected = []
 ```
 
@@ -27,3 +27,7 @@ A subsequent cache operation that triggers eviction can then dereference these d
 - **CWE-415 (Double Free):** potential heap corruption when the same memory is freed multiple times
 
 Both types of undefined behavior can be invoked in safe Rust, but only if unwinding panics are enabled and `std::panic::catch_unwind` is used with key types that have potentially-panicking `Drop` implementations.
+
+## Fix
+
+Fixed in `lru` 0.18.2 by detaching the node from the linked list before freeing it and dropping the key ([lru-rs#238](https://github.com/jeromefroe/lru-rs/pull/238)).


### PR DESCRIPTION
## Affected crate(s)

- `lru` (76,674,892 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- Upstream issue: [jeromefroe/lru-rs#235](https://github.com/jeromefroe/lru-rs/issues/235)
- Fix PR (merged): [jeromefroe/lru-rs#238](https://github.com/jeromefroe/lru-rs/pull/238)
- Patched release: `lru` 0.18.2

## Severity

Use-after-free / double-free in `LruCache::pop()`. If a stored key's `Drop` panics during `pop()`, the internal doubly-linked list is left with a dangling node; a later eviction then dereferences it and writes to freed memory. Reachable from safe Rust via `catch_unwind` with a key whose `Drop` can panic. Affected versions: `< 0.18.2`; fixed in `0.18.2`.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate (maintainer reacted 👍 confirming it's a soundness issue, and merged the fix + released v0.18.2)