### PR TITLE
Add advisory for oneringbuf: vmem double-free reachable from safe Rust

### DIFF
--- a/crates/mutringbuf/RUSTSEC-0000-0000.md
+++ b/crates/mutringbuf/RUSTSEC-0000-0000.md
@@ -1,0 +1,41 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "mutringbuf"
+date = "2026-05-14"
+categories = ["memory-corruption"]
+keywords = ["double-free", "use-after-free", "vmem", "drop", "unmaintained"]
+informational = "unsound"
+references = [
+    "https://github.com/Skilvingr/rust-mutringbuf",
+    "https://github.com/skilvingr/rust-oneringbuf/pull/3",
+]
+
+[versions]
+patched = []
+unaffected = []
+
+[affected]
+functions = { "mutringbuf::VmemStorage::new" = ["*"] }
+```
+
+# Double-free in `vmem` storage reachable from safe Rust (predecessor of `oneringbuf`)
+
+`mutringbuf` is the archived predecessor of [`oneringbuf`](https://crates.io/crates/oneringbuf) — the crate was renamed and the GitHub repository was archived on 2025-11-20. All released versions up to `1.0.0` carry the same `vmem`-feature double-free bug that affects `oneringbuf`, with the same code paths and the same reproduction shape.
+
+When the `vmem` feature is enabled, `VmemStorage<T>::new(Box<[UnsafeSyncCell<T>]>)` (and every public constructor that funnels through it) bit-copies the input buffer into a freshly `mmap`'d region with `ptr::copy_nonoverlapping`, then lets the source `Box<[UnsafeSyncCell<T>]>` drop normally. Because `UnsafeSyncCell<T>` has a `Drop` impl that runs `assume_init_drop` on its inner `MaybeUninit<T>`, the source-side `T` values are dropped at the end of `new`, while bitwise duplicates remain inside the mmap region. The ring-buffer destructor then runs `UnsafeSyncCell::drop` a second time on every cell — a deterministic double-free of every heap-owning element. Reachable from 100% safe Rust.
+
+## Trigger
+
+```rust
+let v: Vec<Vec<u32>> = (0..1024).map(|i| vec![i, i+1, i+2]).collect();
+let rb: mutringbuf::SharedVmemRB<Vec<u32>> = mutringbuf::SharedVmemRB::from(v);
+drop(rb);
+// glibc: free(): double free detected in tcache 2 -> abort
+```
+
+## Fix
+
+`mutringbuf` is no longer maintained. The author renamed the crate to [`oneringbuf`](https://crates.io/crates/oneringbuf) and shipped the fix as `oneringbuf 0.7.1` (upstream PR [skilvingr/rust-oneringbuf#3](https://github.com/skilvingr/rust-oneringbuf/pull/3)). All `mutringbuf` versions have been yanked from crates.io. Users should migrate to `oneringbuf >= 0.7.1`.
+
+See the parallel advisory for the `oneringbuf` crate for the full technical write-up of the bug.

--- a/crates/oneringbuf/RUSTSEC-0000-0000.md
+++ b/crates/oneringbuf/RUSTSEC-0000-0000.md
@@ -1,0 +1,45 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "oneringbuf"
+date = "2026-05-14"
+categories = ["memory-corruption"]
+keywords = ["double-free", "use-after-free", "vmem", "drop"]
+informational = "unsound"
+
+[versions]
+patched = []
+unaffected = []
+
+[affected]
+functions = { "oneringbuf::VmemStorage::new" = ["*"] }
+```
+
+# Double-free in `vmem` storage reachable from safe Rust
+
+When the `vmem` feature is enabled, `VmemStorage<T>::new(Box<[UnsafeSyncCell<T>]>)` (and every public constructor that funnels through it — `ConcurrentHeapRB::default(cap)`, `ConcurrentHeapRB::from(Vec<T>)`, `From<Box<[T]>>`, etc.) bit-copies the input buffer into a freshly `mmap`'d region with `ptr::copy_nonoverlapping`, then lets the source `Box<[UnsafeSyncCell<T>]>` drop normally.
+
+Because `UnsafeSyncCell<T>` has a `Drop` impl that runs `assume_init_drop` on its inner `MaybeUninit<T>`, the source-side `T` values are dropped at the end of `new`, while bitwise duplicates (carrying the same heap pointers for `String`, `Box`, `Vec`, `Arc`, …) remain inside the mmap region. When the ring buffer is later destructed, the destructor's `drop_in_place` over the slice runs `UnsafeSyncCell::drop` a second time on every cell — a deterministic double-free of every heap-owning element. Reachable from 100% safe Rust.
+
+## Trigger
+
+```rust
+let v: Vec<Vec<u32>> = (0..1024).map(|i| vec![i, i+1, i+2]).collect();
+let rb: oneringbuf::SharedVmemRB<Vec<u32>> = oneringbuf::SharedVmemRB::from(v);
+drop(rb);
+// glibc: free(): double free detected in tcache 2 -> abort
+// ASan: AddressSanitizer: attempting double-free
+```
+
+Any `T` with a non-trivial `Drop` reproduces deterministically.
+
+## Affected paths
+
+- `src/ring_buffer/wrappers/unsafe_sync_cell.rs:10-16` — `Drop for UnsafeSyncCell<T>` invokes `assume_init_drop`.
+- `src/ring_buffer/storage/heap/mod.rs:43-52` — `vmem`-branch `new` calls `vmem_helper::new(&value)` and lets `value` drop at function return.
+- `src/ring_buffer/storage/heap/vmem_helper.rs:62-126` — `ptr::copy_nonoverlapping` produces bitwise duplicates.
+- `src/ring_buffer/storage/heap/mod.rs:20-41` — `Drop for HeapStorage<T>` calls `drop_in_place` over the slice before `munmap`.
+
+## Notes
+
+The archived predecessor `mutringbuf` (https://github.com/Skilvingr/rust-mutringbuf, archived 2025-11-20) carries the same bug across all `vmem`-enabled releases up to `1.0.0`. A separate (or merged) advisory should name `mutringbuf` in parallel.

--- a/crates/oneringbuf/RUSTSEC-0000-0000.md
+++ b/crates/oneringbuf/RUSTSEC-0000-0000.md
@@ -34,17 +34,6 @@ drop(rb);
 
 Any `T` with a non-trivial `Drop` reproduces deterministically.
 
-## Affected paths
-
-- `src/ring_buffer/wrappers/unsafe_sync_cell.rs:10-16` — `Drop for UnsafeSyncCell<T>` invokes `assume_init_drop`.
-- `src/ring_buffer/storage/heap/mod.rs:43-52` — `vmem`-branch `new` calls `vmem_helper::new(&value)` and lets `value` drop at function return.
-- `src/ring_buffer/storage/heap/vmem_helper.rs:62-126` — `ptr::copy_nonoverlapping` produces bitwise duplicates.
-- `src/ring_buffer/storage/heap/mod.rs:20-41` — `Drop for HeapStorage<T>` calls `drop_in_place` over the slice before `munmap`.
-
 ## Fix
 
 Fixed in `0.7.1` via upstream PR [skilvingr/rust-oneringbuf#3](https://github.com/skilvingr/rust-oneringbuf/pull/3), which deallocates the source `Box<[UnsafeSyncCell<T>]>` without running per-element `Drop` after the bytes have been copied into the mmap region. Vulnerable versions (`< 0.7.1`) have been yanked from crates.io.
-
-## Related: `mutringbuf` (predecessor crate)
-
-The archived predecessor [`mutringbuf`](https://github.com/Skilvingr/rust-mutringbuf) (archived 2025-11-20) carries the same bug across all `vmem`-enabled releases up to `1.0.0`. All versions have been yanked from crates.io. See the parallel advisory for the `mutringbuf` crate.

--- a/crates/oneringbuf/RUSTSEC-0000-0000.md
+++ b/crates/oneringbuf/RUSTSEC-0000-0000.md
@@ -6,13 +6,14 @@ date = "2026-05-14"
 categories = ["memory-corruption"]
 keywords = ["double-free", "use-after-free", "vmem", "drop"]
 informational = "unsound"
+references = ["https://github.com/skilvingr/rust-oneringbuf/pull/3"]
 
 [versions]
-patched = []
+patched = [">= 0.7.1"]
 unaffected = []
 
 [affected]
-functions = { "oneringbuf::VmemStorage::new" = ["*"] }
+functions = { "oneringbuf::VmemStorage::new" = ["< 0.7.1"] }
 ```
 
 # Double-free in `vmem` storage reachable from safe Rust
@@ -40,6 +41,10 @@ Any `T` with a non-trivial `Drop` reproduces deterministically.
 - `src/ring_buffer/storage/heap/vmem_helper.rs:62-126` — `ptr::copy_nonoverlapping` produces bitwise duplicates.
 - `src/ring_buffer/storage/heap/mod.rs:20-41` — `Drop for HeapStorage<T>` calls `drop_in_place` over the slice before `munmap`.
 
-## Notes
+## Fix
 
-The archived predecessor `mutringbuf` (https://github.com/Skilvingr/rust-mutringbuf, archived 2025-11-20) carries the same bug across all `vmem`-enabled releases up to `1.0.0`. A separate (or merged) advisory should name `mutringbuf` in parallel.
+Fixed in `0.7.1` via upstream PR [skilvingr/rust-oneringbuf#3](https://github.com/skilvingr/rust-oneringbuf/pull/3), which deallocates the source `Box<[UnsafeSyncCell<T>]>` without running per-element `Drop` after the bytes have been copied into the mmap region. Vulnerable versions (`< 0.7.1`) have been yanked from crates.io.
+
+## Related: `mutringbuf` (predecessor crate)
+
+The archived predecessor [`mutringbuf`](https://github.com/Skilvingr/rust-mutringbuf) (archived 2025-11-20) carries the same bug across all `vmem`-enabled releases up to `1.0.0`. All versions have been yanked from crates.io. See the parallel advisory for the `mutringbuf` crate.


### PR DESCRIPTION
Resubmission of the oneringbuf half of #2882, split per @djc's review and trimmed to be in line with the typical advisory-db body length.

`vmem`-feature double-free reachable from safe Rust via `VmemStorage::new` (and every `From<_>` / `default(cap)` constructor that funnels through it). The source `Box<[UnsafeSyncCell<T>]>` drops at the end of `new`, and the destructor's `drop_in_place` later runs `UnsafeSyncCell::drop` a second time over the mmap'd bit-copy — deterministic double-free of every heap-owning `T`.

The companion `unbounded-spsc` advisory is filed separately as a sibling PR.

Closes prior #2882 (superseded by this + the unbounded-spsc PR).
