### PR TITLE
Add advisory for cgmath: `Matrix::swap_columns` can trigger UB with identical indices

### DIFF
--- a/crates/cgmath/RUSTSEC-0000-0000.md
+++ b/crates/cgmath/RUSTSEC-0000-0000.md
@@ -1,0 +1,31 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "cgmath"
+date = "2026-03-11"
+url = "https://github.com/rustgd/cgmath/issues/565"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["soundness", "undefined-behavior", "aliasing", "stacked-borrows"]
+
+[affected.functions]
+"cgmath::Matrix2::swap_columns" = ["= 0.18.0"]
+"cgmath::Matrix3::swap_columns" = ["= 0.18.0"]
+"cgmath::Matrix4::swap_columns" = ["= 0.18.0"]
+
+[versions]
+patched = []
+```
+
+# `Matrix{2,3,4}::swap_columns` can trigger undefined behavior for identical indices
+
+The `Matrix2::swap_columns`, `Matrix3::swap_columns`, and `Matrix4::swap_columns`
+implementations call `ptr::swap(&mut self[a], &mut self[b])`.
+
+When `a == b`, these safe APIs create two mutable references to the same matrix
+column and pass them to `ptr::swap`. This violates Rust's aliasing rules and can
+trigger undefined behavior. The issue can be reproduced from safe Rust by calling
+`swap_columns` with identical column indices, for example `m.swap_columns(0, 0)`.
+
+A minimal fix is to return early when the two column indices are equal before
+calling `ptr::swap`.

--- a/crates/cgmath/RUSTSEC-0000-0000.unmaintained.md
+++ b/crates/cgmath/RUSTSEC-0000-0000.unmaintained.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "cgmath"
+date = "2026-07-01"
+url = "https://github.com/rustsec/advisory-db/pull/2910#pullrequestreview-4611570365"
+references = ["https://github.com/rustgd/cgmath/issues/565"]
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `cgmath` is unmaintained
+
+The `cgmath` crate is no longer maintained.
+
+Users should consider switching to a maintained alternative.


### PR DESCRIPTION
## Affected crate(s)

- `cgmath` (1,618,302 recent downloads per crates.io; 10,211,015 total downloads)

## Links to upstream issue(s) or PR(s)

- https://github.com/rustgd/cgmath/issues/565

The issue was publicly reported upstream on 2026-03-11 and remains open with no maintainer response as of 2026-05-27.

## Severity

Informational soundness issue. Safe Rust code can trigger undefined behavior by calling `Matrix2::swap_columns`, `Matrix3::swap_columns`, or `Matrix4::swap_columns` with identical column indices.

The affected implementations call `ptr::swap(&mut self[a], &mut self[b])`; when `a == b`, this creates overlapping mutable references to the same matrix column and violates Rust aliasing rules. Miri reports a Stacked Borrows violation. No `unsafe` code is required from the caller.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate

The issue was publicly reported upstream on 2026-03-11 and remains open with no maintainer response as of 2026-05-27. The repository also appears inactive. I am filing this advisory under RustSec's documented allowance for advisories after public disclosure with no upstream response.