### PR TITLE
Add advisory for fourq: OOB pointer arithmetic in Point::from_hash()

### DIFF
--- a/crates/fourq/RUSTSEC-0000-0000.md
+++ b/crates/fourq/RUSTSEC-0000-0000.md
@@ -1,0 +1,27 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "fourq"
+date = "2026-05-02"
+url = "https://github.com/982945902/fourq_rust/issues/1"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["undefined-behavior", "out-of-bounds"]
+
+[versions]
+patched = []
+```
+
+# Out-of-bounds pointer arithmetic and write in `Point::from_hash()`
+
+`Point::from_hash()` performs unchecked pointer arithmetic on the input byte
+slice. It casts `bytes.as_ptr()` to `*mut [u64; 2]`, adds 1 to get `r1`, and
+calls `mod1271()` on both `r0` and `r1` without validating that
+`bytes.len() >= 32`. With a short slice (e.g. 4 bytes), `r0.add(1)` produces
+an out-of-bounds pointer, leading to out-of-bounds memory writes.
+
+The function also casts a `const` pointer to `mut` and mutates the caller's
+slice, violating the aliasing rules.
+
+This is undefined behavior that can be triggered through a public safe API —
+no `unsafe` is required from the caller's perspective.


### PR DESCRIPTION
## Affected crate(s)

- fourq (14 recent downloads on crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/982945902/fourq_rust/issues/1

## Severity

Undefined behavior via out-of-bounds pointer arithmetic and write. `Point::from_hash()` is a public safe API that performs unchecked pointer operations on short byte slices, leading to OOB memory writes and aliasing violations. Triggerable from safe code.

## Checklist

- [x] Advisory filename starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate