### PR TITLE
Add advisory for inplace-vec-builder: `InPlaceVecBuilder` can corrupt the backing `Vec`

### DIFF
--- a/crates/inplace-vec-builder/RUSTSEC-0000-0000.md
+++ b/crates/inplace-vec-builder/RUSTSEC-0000-0000.md
@@ -1,0 +1,75 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "inplace-vec-builder"
+date = "2026-03-09"
+url = "https://github.com/rklaehn/inplace-vec-builder/issues/1"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["soundness", "double-free", "mem-forget", "set-len"]
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# `InPlaceVecBuilder` can be leaked to corrupt the backing `Vec`
+
+`InPlaceVecBuilder` temporarily moves elements inside the backing `Vec` and
+sets the vector length to its capacity while building the target region. Its
+safety relies on the builder's `Drop` implementation restoring the correct
+length and cleaning up the intermediate state.
+
+Because `std::mem::forget` is safe, callers can leak the builder after a method
+such as `push` has entered this intermediate state. This bypasses the `Drop`
+cleanup and exposes the backing `Vec` with an invalid length and duplicated or
+otherwise invalid elements. Subsequent safe use or drop of the `Vec` can trigger
+undefined behavior, including double free and use-after-free.
+
+No patched version is currently available. The issue affects the published
+versions `0.1.0` and `0.1.1`.
+
+## Example
+
+```rust
+use inplace_vec_builder::InPlaceVecBuilder;
+
+fn main() {
+    let mut vec = vec![String::from("A"), String::from("B")];
+
+    {
+        let mut builder = InPlaceVecBuilder::from(&mut vec);
+        builder.push(String::from("X"));
+        std::mem::forget(builder);
+    }
+
+    println!("Corrupted Vec length is now: {}", vec.len());
+}
+```
+
+## Miri output
+
+Miri reports undefined behavior when the corrupted vector is later dropped:
+
+```text
+Corrupted Vec length is now: 4
+error: Undefined Behavior: pointer not dereferenceable: alloc396 has been freed, so this pointer is dangling
+   --> library/core/src/ptr/mod.rs:805:1
+    |
+805 | pub const unsafe fn drop_in_place<T: PointeeSized>(to_drop: *mut T)
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Undefined Behavior occurred here
+    |
+    = help: this indicates a bug in the program: it performed an invalid operation, and caused Undefined Behavior
+
+help: alloc396 was allocated here:
+   --> src/main.rs:145:43
+    |
+145 |     let mut vec = vec![String::from("A"), String::from("B")];
+    |                                           ^^^^^^^^^^^^^^^^^
+
+help: alloc396 was deallocated here:
+   --> src/main.rs:161:1
+    |
+161 | }
+    | ^
+```


### PR DESCRIPTION
## Affected crate(s)

- `inplace-vec-builder` (1,222,237 recent downloads per crates.io; 5,820,504 total downloads)

## Links to upstream issue(s) or PR(s)

- https://github.com/rklaehn/inplace-vec-builder/issues/1

The issue was publicly reported upstream on 2026-03-09 and remains open with no maintainer response as of 2026-05-27.

## Severity

Informational soundness issue. Safe Rust code can leak `InPlaceVecBuilder` with `std::mem::forget` after it has entered an intermediate state, bypassing the `Drop` cleanup that restores the backing `Vec`.

This can expose the `Vec` with an invalid length and duplicated or otherwise invalid elements. Subsequent safe use or drop of the `Vec` can trigger undefined behavior, including double free and use-after-free. Miri reports a dangling pointer dereference during drop. No `unsafe` code is required from the caller.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate

The issue has been public for more than two months without upstream response. I am filing this advisory under RustSec's documented allowance for advisories after public disclosure with no upstream response.