### PR TITLE
Add advisory for dahl-salso: buffer overflow in Clusterings

### DIFF
--- a/crates/dahl-salso/RUSTSEC-0000-0000.md
+++ b/crates/dahl-salso/RUSTSEC-0000-0000.md
@@ -1,0 +1,29 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "dahl-salso"
+date = "2026-05-02"
+url = "https://github.com/dbdahl/rust-dahl-salso/issues/1"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["out-of-bounds", "buffer-overflow"]
+
+[versions]
+patched = [">= 0.6.8"]
+```
+
+# Buffer overflow in `Clusterings::from_i32_column_major_order()`
+
+The `from_i32_column_major_order` method can create inconsistent internal
+state. When `labels` length and `n_items` mismatch, `n_clusterings` becomes
+`labels.len() / n_items` (truncated), but subsequent calls to `label()` use
+indices that exceed the internal data bounds, causing a buffer overflow.
+
+For example, `Clusterings::from_i32_column_major_order(&[1,2,3,4,5], 3)`
+creates clusterings with `n_clusterings = 5/3 = 1`. Then
+`clusterings.label(1, 0)` accesses index `1*3 = 3`, but only 3 elements
+exist (indices 0,1,2), causing out-of-bounds access.
+
+This can be triggered through safe public APIs —
+`from_i32_column_major_order()` and `label()` — with no `unsafe` required
+from the caller.


### PR DESCRIPTION
## Affected crate(s)

- dahl-salso (49 recent downloads on crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/dbdahl/rust-dahl-salso/issues/1

## Severity

Buffer overflow. `Clusterings::from_i32_column_major_order()` can create inconsistent internal state when `labels` length and `n_items` mismatch. Subsequent `label()` calls access out-of-bounds indices. Triggerable from safe code. Fixed in version 0.6.8.

## Checklist

- [x] Advisory filename starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate