### PR TITLE
Add advisory for lettre for TLS hostname verification disabled in Boring TLS backend

### DIFF
--- a/crates/lettre/RUSTSEC-0000-0000.md
+++ b/crates/lettre/RUSTSEC-0000-0000.md
@@ -1,0 +1,27 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "lettre"
+date = "2026-05-14"
+url = "https://github.com/lettre/lettre/security/advisories/GHSA-4pj9-g833-qx53"
+categories = ["crypto-failure"]
+cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:H/VA:N/SC:L/SI:L/SA:N"
+keywords = ["tls", "smtp", "mitm"]
+aliases = ["GHSA-4pj9-g833-qx53"]
+
+[versions]
+unaffected = ["< 0.10.1"]
+patched = [">= 0.11.22"]
+```
+
+# TLS hostname verification disabled when using Boring TLS backend
+
+An inverted-boolean bug in lettre's `boring-tls` integration silently
+disables TLS hostname verification for callers using the default (strict)
+configuration. An on-path attacker presenting any chain-valid certificate
+for any domain can intercept SMTP submission, including PLAIN/LOGIN
+credentials and message contents, against any lettre user built with the
+`boring-tls` feature. Other TLS backends (`native-tls`, `rustls`) are
+unaffected.
+
+The bug was introduced in v0.10.1 and persists through v0.11.21 (latest).


### PR DESCRIPTION
Reports https://github.com/lettre/lettre/security/advisories/GHSA-4pj9-g833-qx53