### PR TITLE
CVE-2018-25025: update patched version

### DIFF
--- a/crates/actix-web/RUSTSEC-2018-0019.md
+++ b/crates/actix-web/RUSTSEC-2018-0019.md
@@ -8,7 +8,7 @@ url = "https://github.com/actix/actix-web/issues/289"
 aliases = ["CVE-2018-25024", "CVE-2018-25025", "CVE-2018-25026", "GHSA-7x36-h62w-vw65", "GHSA-9qj6-4rfq-vm84", "GHSA-fgfm-hqjw-3265", "GHSA-w65j-g6c7-g3m4"]
 
 [versions]
-patched = [">= 0.7.15"]
+patched = ["> 0.7.19"]
 ```
 
 # Multiple memory safety issues


### PR DESCRIPTION
After thoroughly inspecting the vulnerability, it is present until 0.7.19, inclusive and only patched in the first 1.0.0 version.

## Affected crate(s)

- actix-web