### PR TITLE
Add advisory for anchor-lang `Program<System>` validation

### DIFF
--- a/crates/anchor-lang/RUSTSEC-0000-0000.md
+++ b/crates/anchor-lang/RUSTSEC-0000-0000.md
@@ -1,0 +1,36 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "anchor-lang"
+date = "2026-05-07"
+url = "https://github.com/otter-sec/anchor/security/advisories/GHSA-c6rc-8jpp-2fgc"
+references = ["https://github.com/solana-foundation/anchor/releases/tag/v1.0.2"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:N"
+keywords = ["solana", "anchor", "account-validation", "system-program"]
+aliases = ["CVE-2026-45137", "GHSA-c6rc-8jpp-2fgc"]
+license = "CC-BY-4.0"
+
+[versions]
+patched = [">= 1.0.2"]
+unaffected = ["< 1.0.0"]
+```
+
+# `Program<System>` accepts arbitrary executable programs
+
+Affected versions of `anchor-lang` did not properly validate accounts declared
+as `Program<'info, System>`. The generic `Program<T>` validation path used
+`Pubkey::default()` as a sentinel to decide whether any executable program
+should be accepted. Since the system program id is also the default pubkey,
+`Program<'info, System>` was treated like the untyped `Program<'info>` case and
+accepted any executable program account.
+
+Programs commonly rely on `Program<'info, System>` to ensure that CPI calls and
+instruction builders target the real Solana system program. With the faulty
+validation, an attacker could supply another executable program where the system
+program was expected, causing downstream logic to make false assumptions about
+payments, account creation, or other system-program CPIs.
+
+The issue was fixed in `anchor-lang` 1.0.2 by separating the typed
+`Program<T>` validation path from the untyped `Program<()>` path, so
+`Program<'info, System>` now checks the provided account key against the system
+program id. Users should upgrade to `anchor-lang` 1.0.2 or later.


### PR DESCRIPTION
## Affected crate(s)

- `anchor-lang` (895235 recent downloads)

## Links to upstream issue(s) or PR(s)

https://github.com/otter-sec/anchor/security/advisories/GHSA-c6rc-8jpp-2fgc

## Severity

The `Program<System>` account type had broken validation, and would accept any account without checking the address. This violates a core guarantee of Anchor.

## Checklist

- [X] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [X] `date` field is set to the public disclosure date
- [X] Contains a concise and descriptive title after advisory metadata
- [X] Asked maintainer(s) if publishing an advisory is appropriate
