### PR TITLE
Safe-code use-after-free via `IntoRef::into_ref`

### DIFF
--- a/crates/oneringbuf/RUSTSEC-0000-0000.md
+++ b/crates/oneringbuf/RUSTSEC-0000-0000.md
@@ -11,7 +11,7 @@ categories = ["memory-corruption"]
 keywords = ["use-after-free", "safe-code", "clone", "drop"]
 
 [versions]
-patched = [>= 0.8.0]
+patched = [">= 0.8.0"]
 unaffected = []
 ```
 

--- a/crates/oneringbuf/RUSTSEC-0000-0000.md
+++ b/crates/oneringbuf/RUSTSEC-0000-0000.md
@@ -1,0 +1,44 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "oneringbuf"
+date = "2026-05-27"
+url = "https://github.com/skilvingr/rust-oneringbuf/commit/643a24b30914068416dff9021a069c12c865a316"
+references = [
+    "https://github.com/skilvingr/rust-oneringbuf/commit/643a24b30914068416dff9021a069c12c865a316",
+]
+categories = ["memory-corruption"]
+keywords = ["use-after-free", "safe-code", "clone", "drop"]
+
+[versions]
+patched = [>= 0.8.0]
+unaffected = []
+```
+
+# Use-after-free
+
+Affected versions of `oneringbuf` exposed the obsolete `IntoRef::into_ref` method through the public `IntoRef` trait. For heap-backed ring buffers, this method returned a `DroppableRef` handle.
+
+`DroppableRef` stored an owning raw pointer created from `Box::into_raw`. Its `Clone` implementation copied this raw pointer without incrementing the internal `alive_iters` counter. Internally, this clone pattern appears to rely on a fixed number of handles being created to match the initial `alive_iters` value. However, exposing `DroppableRef` through the public `IntoRef::TargetRef` associated type allows safe external code to create additional clones beyond that fixed count, breaking the lifetime protocol. `Drop` later dereferenced the pointer and could free the backing allocation with `Box::from_raw`.
+
+Safe code could call `IntoRef::into_ref` to obtain a `DroppableRef` and then clone it. Each clone pointed to the same allocation, but the internal `alive_iters` counter was not increased. As a result, one clone could free the allocation while another clone still existed. Dropping the remaining clone then accessed freed memory, causing a heap-use-after-free.
+
+The issue was fixed in version 0.8.0 by removing the obsolete `into_ref` method.
+
+## Trigger
+
+```rust
+use oneringbuf::{IntoRef, LocalHeapRB};
+
+fn main() {
+    let rb = LocalHeapRB::<usize>::from(vec![1, 2, 3]);
+
+    let r = <LocalHeapRB<usize> as IntoRef>::into_ref(rb);
+    let r2 = r.clone();
+    let r3 = r.clone();
+
+    drop(r);
+    drop(r2);
+    drop(r3); // AddressSanitizer: heap-use-after-free
+}
+```


### PR DESCRIPTION
## Affected crate(s)

- `oneringbuf` — affected versions: `< 0.8.0`; patched in `0.8.0`

## Links to upstream issue(s) or PR(s)

<!-- In principle, we do not publish advisories for issues that have
     not been reported upstream. -->

- Fix commit: https://github.com/skilvingr/rust-oneringbuf/commit/643a24b30914068416dff9021a069c12c865a316

- Maintainer confirmed the issue privately and said opening a RustSec advisory is appropriate.

## Severity

<!-- Briefly describe the risk and potential effect of the vulnerability.
     For example: allows remote denial-of-service via stack exhaustion,
     or: use-after-free that can lead to arbitrary code execution. -->

Safe-code heap-use-after-free. Affected versions exposed the obsolete `IntoRef::into_ref` method through the public `IntoRef` trait. For heap-backed ring buffers, this allowed safe external code to obtain and clone a `DroppableRef` handle. Extra clones were not reflected in the internal `alive_iters` counter, so one clone could free the backing allocation while another clone still existed. Dropping the remaining clone then accessed freed memory.

AddressSanitizer confirms this as a heap-use-after-free. The issue was fixed in `0.8.0` by removing the obsolete `into_ref` method.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
