### PR TITLE
Add an astral-tokio-tar advisory

### DIFF
--- a/crates/astral-tokio-tar/RUSTSEC-0000-0000.md
+++ b/crates/astral-tokio-tar/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "astral-tokio-tar"
+date = "2026-05-18"
+url = "https://github.com/astral-sh/tokio-tar/security/advisories/GHSA-3cv2-h65g-fgmm"
+categories = ["file-disclosure"]
+keywords = ["tar", "chmod"]
+aliases = ["GHSA-3cv2-h65g-fgmm"]
+
+
+[versions]
+patched = [">= 0.6.2"]
+```
+
+# PAX Header Desynchronization in astral-tokio-tar
+
+Versions of astral-tokio-tar prior to 0.6.2 contain a PAX header interpretation bug that allows manipulated entries to be made selectively visible or invisible during extraction with astral-tokio-tar versus other tar implementations. An attacker could use this differential to smuggle unexpected files onto a victim's filesystem.


### PR DESCRIPTION
## Affected crate(s)

- astral-tokio-tar (6,507,527 recent downloads)

## Links to upstream issue(s) or PR(s)

https://github.com/astral-sh/tokio-tar/security/advisories/GHSA-3cv2-h65g-fgmm

## Severity

We've classified this as a "medium" severity via GHSA.

(Note: this is similar in impact to other desync vulns in tar and astral-tokio-tar, but has a different root cause.)

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
