### PR TITLE
Add advisory for auto_vec: invalid pointer arithmetic in iter()

### DIFF
--- a/crates/auto_vec/RUSTSEC-0000-0000.md
+++ b/crates/auto_vec/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "auto_vec"
+date = "2026-05-02"
+url = "https://github.com/lluvz/AutoVec/issues/1"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["out-of-bounds", "pointer-arithmetic"]
+
+[versions]
+patched = []
+```
+
+# Invalid pointer arithmetic in `iter()` and `iter_mut()`
+
+The `iter()` and `iter_mut()` APIs compute
+`current = (&children[0] as *const *const RawAutoChild).sub(1)`, which
+performs pointer subtraction going before the start of the allocation. This
+is undefined behavior per Rust's pointer arithmetic rules.
+
+This can be triggered through safe public APIs — `iter()` and `iter_mut()`
+— with no `unsafe` required from the caller.


### PR DESCRIPTION
## Affected crate(s)

- auto_vec (12 recent downloads on crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/lluvz/AutoVec/issues/1

## Severity

Invalid pointer arithmetic. `iter()` and `iter_mut()` compute `.sub(1)` on a pointer, going before the start of the allocation. This is undefined behavior. Triggerable from safe code.

## Checklist

- [x] Advisory filename starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate