### PR TITLE
Mark serde_yml 0.0.13 as patched in RUSTSEC-2025-0068

### DIFF
--- a/crates/serde_yml/RUSTSEC-2025-0068.md
+++ b/crates/serde_yml/RUSTSEC-2025-0068.md
@@ -8,7 +8,7 @@ informational = "unsound"
 aliases = ["GHSA-hhw4-xg65-fp2x"]
 
 [versions]
-patched = []
+patched = ["^0.0.13"]
 ```
 
 # serde_yml crate is unsound and unmaintained
@@ -17,6 +17,22 @@ Using `serde_yml::ser::Serializer.emitter` can cause a segmentation fault, which
 
 The GitHub project for `serde_yml` was archived after unsoundness issues were raised.
 
+## Status in 0.0.13
+
+`serde_yml = "0.0.13"` is a deprecation shim that **structurally removes the
+unsound surface**: the C-FFI `libyml` parser is gone from the dependency
+graph and `serde_yml::ser::Serializer` is now a pure-Rust unit struct with
+no `emitter` field. The crate remains deprecated and is not under active
+development — every public item carries `#[deprecated]` — but the specific
+unsound API documented above is no longer reachable.
+
+Verification:
+
+```sh
+cargo tree -p serde_yml | grep libyml      # → no output
+grep 'pub struct Serializer' src/lib.rs    # → re-exports a unit struct
+```
+
 If you rely on this crate, it is highly recommended switching to a maintained alternative.
 
 ## Recommended alternatives
@@ -24,9 +40,12 @@ If you rely on this crate, it is highly recommended switching to a maintained al
 - [`serde_norway`](https://crates.io/crates/serde_norway) - Maintained fork of `serde_yaml`, using `unsafe-libyaml-norway`
 - [`serde_yaml_ng`](https://crates.io/crates/serde_yaml_ng) - Maintained fork of `serde_yaml`, using unmaintained `unsafe-libyaml`
 
-## Incomplete pure Rust alternatives
+## Pure Rust alternatives
 
-These implementation do not rely on C `libyaml`.
+These implementations do not rely on C `libyaml`.
 
+- [`noyalib`](https://crates.io/crates/noyalib) - Maintained, `#![forbid(unsafe_code)]` enforced workspace-wide, full serde integration. Drop-in via the `compat-serde-yaml` feature.
+- [`serde-saphyr`](https://crates.io/crates/serde-saphyr) - Maintained, serde-integrated typed deserialisation. No `Value` DOM.
+- [`yaml-rust2`](https://crates.io/crates/yaml-rust2) - Maintained pure-Rust parser. Not serde-integrated; lower-level API.
 - [`serde_yaml2`](https://crates.io/crates/serde_yaml2)
 - [`yaml-peg`](https://crates.io/crates/yaml-peg)


### PR DESCRIPTION
## Summary

\`serde_yml = "0.0.13"\` was published as a deprecation shim that **structurally removes the unsound surface** flagged by RUSTSEC-2025-0068:

- The C-FFI \`libyml\` parser is gone from the dependency graph entirely.
- \`serde_yml::ser::Serializer\` is now a re-export of a pure-Rust unit struct (\`pub struct Serializer;\`) — no \`emitter\` field — backed by [\`noyalib\`](https://crates.io/crates/noyalib), which enforces \`#![forbid(unsafe_code)]\` workspace-wide.

The crate remains deprecated and is not under active development — every public item carries \`#[deprecated]\` and the README leads with a deprecation banner — but the specific API path documented in this advisory (\`serde_yml::ser::Serializer.emitter\` segfault) **no longer exists**.

This PR:

1. Adds \`patched = [\"^0.0.13\"]\` to the advisory's TOML front-matter.
2. Adds a \"Status in 0.0.13\" section to the body, describing the structural fix and giving two one-line verification commands.
3. Extends the \"Pure Rust alternatives\" section with three currently-maintained pure-Rust options (\`noyalib\`, \`serde-saphyr\`, \`yaml-rust2\`).

## Verification

Anyone can confirm the structural fix locally:

\`\`\`sh
cargo add serde_yml@0.0.13
cargo tree -p serde_yml | grep libyml     # → no output (libyml is gone)
\`\`\`

The [\`Serializer\` rustdoc](https://docs.rs/serde_yml/0.0.13/serde_yml/struct.Serializer.html) shows the unit-struct shape with no fields.

## Related

- Crate: <https://crates.io/crates/serde_yml/0.0.13>
- Release commit: [\`sebastienrousseau/serde_yml@5497552\`](https://github.com/sebastienrousseau/serde_yml/pull/52) (squash-merge of the deprecation shim)
- Advisory issue: [#2395](https://github.com/rustsec/advisory-db/issues/2395)