### PR TITLE
Add advisory for sfbinpack: OOB read via BitReader

### DIFF
--- a/crates/sfbinpack/RUSTSEC-0000-0000.md
+++ b/crates/sfbinpack/RUSTSEC-0000-0000.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "sfbinpack"
+date = "2026-05-02"
+url = "https://github.com/Disservin/binpack-rust/issues/17"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["out-of-bounds"]
+
+[versions]
+patched = []
+```
+
+# Out-of-bounds read via `BitReader` in `CompressedTrainingDataEntryReader`
+
+`CompressedTrainingDataEntryReader` constructs a `BitReader` from a raw
+pointer without tracking length. A crafted chunk with `num_plies > 0` but no
+movetext bytes triggers out-of-bounds reads via the `BitReader`, which uses
+`*self.movetext.add(self.read_offset)` without bounds checks.
+
+This can be triggered through safe public APIs —
+`CompressedTrainingDataEntryReader::new()` and `.next()` — with no `unsafe`
+required from the caller.


### PR DESCRIPTION
## Affected crate(s)

- sfbinpack (4329 recent downloads on crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/Disservin/binpack-rust/issues/17

## Severity

Out-of-bounds read. `CompressedTrainingDataEntryReader` constructs a `BitReader` from a raw pointer without tracking length. Crafted input triggers OOB reads. Triggerable from safe code (`CompressedTrainingDataEntryReader::new()`, `.next()`).

## Checklist

- [x] Advisory filename starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate