### PR TITLE
Add advisory for solana_rbpf: OOB pointer arithmetic in `invoke_function`

### DIFF
--- a/crates/solana_rbpf/RUSTSEC-0000-0000.md
+++ b/crates/solana_rbpf/RUSTSEC-0000-0000.md
@@ -1,0 +1,43 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "solana_rbpf"
+date = "2026-05-28"
+url = "https://github.com/solana-labs/rbpf"
+references = [
+    "https://github.com/anza-xyz/sbpf/pull/151",
+    "https://crates.io/crates/solana-sbpf",
+]
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["soundness", "pointer-arithmetic", "out-of-bounds"]
+
+[affected.functions]
+"solana_rbpf::vm::EbpfVm::invoke_function" = [">= 0.8.0, <= 0.8.5"]
+
+[versions]
+patched = []
+unaffected = ["< 0.8.0"]
+```
+
+# `EbpfVm::invoke_function` performs out-of-bounds pointer arithmetic
+
+Affected versions of `solana_rbpf` expose the safe method
+`EbpfVm::invoke_function`. This method computes an obfuscated VM pointer by
+casting `self` to `*mut u64` and applying a randomized offset derived from
+`get_runtime_environment_key()`.
+
+The resulting pointer arithmetic is performed with `ptr::offset`, which
+requires the computed pointer to remain within the same allocation. In practice,
+the randomized offset can move the pointer far outside the allocation
+containing the `EbpfVm`, causing undefined behavior before the supplied builtin
+function is invoked.
+
+## Unmaintained
+
+The upstream `solana_rbpf` repository is archived, and no patched version of
+this crate is currently available.
+
+Users should migrate to the maintained [`solana-sbpf`](https://crates.io/crates/solana-sbpf)
+crate. The issue has been fixed there in
+[`anza-xyz/sbpf#151`](https://github.com/anza-xyz/sbpf/pull/151).


### PR DESCRIPTION
## Affected crate(s)

- `solana_rbpf` (362,603 recent downloads per crates.io; 4,761,947 total downloads)

## Links to upstream issue(s) or PR(s)

The upstream repository is archived, so I cannot report this through the normal upstream issue tracker.

- https://github.com/solana-labs/rbpf

## Severity

Informational soundness issue. Safe Rust code can construct an `EbpfVm` and call the safe method `EbpfVm::invoke_function`, which performs out-of-bounds pointer arithmetic internally.

The affected implementation casts `self` to `*mut u64` and applies a randomized offset from `get_runtime_environment_key()` using `ptr::offset`. This can move the pointer outside the allocation containing the `EbpfVm`, causing undefined behavior before the supplied builtin function is invoked. Miri reports an in-bounds pointer arithmetic violation. No `unsafe` code is required from the caller.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate
