### PR TITLE
Add advisory for audiopus_sys

### DIFF
--- a/crates/audiopus_sys/RUSTSEC-0000-0000.md
+++ b/crates/audiopus_sys/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "audiopus_sys"
+date = "2026-05-21"
+url = "https://github.com/Lakelezz/audiopus_sys/issues/22"
+references = ["https://github.com/rustsec/advisory-db/issues/2704", "https://github.com.Lakelezz/audiopus_sys/pull/23"]
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+# audiopus_sys is unmaintained
+
+audiopus_sys is implicitly unmaintained and holds a reference to CMake versions with which CMake 4.0 is not backwards compatible, causing cargo builds to error. An effort to contact the maintainer was made on June 10th, 2025 with no reply. A separate 2025 PR was made (from a different user) addressing the CMake 4.0 issue with no reply. The last commit to audiopus_sys is dated 5 years ago. 
+


### PR DESCRIPTION
Closes #2704

## Affected crate(s)

- audiopus_sys

## Links to upstream issue(s) or PR(s)

https://github.com/Lakelezz/audiopus_sys/issues/22

https://github.com/Lakelezz/audiopus_sys/pull/23

## Severity

Implicitly unmaintained. Holds references to `make` that lack backwards compatibility with CMake 4.0 and causes cargo builds downstream to error.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
