### PR TITLE
Add advisory for git2: buffer-created BlameHunk leads to null pointers

### DIFF
--- a/crates/git2/RUSTSEC-0000-0000.md
+++ b/crates/git2/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git2"
+date = "2026-05-13"
+url = "https://github.com/rust-lang/git2-rs/pull/1254"
+informational = "unsound"
+keywords = ["git2"]
+
+[versions]
+patched = ["> 0.20.4"]
+```
+
+# Potential undefined behavior with Signature from a buffer-created BlameHunk
+
+When a `Blame` is created via `Blame::blame_buffer()`, and a `BlameHunk` is retrieved, the pointers to the original author, original committer, final author, and final committer may be null if unavailable. The corresponding `BlameHunk` methods then create `Signature`s based on null pointers; attempting to access the data of the `Signature`s leads to dereferencing null pointers.

--- a/crates/git2/RUSTSEC-0000-0000.md
+++ b/crates/git2/RUSTSEC-0000-0000.md
@@ -8,7 +8,7 @@ informational = "unsound"
 keywords = ["git2"]
 
 [versions]
-patched = ["> 0.20.4"]
+patched = [">= 0.21.0"]
 ```
 
 # Potential undefined behavior with Signature from a buffer-created BlameHunk


### PR DESCRIPTION
## Affected crate(s)

- git2

## Links to upstream issue(s) or PR(s)

rust-lang/git2-rs#1253, rust-lang/git2-rs#1254

## Severity

<!-- Briefly describe the risk and potential effect of the vulnerability.
     For example: allows remote denial-of-service via stack exhaustion,
     or: use-after-free that can lead to arbitrary code execution. -->

Low? Null pointer derefs

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [ ] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate
