### PR TITLE
Add advisory for accessor: integer overflow in array::ReadWrite::new()

### DIFF
--- a/crates/accessor/RUSTSEC-0000-0000.md
+++ b/crates/accessor/RUSTSEC-0000-0000.md
@@ -1,0 +1,26 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "accessor"
+date = "2026-05-02"
+url = "https://github.com/toku-sa-n/accessor/issues/49"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["integer-overflow", "out-of-bounds"]
+
+[versions]
+patched = []
+```
+
+# Integer overflow in `array::ReadWrite::new()` leading to potential memory corruption
+
+In `array::ReadWrite::new()` (line 83 of `accessor/src/array.rs`),
+`let bytes = mem::size_of::<T>() * len` can overflow `usize` when `len` is
+very large. In release mode, this silently wraps, potentially making
+`bytes = 0`. The mapper then maps with 0 bytes, and subsequent accesses
+(e.g. `read_volatile_at`) lead to undefined behavior or memory corruption.
+
+Note: `array::ReadWrite::new()` itself is `unsafe`, so direct triggering
+requires an `unsafe` block. However, the integer overflow violates the
+implicit safety contract expected by callers and can lead to memory
+corruption downstream.


### PR DESCRIPTION
## Affected crate(s)

- accessor (2961 recent downloads on crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/toku-sa-n/accessor/issues/49

## Severity

Integer overflow leading to potential memory corruption. `array::ReadWrite::new()` computes `mem::size_of::<T>() * len` which can overflow `usize` in release mode, wrapping to 0. This causes subsequent memory accesses to be undefined behavior. Note: `new()` itself is `unsafe`, but the overflow violates the implicit safety contract.

## Checklist

- [x] Advisory filename starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate