### PR TITLE
Add advisory for metacall: null-ptr dereference and double-free via safe APIs

### DIFF
--- a/crates/metacall/RUSTSEC-0000-0000.md
+++ b/crates/metacall/RUSTSEC-0000-0000.md
@@ -1,0 +1,31 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "metacall"
+date = "2026-05-02"
+url = "https://github.com/metacall/core/issues/618"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["double-free", "null-pointer", "undefined-behavior"]
+
+[versions]
+patched = []
+```
+
+# Null-pointer dereference and double-free via safe APIs
+
+Two soundness violations exist in the Rust bindings for MetaCall:
+
+**Null-pointer dereference:** `MetaCallFuture::new_raw()` accepts a raw
+pointer without validation. The `Debug` impl calls `Box::from_raw(self.data)`
+on it. Passing a null pointer causes the `Debug` impl to construct a
+`NonNull` from null, producing undefined behavior.
+
+**Double-free:** `MetaCallPointer::clone()` shares the same `rust_value` raw
+pointer between the clone and the original. Calling `get_value_untyped()` on
+both clones calls `Box::from_raw` on the same pointer twice, resulting in a
+double-free.
+
+Both issues can be triggered through safe public APIs —
+`MetaCallFuture::new_raw()`, `MetaCallPointer::new()`, `clone()`, and
+`get_value_untyped()` — with no `unsafe` required from the caller.


### PR DESCRIPTION
## Affected crate(s)

- metacall (2350 recent downloads on crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/metacall/core/issues/618

## Severity

Two soundness violations: (1) Null-pointer dereference — `MetaCallFuture::new_raw()` accepts raw pointers without validation, `Debug` impl constructs `NonNull` from null producing UB. (2) Double-free — `MetaCallPointer::clone()` shares raw pointers, `get_value_untyped()` calls `Box::from_raw` twice on the same pointer. Both triggerable from safe code.

## Checklist

- [x] Advisory filename starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate