### PR TITLE
Add advisory for trk-io: OOB read in ArraySequence Index

### DIFF
--- a/crates/trk-io/RUSTSEC-0000-0000.md
+++ b/crates/trk-io/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "trk-io"
+date = "2026-05-02"
+url = "https://github.com/imeka/trk-io/issues/24"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["out-of-bounds"]
+
+[versions]
+patched = []
+```
+
+# Out-of-bounds read in `ArraySequence` `Index` implementation
+
+The `Index` implementation for `ArraySequence` uses `get_unchecked(i)` and
+`get_unchecked(i+1)` on `self.offsets` without validating bounds. An empty
+`ArraySequence` (offsets = `[0]`, len() = 0) indexed at 0 calls
+`get_unchecked(1)` which is out-of-bounds.
+
+This can be triggered through safe public APIs — `ArraySequence::empty()`
+followed by `&seq[0]` — with no `unsafe` required from the caller.


### PR DESCRIPTION
## Affected crate(s)

- trk-io (79 recent downloads on crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/imeka/trk-io/issues/24

## Severity

Out-of-bounds read. The `Index` implementation for `ArraySequence` uses `get_unchecked` without validating bounds. An empty sequence indexed at 0 triggers OOB. Triggerable from safe code.

## Checklist

- [x] Advisory filename starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate