### PR TITLE
Add advisories: oneringbuf vmem double-free + unbounded-spsc transmute UAF

### DIFF
--- a/crates/oneringbuf/RUSTSEC-0000-0000.md
+++ b/crates/oneringbuf/RUSTSEC-0000-0000.md
@@ -1,0 +1,87 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "oneringbuf"
+date = "2026-05-14"
+url = "https://github.com/Skilvingr/rust-oneringbuf/security/advisories"
+categories = ["memory-corruption"]
+keywords = ["double-free", "use-after-free", "vmem", "drop", "safe-api-ub"]
+informational = "unsound"
+references = [
+    "https://github.com/Skilvingr/rust-mutringbuf/commit/030effa",
+    "https://github.com/Skilvingr/rust-oneringbuf/commit/53a9a0a",
+]
+related = []  # cross-link to the mutringbuf advisory once RUSTSEC IDs are issued
+
+[versions]
+patched = []
+unaffected = []
+
+[affected]
+functions = { "oneringbuf::VmemStorage::new" = ["*"] }
+```
+
+# Double-free / use-after-free in `vmem` storage reachable from 100% safe Rust
+
+When the `vmem` feature is enabled, `VmemStorage<T>::new(Box<[UnsafeSyncCell<T>]>)` (and every public constructor that funnels through it — `ConcurrentHeapRB::default(cap)`, `ConcurrentHeapRB::from(Vec<T>)`, `From<Box<[T]>>`, `From<Box<[UnsafeSyncCell<T>]>>`, `From<Vec<UnsafeSyncCell<T>>>`) bit-copies the input buffer into a freshly `mmap`'d region with `ptr::copy_nonoverlapping`, then lets the source `Box<[UnsafeSyncCell<T>]>` drop normally.
+
+Because `UnsafeSyncCell<T>` has a `Drop` impl that runs `assume_init_drop` on its inner `MaybeUninit<T>`, the source-side `T` values are dropped immediately at the end of `new`, while bitwise duplicates (containing the same heap pointers for `String`, `Box`, `Vec`, `Arc`, …) remain inside the `mmap` region. When the ring buffer is later destructed, the destructor's `drop_in_place` over the slice runs `UnsafeSyncCell::drop` a second time on every cell — a deterministic double-free of every heap-owning element.
+
+The defect is reachable from 100% safe Rust. No `unsafe` is required on the caller side; the unsafe boundary is crossed entirely inside the crate's public constructors.
+
+## Trigger
+
+```rust
+let v: Vec<Vec<u32>> = (0..1024).map(|i| vec![i, i+1, i+2]).collect();
+let rb: oneringbuf::SharedVmemRB<Vec<u32>> = oneringbuf::SharedVmemRB::from(v);
+drop(rb);
+// glibc: free(): double free detected in tcache 2 -> abort
+// ASan: AddressSanitizer: attempting double-free
+```
+
+The double-free is independent of the mmap mechanism — the underlying defect (drop source `Box` *and* `drop_in_place` the bit-copy) is pure-Rust UB and surfaces cleanly under `glibc` `MALLOC_CHECK_` and under `-Zsanitizer=address`. `String::default()` does not trigger because the empty string has no heap allocation; any `T` with a non-trivial `Drop` (`Vec<u32>`, `String` with content, `Box<U>`, `Arc<U>`, …) reproduces deterministically.
+
+## Affected paths
+
+Four code excerpts compose the bug. Locations are quoted against the predecessor `mutringbuf` source (the byte-identical code lives in `oneringbuf` under the renamed `VmemStorage`):
+
+1. `src/ring_buffer/wrappers/unsafe_sync_cell.rs:10-16` — `Drop for UnsafeSyncCell<T>` invokes `assume_init_drop` unless the bytes are all-zero.
+2. `src/ring_buffer/storage/heap/mod.rs:69-91` — every `From<_>` impl funnels into `Self::new(value: Box<[UnsafeSyncCell<T>]>)`.
+3. `src/ring_buffer/storage/heap/mod.rs:43-52` — the `vmem`-branch `new` calls `vmem_helper::new(&value)` and lets `value` drop at function return (no `mem::forget`, no `ManuallyDrop`).
+4. `src/ring_buffer/storage/heap/vmem_helper.rs:62-126` — ends with `ptr::copy_nonoverlapping(value.as_ptr(), r, value.len())`, the move-without-Drop primitive.
+5. `src/ring_buffer/storage/heap/mod.rs:20-41` — `Drop for HeapStorage<T>` (vmem branch) runs `drop_in_place` over the slice before `munmap`. This second `Drop` re-frees the heap pointers that the source-side cells already freed in step 3.
+
+The current double-free shape was introduced by `030effa` (2025-11-10, "Fix: Improve drop implementation and iterator aliveness"), which added the `drop_in_place(p)` to `HeapStorage::drop`. Before that commit the destructor only `munmap`'d, so the bug was a different UB shape (T leaked by source-drop, then any subsequent access read already-freed values from the mmap). The "fix" converted the leak/UAF into a confirmed double-free. The crate rename commit `53a9a0a` (2025-11-20, "full rework and new release") carried the pattern forward into `oneringbuf` as `VmemStorage`.
+
+CI ran sanitizers but only over `i32` / `u32` / `usize` types in tests — `Copy` types with no-op `Drop` cannot exhibit this bug.
+
+## Suggested patch
+
+`mem::forget(value)` after `vmem_helper::new(&value)` is necessary but not sufficient — it leaks the `Box` backing allocation. The clean form `ManuallyDrop`s the source and then `dealloc`s the box backing directly, bypassing the per-cell `Drop`:
+
+```rust
+#[cfg(feature = "vmem")]
+fn new(value: Box<[UnsafeSyncCell<T>]>) -> Self {
+    use core::mem::ManuallyDrop;
+    let len = value.len();
+    let r = vmem_helper::new(&value);
+    let value = ManuallyDrop::new(value);
+    let raw = Box::into_raw(ManuallyDrop::into_inner(value));
+    let layout = core::alloc::Layout::array::<UnsafeSyncCell<T>>(len).unwrap();
+    unsafe { core::alloc::dealloc(raw as *mut u8, layout); }
+    Self { inner: r, len }
+}
+```
+
+Alternative — remove the `Drop` impl from `UnsafeSyncCell` entirely (matching the documented `MaybeUninit` contract that owners must call `assume_init_drop` explicitly), and have `HeapStorage::drop` remain the sole authority on when cells are dropped. This applies uniformly across the `vmem` and non-`vmem` paths.
+
+## Notes
+
+- The archived predecessor `mutringbuf` (https://github.com/Skilvingr/rust-mutringbuf, archived 2025-11-20) carries the same bug across all `vmem`-enabled releases up to `1.0.0`. A separate (or merged) RustSec advisory should name `mutringbuf` in parallel. The crate's README points users to `oneringbuf` as the maintained successor, so the primary remediation target is `oneringbuf`.
+- Practical exposure on crates.io is currently minimal: 0 reverse dependencies on either crate, ~10 downloads/month combined. The advisory is justified because the bug is a clear soundness defect on a public safe-Rust API, present in the maintained successor, and would survive any future popularity growth.
+- A coordinated GitHub Security Advisory has been drafted at https://github.com/Skilvingr/rust-oneringbuf/security/advisories.
+
+## Researcher
+
+Berkant Koc <me@berkoc.com>
+PGP: 0C588DFD76204987284213EA0AC529C41F8AA5D6

--- a/crates/unbounded-spsc/RUSTSEC-0000-0000.md
+++ b/crates/unbounded-spsc/RUSTSEC-0000-0000.md
@@ -1,0 +1,111 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "unbounded-spsc"
+date = "2026-05-14"
+url = "https://github.com/spearman/unbounded-spsc/security/advisories"
+categories = ["memory-corruption"]
+keywords = ["transmute", "uaf", "race", "drop", "safe-api-ub", "toctou"]
+informational = "unsound"
+references = [
+    "https://github.com/spearman/unbounded-spsc/blob/master/src/lib.rs",
+]
+
+[versions]
+patched = []
+unaffected = []
+
+[affected]
+functions = { "unbounded_spsc::Sender::send" = ["<= 0.2.0"] }
+```
+
+# `Sender::send` pointer-as-value transmute causes OOB read and fake-Arc drop under TX/RX race
+
+`Sender::send` (single-file crate, `src/lib.rs`, lines 379-405 in 0.2.0 / commit `23a9ce7`) contains an `unsafe` block in the `DISCONNECTED` arm that transmutes the *pointer to* the producer instead of the producer value:
+
+```rust
+let consumer: spsc::Consumer<T> = std::mem::transmute(self.producer.get());
+```
+
+`self.producer` has type `UnsafeCell<spsc::Producer<T>>`. `UnsafeCell::<X>::get(&self)` returns `*mut X` — a pointer-sized value. The author's intent (visible in the surrounding comment) was a value-level transmute (`Producer<T>` and `Consumer<T>` in `bounded_spsc_queue` are layout-compatible newtypes around `Arc<Buffer<T>>`). The shipped code is one indirection off: it copies 8 bytes of pointer into the bytes of a `Consumer<T>`. The resulting `Consumer<T>::buffer.ptr` is the address of the producer field on the `Sender`, not the real `ArcInner<Buffer<T>>`.
+
+The subsequent `consumer.try_pop()` walks `Buffer<T>` fields at offsets that lie inside the `Sender<T>` struct (`send_new`, `inner`) and adjacent memory — an out-of-bounds read of the Sender's own frame. The fake `Consumer<T>`'s `Drop` decrements bytes that are actually the real `Arc::ptr` value (treated as an `AtomicUsize` `strong_count`) and then calls `dealloc(Layout::for_value(...))` on a non-allocated address — a fake `Arc::drop` against the Sender memory.
+
+The branch is **not** reachable single-threaded: `Receiver::drop` (line 332) stores `connected = false` before setting `counter = DISCONNECTED`; `Sender::send` (line 359) early-returns on `connected == false`. The trigger is a TOCTOU race where the sender's `connected.load()` wins but the receiver's `counter.compare_exchange(_, DISCONNECTED, ...)` wins. Under heavy contention the race reproduces ~3/10 trials, observed via ASan `stack-buffer-overflow` reports and plain release-mode `Segmentation fault` aborts.
+
+## Trigger
+
+```rust
+use std::thread;
+use unbounded_spsc::channel;
+
+for _ in 0..500 {
+    let (tx, rx) = channel::<Box<u64>>();
+    let h = thread::spawn(move || {
+        for _ in 0..10_000 { let _ = tx.send(Box::new(0xDEAD_BEEF)); }
+    });
+    drop(rx);
+    let _ = h.join();
+}
+// Release: SIGSEGV reliably within a few trials.
+// ASan: stack-buffer-overflow / stack-use-after-scope inside fake-Consumer::try_pop.
+```
+
+## Smoking-gun upstream evidence
+
+`src/lib.rs:975` in the project's own test suite carries a TODO:
+
+```
+// TODO: failures
+// - failed with assertion on line 394 in send fn
+//   assert!(second.is_none())
+```
+
+That assertion site is the same line as the transmute block above (`assert!(second.is_none())` at line 396 in 0.2.0). The author has observed the symptom — `try_pop()` returning a non-`None` value where logically there should be none — as a flaky test rather than recognising it as UB. The bug has been visible in the project's own test runs.
+
+The crate's `Cargo.toml` lints `transmute-ptr-to-ptr = "warn"` and `mem-forget = "warn"` are active but neither catches this pattern: `transmute-ptr-to-ptr` only fires on pointer-to-pointer transmutes (not pointer-to-value), and `mem-forget = "warn"` actively discourages the correct fix.
+
+## Affected versions
+
+`unbounded-spsc` `0.2.0` (latest, 2025-08-24) and earlier. The master branch (`23a9ce7`, "apply more lints", 2025-09-07) is at the same commit as the published 0.2.0. No upstream activity in the last 60 days. No GitHub issues open or closed referencing this defect.
+
+## Reverse dependencies
+
+Two crates depend on `unbounded-spsc`, both owned by the same author (`spearman`):
+
+- `apis` — process-calculus framework (374 dl/version)
+- `gooey-rs` — tile-UI library, `unbounded-spsc` gated behind `opengl`/`fmod` features (347 dl/version)
+
+Both should be notified in the same disclosure cycle. The `gooey-rs` OpenGL/FMOD callback-mailbox use is a natural rx-drop-during-tx-send scenario at scene-graph teardown.
+
+## Suggested patch
+
+Replace the pointer-as-value transmute with a value-level read plus `ManuallyDrop` on the alias to suppress the double `Producer::drop`:
+
+```rust
+unsafe {
+    use core::mem::ManuallyDrop;
+    let producer_val: spsc::Producer<T> = std::ptr::read(self.producer.get());
+    let consumer    : spsc::Consumer<T> = std::mem::transmute(producer_val);
+    let first  = consumer.try_pop();
+    let second = consumer.try_pop();
+    assert!(second.is_none());
+    if let Some(t) = first {
+        return Err(SendError(t));
+    }
+    let _ = ManuallyDrop::new(consumer);
+}
+```
+
+Cleaner — restructure `Sender<T>` to store `producer` and `consumer` in a private `enum Endpoint<T>` so no transmute is required.
+
+## Notes
+
+- Practical exposure on crates.io is modest: 13,433 total downloads, 121 in last 90 days, only the author's own two crates as reverse-deps. The advisory is justified by the reachable-from-safe-Rust UB classification and the upstream evidence that the symptom has been observed and misclassified.
+- Realistic CVSS: `AV:L/AC:H/PR:L/UI:N/S:U/C:L/I:L/A:H` ~ 4.5-5.0 Medium. Higher if a network-driven actor's mailbox teardown is attacker-induced.
+- A coordinated GitHub Security Advisory has been drafted at https://github.com/spearman/unbounded-spsc/security/advisories.
+
+## Researcher
+
+Berkant Koc <me@berkoc.com>
+PGP: 0C588DFD76204987284213EA0AC529C41F8AA5D6


### PR DESCRIPTION
Two unsoundness advisories for memory-corruption bugs reachable from 100% safe Rust APIs.

## oneringbuf
`vmem` feature double-free / UAF when source `Box<[UnsafeSyncCell<T>]>` drops after `ptr::copy_nonoverlapping` into the `mmap`'d region. Reachable through `ConcurrentHeapRB::<String>::default(cap)` and any other constructor that funnels through `HeapStorage<T>::new` / `VmemStorage<T>::new`. Affects the actively maintained successor `oneringbuf` 0.7.0 AND the archived predecessor `mutringbuf` (all vmem-enabled versions up to 1.0.0).

## unbounded-spsc
Pointer-as-value `transmute` in `Sender::send` DISCONNECTED arm (`src/lib.rs:379-405`). Transmutes `*mut Producer<T>` (8 bytes) into `Consumer<T>` (which expects a real `Arc` pointer), yielding OOB read inside the `Sender` struct and a fake-Arc drop that hits `dealloc` on an address the allocator never returned. Reachable through `tx.send()` racing `rx.drop()` such that the sender's `connected` check wins but the receiver's `DISCONNECTED` store wins the subsequent `fetch_add`.

Both advisories are also being filed as private disclosures with the respective maintainers via email (no GHSA was available on either upstream repo at the time of submission).

Researcher: Berkant Koc <me@berkoc.com>
PGP: 0C588DFD76204987284213EA0AC529C41F8AA5D6
