### PR TITLE
Add advisory for boxlite (GHSA-g6ww-w5j2-r7x3 / CVE-2026-46695)

### DIFF
--- a/crates/boxlite/RUSTSEC-0000-0000.md
+++ b/crates/boxlite/RUSTSEC-0000-0000.md
@@ -1,0 +1,36 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "boxlite"
+date = "2026-05-16"
+url = "https://github.com/boxlite-ai/boxlite/security/advisories/GHSA-g6ww-w5j2-r7x3"
+references = [
+    "https://github.com/boxlite-ai/boxlite/pull/454",
+]
+categories = ["privilege-escalation"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+keywords = ["sandbox", "container", "vm", "virtiofs", "mount"]
+aliases = ["CVE-2026-46695", "GHSA-g6ww-w5j2-r7x3"]
+
+[versions]
+patched = [">= 0.9.0"]
+```
+
+# Read-only volume remount bypass via guest CAP_SYS_ADMIN
+
+Affected versions of `boxlite` mount host directories shared via virtiofs
+as guest-side read-only by setting `MS_RDONLY` from the guest. Because the
+default guest capability set included `CAP_SYS_ADMIN`, untrusted code
+running inside a sandbox could execute `mount -o remount,rw <path>` to
+re-flag the share as read-write and then write through to the host
+filesystem — fully escaping the read-only contract `boxlite` advertised
+to callers.
+
+The fix in v0.9.0 enforces read-only at the hypervisor level via
+`krun_add_virtiofs3` (so the guest's `MS_RDONLY` is no longer the
+authoritative gate) and drops `CAP_SYS_ADMIN` from the default guest
+capability set (matching Docker's defaults).
+
+This is a sandbox-escape bug: `boxlite` is a sandboxing runtime, so the
+read-only invariant is part of its security contract. CVSS rated 10.0 by
+the upstream advisory.


### PR DESCRIPTION
Adds RustSec entries for two **Critical** sandbox-escape vulnerabilities in
the [`boxlite`](https://crates.io/crates/boxlite) sandboxing runtime and
its CLI front-end [`boxlite-cli`](https://crates.io/crates/boxlite-cli),
fixed in 0.9.0 (2026-05-03), publicly disclosed 2026-05-16.

| Advisory | CVE | Crate(s) | Affected | Patched |
|---|---|---|---|---|
| [GHSA-g6ww-w5j2-r7x3](https://github.com/boxlite-ai/boxlite/security/advisories/GHSA-g6ww-w5j2-r7x3) | CVE-2026-46695 | `boxlite`, `boxlite-cli` | `< 0.9.0` | 0.9.0 |
| [GHSA-f396-4rp4-7v2j](https://github.com/boxlite-ai/boxlite/security/advisories/GHSA-f396-4rp4-7v2j) | CVE-2026-46703 | `boxlite`, `boxlite-cli` | `< 0.9.0` | 0.9.0 |

The vulnerable code lives in the `boxlite` core crate; `boxlite-cli`
depends on it, so both are affected by both advisories. The upstream
advisories on GitHub include structured ecosystem rows for
pip / npm / go / rust (`boxlite` and `boxlite-cli`); this PR mirrors
that into the RustSec database so `cargo audit` users get the alert.

Filed by the boxlite maintainers post-disclosure per CONTRIBUTING.md
("The above steps can be skipped for advisories filed by crate
authors"). Happy to split into per-crate or per-advisory PRs if
reviewers prefer.