### PR TITLE
create rustsec advisory wasmtime-wasi crate: wasmtime project's GHSA-2r75-cxrj-cmph

### DIFF
--- a/crates/wasmtime-wasi/RUSTSEC-0000-0000.md
+++ b/crates/wasmtime-wasi/RUSTSEC-0000-0000.md
@@ -1,0 +1,27 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime-wasi"
+date = "2026-05-21"
+url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-2r75-cxrj-cmph"
+categories = []
+keywords = []
+aliases = ["CVE-2026-47261", "GHSA-2r75-cxrj-cmph"]
+license = "CC0-1.0"
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+
+[versions]
+patched = [
+    ">= 24.0.9, < 25.0.0",
+    ">= 36.0.10, < 37.0.0",
+    ">= 44.0.2, < 45.0.0",
+    ">= 45.0.0",
+]
+```
+
+# WASI path_open(TRUNCATE) bypasses `FilePerms::WRITE` host restriction
+
+This is an entry in the RustSec database for the Wasmtime security advisory
+located at
+https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-2r75-cxrj-cmph
+For more information see the GitHub-hosted security advisory.


### PR DESCRIPTION

## Affected crate(s)

- wasmtime-wasi (6,589,947)

## Links to upstream issue(s) or PR(s)

Fix in main: https://github.com/bytecodealliance/wasmtime/pull/13429

which contains links to all of the backports to release branch PRs

Security advisory: https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-2r75-cxrj-cmph

## Severity

Filesystem access control: bug permits truncation and writing to existing files in the filesystem where wasmtime-wasi was configured to provide read-only access.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate