### PR TITLE
Add advisory for boxlite (GHSA-f396-4rp4-7v2j / CVE-2026-46703)

### DIFF
--- a/crates/boxlite/RUSTSEC-0000-0000.md
+++ b/crates/boxlite/RUSTSEC-0000-0000.md
@@ -1,0 +1,38 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "boxlite"
+date = "2026-05-16"
+url = "https://github.com/boxlite-ai/boxlite/security/advisories/GHSA-f396-4rp4-7v2j"
+references = [
+    "https://github.com/boxlite-ai/boxlite/pull/429",
+    "https://github.com/boxlite-ai/boxlite/pull/446",
+    "https://github.com/boxlite-ai/boxlite/pull/461",
+]
+categories = ["privilege-escalation", "file-disclosure"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+keywords = ["sandbox", "container", "oci", "tar", "symlink", "path-traversal"]
+aliases = ["CVE-2026-46703", "GHSA-f396-4rp4-7v2j"]
+
+[versions]
+patched = [">= 0.9.0"]
+```
+
+# OCI layer symlink escape → arbitrary host write
+
+Affected versions of `boxlite` extract OCI image layer tarballs without
+fully containing path resolution to the extraction root. A crafted layer
+containing a symlink whose target is an absolute on-host path (e.g.
+`escape -> /tmp`) followed by a file entry that resolves through that
+symlink (e.g. `escape/<path>/pwned.txt`) caused the extractor to write
+the payload to the host filesystem outside the intended rootfs directory.
+
+The fix in v0.9.0 routes every destructive filesystem operation through a
+`SafeRoot` handle (`openat2(RESOLVE_IN_ROOT)` on Linux, lexical fallback
+elsewhere) so that no tar entry can resolve outside the extraction root,
+even with adversarial symlinks placed by earlier entries in the same
+layer.
+
+This is a container-escape during image extraction, exploitable by any
+user who pulls or loads a malicious OCI image — including via
+`SimpleBox(rootfs_path=...)` from an untrusted local layout.


### PR DESCRIPTION
OCI layer symlink escape → arbitrary host write in [`boxlite`](https://crates.io/crates/boxlite) and its CLI front-end [`boxlite-cli`](https://crates.io/crates/boxlite-cli). Fixed in **0.9.0** (2026-05-03), published 2026-05-16.

| Advisory | CVE | Crate(s) | Affected | Patched |
|---|---|---|---|---|
| [GHSA-f396-4rp4-7v2j](https://github.com/boxlite-ai/boxlite/security/advisories/GHSA-f396-4rp4-7v2j) | CVE-2026-46703 | `boxlite`, `boxlite-cli` | `< 0.9.0` | 0.9.0 |

The vulnerable extractor lives in the `boxlite` core crate; `boxlite-cli` depends on it, so both are affected. The GitHub advisory has structured rows for pip / npm / go / rust (both crates); this PR mirrors that into RustSec for `cargo audit`.

Companion to #2899 (GHSA-g6ww-w5j2-r7x3). Filed under the post-disclosure crate-author path per CONTRIBUTING. Split from the original PR per @djc's feedback.