### PR TITLE
Add advisory for bitvec-nom2: `BSlice::offset` can trigger UB via unsound offset

### DIFF
--- a/crates/bitvec-nom2/RUSTSEC-0000-0000.md
+++ b/crates/bitvec-nom2/RUSTSEC-0000-0000.md
@@ -1,0 +1,70 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "bitvec-nom2"
+date = "2026-03-09"
+url = "https://github.com/rust-bakery/nom-bitvec/issues/5"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["soundness", "undefined-behavior", "pointer-arithmetic", "offset-from"]
+
+[affected.functions]
+"bitvec_nom2::BSlice::offset" = [">= 0.2.0, <= 0.2.1"]
+
+[versions]
+patched = []
+```
+
+# `BSlice::offset` can trigger undefined behavior with slices from different allocations
+
+The `Offset` implementation for `BSlice` calls
+`second.0.as_bitptr().offset_from(self.0.as_bitptr())`.
+
+This is only valid when both pointers are derived from the same allocation. Safe
+Rust code can construct two `BSlice` values from independent backing arrays and
+then call `offset` on them, causing cross-allocation pointer arithmetic and
+undefined behavior.
+
+## Example
+
+The issue can be triggered without unsafe code in the caller:
+
+```rust
+use bitvec::prelude::*;
+use bitvec_nom2::BSlice;
+use nom::Offset;
+
+fn main() {
+    let array_a = [0u8; 4];
+    let array_b = [0u8; 4];
+
+    let slice_a = array_a.view_bits::<Lsb0>();
+    let slice_b = array_b.view_bits::<Lsb0>();
+
+    let bslice_a = BSlice(slice_a);
+    let bslice_b = BSlice(slice_b);
+
+    let diff = bslice_a.offset(&bslice_b);
+    println!("Computed offset: {}", diff);
+}
+```
+
+## Miri output
+
+The issue was validated with Miri on `bitvec-nom2` 0.2.1. Miri reports:
+
+```text
+error: Undefined Behavior: `ptr_offset_from` called on two different pointers
+that are not both derived from the same allocation
+   --> wyz-0.5.1/src/comu.rs:305:2
+    = note: inside `wyz::comu::Address::<bitvec::ptr::Const, u8>::offset_from`
+    = note: inside `bitvec::ptr::BitPtr::<bitvec::ptr::Const, u8>::offset_from::<u8>`
+    = note: inside `bitvec_nom2::input::<impl nom::Offset for bitvec_nom2::BSlice<'_, u8, bitvec::order::Lsb0>>::offset`
+note: inside `main`
+   --> src/main.rs:1570:16
+    |
+1570 |     let diff = bslice_a.offset(&bslice_b);
+     |                ^^^^^^^^^^^^^^^^^^^^^^^^^^
+```
+
+No patched version is currently available.


### PR DESCRIPTION
## Affected crate(s)

- `bitvec-nom2` (1,011,172 recent downloads per crates.io; 10,569,329 total downloads)

## Links to upstream issue(s) or PR(s)

- https://github.com/rust-bakery/nom-bitvec/issues/5

The issue was publicly reported upstream on 2026-03-09 and remains open with no maintainer response as of 2026-05-27.

## Severity

Informational soundness issue. Safe Rust code can trigger undefined behavior by calling `BSlice::offset` on two `BSlice` values backed by different allocations.

The affected implementation calls `offset_from` on the two underlying bit pointers. This is only valid when both pointers are derived from the same allocation. Miri reports `ptr_offset_from` being called on pointers from different allocations. No `unsafe` code is required from the caller.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate

The issue has been public for more than two months without upstream response. I am filing this advisory under RustSec's documented allowance for advisories after public disclosure with no upstream response.