### PR TITLE
Add advisory for onig Region heap buffer overflow

### DIFF
--- a/crates/onig/RUSTSEC-0000-0000.md
+++ b/crates/onig/RUSTSEC-0000-0000.md
@@ -1,0 +1,37 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "onig"
+date = "2026-01-07"
+url = "https://github.com/rust-onig/rust-onig/issues/215"
+references = [
+    "https://github.com/rust-onig/rust-onig/pull/221",
+    "https://github.com/rust-onig/rust-onig/commit/fa76915bad1bf87c796b5a2d917b86fd5f23bf1c",
+]
+categories = ["memory-corruption", "memory-exposure"]
+keywords = ["integer-overflow", "heap-buffer-overflow", "out-of-bounds-read", "ffi"]
+
+[affected.functions]
+"onig::Region::reserve" = ["< 6.5.2"]
+"onig::Region::with_capacity" = ["< 6.5.2"]
+"onig::Region::pos" = ["< 6.5.2"]
+
+[versions]
+patched = [">= 6.5.2"]
+```
+
+# Heap buffer overflow in `Region`
+
+Affected versions of `onig` expose a memory-safety bug in the safe `Region` API.
+`Region::reserve()` and `Region::with_capacity()` accepted a `usize` capacity
+and passed it to `onig_sys::onig_region_resize()` after an unchecked cast to
+`c_int`. A capacity larger than `c_int::MAX` could wrap to a negative value
+before entering the C API.
+
+The wrapped value could cause the C implementation to allocate only the default
+small region while storing the negative value in `num_regs`. Later,
+`Region::len()` cast `num_regs` back to `usize`, so `Region::pos()` could treat
+out-of-range indices as valid and read past the heap allocation.
+
+The issue was fixed in version `6.5.2` by checking the `usize` to `c_int`
+conversion in `Region::reserve()` and panicking on overflow.


### PR DESCRIPTION
## Affected crate(s)

- `onig` (10,583,261 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/rust-onig/rust-onig/issues/215
- https://github.com/rust-onig/rust-onig/pull/221
- https://github.com/rust-onig/rust-onig/commit/fa76915bad1bf87c796b5a2d917b86fd5f23bf1c

## Severity

Affected versions expose a memory-safety issue in the safe `Region` API. `Region::reserve()` and `Region::with_capacity()` cast a user-provided `usize` capacity to `c_int` before calling the Oniguruma C API. Very large capacities can wrap to a negative `c_int`, causing a small allocation while `Region::len()` later interprets the stored value as a large `usize`. A subsequent `Region::pos()` call can then perform an out-of-bounds heap read.

This can lead to memory exposure and violates Rust safety expectations for safe APIs. The issue is fixed in `onig` 6.5.2 by checking the `usize` to `c_int` conversion in `Region::reserve()`.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate

## Validation

- `rustsec-admin lint`
- GitHub Actions: `Lint advisories` passed