### PR TITLE
Add advisory for emap: double-free and use-after-free in Keys::next()

### DIFF
--- a/crates/emap/RUSTSEC-0000-0000.md
+++ b/crates/emap/RUSTSEC-0000-0000.md
@@ -1,0 +1,26 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "emap"
+date = "2026-05-02"
+url = "https://github.com/yegor256/emap/issues/168"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["double-free", "use-after-free"]
+
+[versions]
+patched = []
+```
+
+# Double-free and use-after-free in `Keys::next()`
+
+`Keys::next()` uses `ptr::read` to move out the `Option<V>` by value, which
+drops the contained `V` when `V` is non-Copy (e.g. `String`). This leaves a
+dangling value in the map's storage slot. Subsequent `get()` operations on
+that key return a dangling reference to already-freed memory.
+
+This can be triggered through safe public APIs — `Map::keys()`,
+`Keys::next()`, and `Map::get()` — with no `unsafe` required from the
+caller. Under Miri, accessing the freed slot produces "Undefined Behavior:
+pointer not dereferenceable: alloc has been freed, so this pointer is
+dangling".


### PR DESCRIPTION
## Affected crate(s)

- emap (99 recent downloads on crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/yegor256/emap/issues/168

## Severity

Double-free and use-after-free. `Keys::next()` uses `ptr::read` to move out `Option<V>`, dropping non-Copy values and leaving dangling entries. Subsequent `get()` returns dangling references. Triggerable from safe code (`Map::keys()`, `Keys::next()`, `Map::get()`). Confirmed by Miri.

## Checklist

- [x] Advisory filename starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate