### PR TITLE
Add advisory for aeron: OOB memory access in atomic_buffer()

### DIFF
--- a/crates/aeron/RUSTSEC-0000-0000.md
+++ b/crates/aeron/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "aeron"
+date = "2026-05-02"
+url = "https://github.com/UnitedTraders/aeron-rs/issues/31"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["out-of-bounds", "segfault"]
+
+[versions]
+patched = []
+```
+
+# Out-of-bounds memory access in `MemoryMappedFile::atomic_buffer()`
+
+`MemoryMappedFile::atomic_buffer()` performs unchecked pointer arithmetic
+without validating that the offset + length fits within the mapped file size.
+Passing an offset far beyond the file size causes a segmentation fault on
+subsequent buffer operations.
+
+This can be triggered through safe public APIs — `atomic_buffer()` is a safe
+method — with no `unsafe` required from the caller.


### PR DESCRIPTION
## Affected crate(s)

- aeron (434 recent downloads on crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/UnitedTraders/aeron-rs/issues/31

## Severity

Out-of-bounds memory access / segfault. `MemoryMappedFile::atomic_buffer()` performs unchecked pointer arithmetic without validating that offset + length fits within the mapped file size. Triggerable from safe code.

## Checklist

- [x] Advisory filename starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate