### PR TITLE
Add advisory for bitchomp: double-free in Chomp::inner()

### DIFF
--- a/crates/bitchomp/RUSTSEC-0000-0000.md
+++ b/crates/bitchomp/RUSTSEC-0000-0000.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "bitchomp"
+date = "2026-05-02"
+url = "https://github.com/KingPEPSALT/bitchomp/issues/5"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["double-free"]
+
+[versions]
+patched = []
+```
+
+# Double-free in `Chomp::inner()`
+
+`Chomp::inner()` uses `std::ptr::read_unaligned` to move out the value from a
+raw pointer. If the original value is an owned type (e.g. `Box`), calling
+`inner()` moves out the ownership, but the original variable will still be
+dropped at the end of its scope. This causes the same heap memory to be freed
+twice, resulting in a double-free and undefined behavior.
+
+This can be triggered through safe public APIs — `Chomp::new()` and
+`Chomp::inner()` — with no `unsafe` required from the caller.


### PR DESCRIPTION
## Affected crate(s)

- bitchomp (219 recent downloads on crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/KingPEPSALT/bitchomp/issues/5

## Severity

Double-free via `Chomp::inner()`. Uses `ptr::read_unaligned` to move out values from raw pointers, but the original variable is still dropped, causing the same heap memory to be freed twice. Triggerable from safe code (`Chomp::new()`, `Chomp::inner()`).

## Checklist

- [x] Advisory filename starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate