### PR TITLE
Add advisory for ssdeep: OOB write via public Context fields

### DIFF
--- a/crates/ssdeep/RUSTSEC-0000-0000.md
+++ b/crates/ssdeep/RUSTSEC-0000-0000.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "ssdeep"
+date = "2026-05-02"
+url = "https://github.com/rustysec/fuzzyhash-rs/issues/14"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["out-of-bounds", "encapsulation"]
+
+[versions]
+patched = []
+```
+
+# Potential out-of-bounds write via public `Context` fields
+
+The `Context` struct has all fields public (`pub d_len`, `pub digest`, etc.).
+External code can directly modify `d_len` to a value exceeding the `digest`
+vector length. When `reset()` is subsequently called,
+`self.digest[self.d_len as usize] = 0` indexes out of bounds, causing an
+out-of-bounds write.
+
+This can be triggered through safe code — modifying public `Context` fields
+and then calling `reset()` — with no `unsafe` required.


### PR DESCRIPTION
## Affected crate(s)

- ssdeep (2340 recent downloads on crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/rustysec/fuzzyhash-rs/issues/14

## Severity

Potential out-of-bounds write. The `Context` struct has all public fields, allowing external code to set `d_len` beyond `digest` length. Subsequent `reset()` call indexes out of bounds. Triggerable from safe code.

## Checklist

- [x] Advisory filename starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate