### PR TITLE
Fix url

### DIFF
--- a/crates/audiopus_sys/RUSTSEC-2026-0150.md
+++ b/crates/audiopus_sys/RUSTSEC-2026-0150.md
@@ -4,7 +4,7 @@ id = "RUSTSEC-2026-0150"
 package = "audiopus_sys"
 date = "2026-05-21"
 url = "https://github.com/Lakelezz/audiopus_sys/issues/22"
-references = ["https://github.com/rustsec/advisory-db/issues/2704", "https://github.com.Lakelezz/audiopus_sys/pull/23"]
+references = ["https://github.com/rustsec/advisory-db/issues/2704", "https://github.com/Lakelezz/audiopus_sys/pull/23"]
 informational = "unmaintained"
 
 [versions]


### PR DESCRIPTION
The PR URL in RUSTSEC-2026-0150 used a . instead of / to separate the domain from the path.