### PR TITLE
Add advisory for caja: OOB read/write in Index/IndexMut

### DIFF
--- a/crates/caja/RUSTSEC-0000-0000.md
+++ b/crates/caja/RUSTSEC-0000-0000.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "caja"
+date = "2026-05-02"
+url = "https://github.com/EmanuelGCC/Caja/issues/1"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["out-of-bounds"]
+
+[versions]
+patched = [">= 0.3.0"]
+```
+
+# Out-of-bounds read/write in `Index` and `IndexMut` implementations
+
+The `Index` and `IndexMut` implementations for `Caja` use unchecked pointer
+arithmetic without bounds validation. Creating a `Caja` with a small key and
+then accessing an out-of-range index causes out-of-bounds reads or writes
+beyond the allocated memory.
+
+This can be triggered through safe public APIs — the `[]` indexing operator
+on a `Caja` with an out-of-range index — with no `unsafe` required from the
+caller.


### PR DESCRIPTION
## Affected crate(s)

- caja (21 recent downloads on crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/EmanuelGCC/Caja/issues/1

## Severity

Out-of-bounds read/write. The `Index` and `IndexMut` implementations for `Caja` use unchecked pointer arithmetic without bounds validation. Triggerable from safe code via the `[]` indexing operator. Fixed in version 0.3.0.

## Checklist

- [x] Advisory filename starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate