### PR TITLE
Add advisory for dynoxide-rs (DNS rebinding / CSRF)

### DIFF
--- a/crates/dynoxide-rs/RUSTSEC-0000-0000.md
+++ b/crates/dynoxide-rs/RUSTSEC-0000-0000.md
@@ -1,0 +1,38 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "dynoxide-rs"
+date = "2026-05-12"
+url = "https://github.com/nubo-db/dynoxide/security/advisories/GHSA-fvh2-gm75-j4j7"
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+keywords = ["dns-rebinding", "csrf", "mcp"]
+aliases = ["CVE-2026-42559", "GHSA-fvh2-gm75-j4j7"]
+related = ["GHSA-89vp-x53w-74fx"]
+
+[versions]
+patched = [">= 0.9.13"]
+unaffected = ["< 0.9.3"]
+```
+
+# DNS rebinding and cross-origin CSRF in dynoxide's MCP HTTP transport
+
+dynoxide's MCP HTTP transport was vulnerable to DNS rebinding via its transitive `rmcp` dependency, plus a related cross-origin CSRF gap.
+
+A malicious web page could make the user's browser send requests to a local `dynoxide mcp --http` or `dynoxide serve --mcp` server with a non-loopback `Host` header, which the server would then process. The Host check alone did not close a related cross-origin CSRF vector: a page could `fetch` the loopback endpoint with `mode: 'no-cors'`, and the Host header would match while the Origin header went unchecked.
+
+Affected MCP write tools include `put_item`, `update_item`, `delete_item`, `create_table`, and `batch_write_item`.
+
+The stdio transport (`dynoxide mcp` without `--http`) is not affected.
+
+## Patches
+
+dynoxide 0.9.13 closes both vectors:
+
+- Upgrades `rmcp` from 1.1.1 to 1.6.0 (which ships a default Host-header allowlist).
+- Sets explicit `allowed_hosts` and `allowed_origins` on `StreamableHttpServerConfig`.
+
+## References
+
+- GitHub Security Advisory: https://github.com/nubo-db/dynoxide/security/advisories/GHSA-fvh2-gm75-j4j7
+- Upstream rmcp advisory: https://github.com/modelcontextprotocol/rust-sdk/security/advisories/GHSA-89vp-x53w-74fx
+- dynoxide release: https://github.com/nubo-db/dynoxide/releases/tag/v0.9.13

--- a/crates/dynoxide-rs/RUSTSEC-0000-0000.md
+++ b/crates/dynoxide-rs/RUSTSEC-0000-0000.md
@@ -8,6 +8,7 @@ cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
 keywords = ["dns-rebinding", "csrf", "mcp"]
 aliases = ["CVE-2026-42559", "GHSA-fvh2-gm75-j4j7"]
 related = ["GHSA-89vp-x53w-74fx"]
+references = ["https://github.com/nubo-db/dynoxide/releases/tag/v0.9.13"]
 
 [versions]
 patched = [">= 0.9.13"]
@@ -31,8 +32,3 @@ dynoxide 0.9.13 closes both vectors:
 - Upgrades `rmcp` from 1.1.1 to 1.6.0 (which ships a default Host-header allowlist).
 - Sets explicit `allowed_hosts` and `allowed_origins` on `StreamableHttpServerConfig`.
 
-## References
-
-- GitHub Security Advisory: https://github.com/nubo-db/dynoxide/security/advisories/GHSA-fvh2-gm75-j4j7
-- Upstream rmcp advisory: https://github.com/modelcontextprotocol/rust-sdk/security/advisories/GHSA-89vp-x53w-74fx
-- dynoxide release: https://github.com/nubo-db/dynoxide/releases/tag/v0.9.13


### PR DESCRIPTION
Filing the dynoxide-rs counterpart to [GHSA-fvh2-gm75-j4j7](https://github.com/nubo-db/dynoxide/security/advisories/GHSA-fvh2-gm75-j4j7) / CVE-2026-42559 so cargo audit and cargo deny users get the alert.

The vulnerability lives in the MCP HTTP transport. dynoxide 0.9.13 ships the fix. Full write-up in the GHSA.