### PR TITLE
Add advisory for rustdx: OOB read in bytes_helper safe functions

### DIFF
--- a/crates/rustdx/RUSTSEC-0000-0000.md
+++ b/crates/rustdx/RUSTSEC-0000-0000.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rustdx"
+date = "2026-05-02"
+url = "https://github.com/zjp-CN/rustdx/issues/38"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["out-of-bounds", "buffer-overflow"]
+
+[versions]
+patched = [">= 0.4.4"]
+```
+
+# Out-of-bounds read in `bytes_helper` public safe functions
+
+The `bytes_helper` module contains multiple public functions
+(`into_arr4()`, `into_arr2()`, `u8_from_le_bytes()`) that use
+`slice.get_unchecked(pos..pos + N)` without verifying that
+`pos + N <= slice.len()`. These are public safe API functions, allowing any
+caller to trigger undefined behavior by passing invalid positions.
+
+For example, calling `into_arr4(&data, 10)` where `data` is a 3-byte slice
+causes an out-of-bounds access since position 10 exceeds the slice length.


### PR DESCRIPTION
## Affected crate(s)

- rustdx (157 recent downloads on crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/zjp-CN/rustdx/issues/38

## Severity

Out-of-bounds read / buffer overflow. The `bytes_helper` module has public safe functions (`into_arr4()`, `into_arr2()`, `u8_from_le_bytes()`) that use `get_unchecked` without validating positions. Triggerable from safe code. Fixed in version 0.4.4.

## Checklist

- [x] Advisory filename starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate