### PR TITLE
Add advisory for anchor-lang `InterfaceAccount` validation

### DIFF
--- a/crates/anchor-lang/RUSTSEC-0000-0000.md
+++ b/crates/anchor-lang/RUSTSEC-0000-0000.md
@@ -1,0 +1,36 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "anchor-lang"
+date = "2026-05-08"
+url = "https://github.com/otter-sec/anchor/security/advisories/GHSA-429q-fhh4-r6hj"
+references = ["https://github.com/otter-sec/anchor/pull/3837", "https://github.com/otter-sec/anchor/pull/4139", "https://github.com/otter-sec/anchor/commit/26ef36968a62e28a1f028e7adae4806af30c747d"]
+cvss = "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:H/VA:N/SC:N/SI:N/SA:N"
+keywords = ["solana", "anchor", "account-validation", "interface-account"]
+aliases = ["GHSA-429q-fhh4-r6hj"]
+license = "CC-BY-4.0"
+
+[versions]
+patched = [">= 1.0.0-rc.2"]
+unaffected = ["< 1.0.0-rc.1"]
+```
+
+# `InterfaceAccount` allows account substitution between unexpected types
+
+Affected versions of `anchor-lang` allowed `InterfaceAccount` to accept accounts
+with an unexpected Anchor discriminator. A change to `InterfaceAccount` caused
+checked deserialization to be bypassed for this account wrapper, so validation
+proved only that the account owner matched one of the accepted interface owners.
+It did not prove that the account data belonged to the expected account type.
+
+Programs using `InterfaceAccount` rely on Anchor to enforce both owner and
+account-type validation before the handler runs. With discriminator checking
+disabled, an attacker could pass another account type owned by an accepted
+program and have it deserialized through the expected interface wrapper. This
+could bypass account-type assumptions made by the program and lead to incorrect
+authorization or state handling.
+
+The issue was fixed in `anchor-lang` 1.0.0-rc.2 by restoring checked
+deserialization for `InterfaceAccount::try_from`, while keeping explicitly
+unchecked behavior available only through the unchecked API. Users should
+upgrade to `anchor-lang` 1.0.0-rc.2 or later.


### PR DESCRIPTION
## Affected crate(s)

- anchor-lang (895235 recent downloads)

## Links to upstream issue(s) or PR(s)

https://github.com/otter-sec/anchor/security/advisories/GHSA-429q-fhh4-r6hj

## Severity

`InterfaceAccount` had discriminator checks disabled. This bypasses a core Anchor guarantee, and allowed type confusion by passing a different account than expected.

## Checklist

- [X] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [X] `date` field is set to the public disclosure date
- [X] Contains a concise and descriptive title after advisory metadata
- [X] Asked maintainer(s) if publishing an advisory is appropriate
