### PR TITLE
Add advisory for potato: invalid UTF-8 from safe code via RefStr

### DIFF
--- a/crates/potato/RUSTSEC-0000-0000.md
+++ b/crates/potato/RUSTSEC-0000-0000.md
@@ -1,0 +1,27 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "potato"
+date = "2026-05-02"
+url = "https://github.com/fawdlstty/potato/issues/1"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["undefined-behavior", "utf-8"]
+
+[versions]
+patched = []
+```
+
+# `RefStr::from_slice()` allows constructing invalid UTF-8 from safe code
+
+`RefStr::from_slice(data, start, len)` is declared safe but uses
+`unsafe { data.get_unchecked(start) }` internally without validating `start`
+and `len`. Callers can construct a `RefStr` pointing to arbitrary bytes.
+
+Combined with `to_str()`, which calls `std::str::from_utf8_unchecked()` on
+the underlying bytes, a caller can produce an invalid `&str` that violates
+Rust's safety requirements. For example, slicing a multi-byte UTF-8 character
+in the middle produces an invalid `&str`.
+
+Both `from_slice()` and `to_str()` are public safe APIs, so this undefined
+behavior can be triggered without writing any `unsafe` code.


### PR DESCRIPTION
## Affected crate(s)

- potato (375 recent downloads on crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/fawdlstty/potato/issues/1

## Severity

Undefined behavior via invalid UTF-8 construction from safe code. `RefStr::from_slice()` is declared safe but uses unsafe internals without validation. Combined with `to_str()`, this allows producing invalid `&str` from safe code, violating Rust's safety guarantees.

## Checklist

- [x] Advisory filename starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate