### PR TITLE
Add advisories for libcrux-chacha20poly1305, libcrux-ml-dsa

### DIFF
--- a/crates/libcrux-chacha20poly1305/RUSTSEC-0000-0000.md
+++ b/crates/libcrux-chacha20poly1305/RUSTSEC-0000-0000.md
@@ -1,0 +1,34 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libcrux-chacha20poly1305"
+date = "2026-03-29"
+
+url = "https://github.com/cryspen/libcrux/pull/1386"
+
+cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
+
+[affected.functions]
+"libcrux_chacha20poly1305::encrypt" = ["< 0.0.8"]
+"libcrux_chacha20poly1305::xchacha20_poly1305::encrypt" = ["< 0.0.8"]
+
+[versions]
+patched = [">= 0.0.8"]
+```
+
+# Potential Panic on Overlong Ciphertext Buffer
+
+An application that passes in a ciphertext buffer of length greater
+than `ptxt.len() + TAG_LEN` to `libcrux_chacha20poly1305::encrypt` or
+`libcrux_chacha20poly1305::xchacha20_poly1305::encrypt` would
+experience a panic.
+
+## Impact
+An application where the length of the ciphertext buffer is under
+attacker control could be made to crash.
+
+## Mitigation
+The fix makes it so that `libcrux_chacha20poly1305::encrypt` and
+`libcrux_chacha20poly1305::xchacha20_poly1305::encrypt` no longer
+panic in this case, but instead write out the ciphertext and tag into
+the first `ptxt.len() + TAG_LEN` bytes of the provided buffer.

--- a/crates/libcrux-ml-dsa/RUSTSEC-0000-0000.0.md
+++ b/crates/libcrux-ml-dsa/RUSTSEC-0000-0000.0.md
@@ -1,0 +1,32 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libcrux-ml-dsa"
+date = "2026-04-27"
+
+url = "https://github.com/cryspen/libcrux/pull/1395"
+
+informational = "notice"
+
+[affected]
+arch = ["x86_64"]
+
+[versions]
+patched = [">= 0.0.9"]
+```
+
+# AVX2 Implementation Did Not Fully Reduce Intermediate Values
+
+The AVX2 implementation of ML-DSA did not fully reduce intermediate
+inputs to the inverse NTT, which leads to a testable difference in
+panic behaviour of internal functions compared to the portable
+implementation.
+
+## Impact
+We are not aware of inputs to the public key generation, signing or
+verification APIs that trigger a panic in the AVX2 implementation
+because the intermediate values were not fully reduced.
+
+## Mitigation
+From version `0.0.9` intermediate values on AVX2 platforms are fully
+reduced in alignment with the portable implementation.

--- a/crates/libcrux-ml-dsa/RUSTSEC-0000-0000.1.md
+++ b/crates/libcrux-ml-dsa/RUSTSEC-0000-0000.1.md
@@ -1,0 +1,31 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libcrux-ml-dsa"
+date = "2026-05-05"
+
+url = "https://github.com/cryspen/libcrux/pull/1398"
+references = ["https://github.com/C2SP/wycheproof/pull/234", "https://github.com/tink-crypto/tink-go/pull/48"]
+cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N"
+
+[affected]
+arch = ["x86_64"]
+
+[versions]
+patched = [">= 0.0.9"]
+```
+
+# Signature Verification on AVX2 Platforms Mishandles Edge Case
+
+The AVX2 implementation of ML-DSA verification incorrectly implemented
+the `use_hint` function, mishandling an edge case that should lead to
+signature rejection.
+
+## Impact
+An attacker could make the ML-DSA verifier accept a crafted invalid
+signature under a maliciously generated verification key, if the AVX2
+implementation is used.
+
+## Mitigation
+From version `0.0.9` the edge case is handled correctly and invalid
+signatures are rejected.


### PR DESCRIPTION
These are advisories for bug fixes in the latest release of libcrux crates.

Please let me know if more context is necessary, or if the `informational = "notice"` one for ML-DSA is inappropriate.