### PR TITLE
Add advisory for git2: Remote::list() with an empty list triggers UB

### DIFF
--- a/crates/git2/RUSTSEC-0000-0000.md
+++ b/crates/git2/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git2"
+date = "2026-05-12"
+url = "https://github.com/rust-lang/git2-rs/pull/1250"
+informational = "unsound"
+keywords = ["git2"]
+
+[versions]
+patched = ["> 0.20.4"]
+```
+
+# Potential undefined behavior when calling Remote::list()
+
+When calling `Remote::list()` for a remote of a git repository, when that remote does not advertise any references, git2 passes a null pointer to the unsafe function `slice::from_raw_parts()`. Based on the safety section documentation of function, data must be non-null even for slices of length zero. Thus, the use of a null pointer leads to undefined behavior.

--- a/crates/git2/RUSTSEC-0000-0000.md
+++ b/crates/git2/RUSTSEC-0000-0000.md
@@ -8,7 +8,7 @@ informational = "unsound"
 keywords = ["git2"]
 
 [versions]
-patched = ["> 0.20.4"]
+patched = [">= 0.21.0"]
 ```
 
 # Potential undefined behavior when calling Remote::list()


### PR DESCRIPTION
## Affected crate(s)

- git2

## Links to upstream issue(s) or PR(s)

<!-- In principle, we do not publish advisories for issues that have
     not been reported upstream. -->

rust-lang/git2-rs#1217, rust-lang/git2-rs#1250

## Severity

<!-- Briefly describe the risk and potential effect of the vulnerability.
     For example: allows remote denial-of-service via stack exhaustion,
     or: use-after-free that can lead to arbitrary code execution. -->

Low? Potential UB from misuse of an unsafe function

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [ ] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate
