### PR TITLE
Add advisory for domain: Dnskey::parse bypass the 16-bit RDATA length invariant

### DIFF
--- a/crates/domain/RUSTSEC-0000-0000.md
+++ b/crates/domain/RUSTSEC-0000-0000.md
@@ -1,0 +1,57 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "domain"
+date = "2026-03-12"
+url = "https://github.com/NLnetLabs/domain/issues/621"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["soundness", "length-check"]
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# `Dnskey::parse` can bypass the 16-bit RDATA length invariant
+
+`Dnskey::new` enforces that the DNSKEY RDATA wire length is at most 65,535 bytes
+via `LongRecordData::check_len(...)`, but `Dnskey::parse` does not enforce the
+same bound. Instead, it calls `unsafe { Dnskey::new_unchecked(...) }` with
+`parser.remaining() - 4` bytes. This allows safe code to construct a `Dnskey`
+with total wire length greater than 65,535, breaking the documented safety
+precondition of `new_unchecked` and violating the type's invariant.
+
+No patched version is currently available. The issue affects the reported
+version `0.11.1`.
+
+## Example
+
+```rust
+use domain::rdata::dnssec::Dnskey;
+use octseq::Parser;
+
+fn main() {
+    // Build a DNSKEY-like blob larger than the 16-bit DNS RDATA limit.
+    let mut buf = vec![0u8; 70_000];
+    buf[2] = 3;
+    buf[3] = 8;
+
+    let mut parser = Parser::from_ref(&buf[..]);
+
+    // Safe parse accepts the oversized payload.
+    let dnskey = Dnskey::parse(&mut parser).expect("Parse should succeed");
+
+    let total_wire_length = 4 + dnskey.into_public_key().as_ref().len();
+    println!("total wire length: {total_wire_length}");
+
+    // This should not be possible if the constructor invariant were preserved.
+    assert!(total_wire_length > 65_535);
+}
+```
+
+Observed output:
+
+```text
+total wire length: 70000
+```


### PR DESCRIPTION
## Affected crate(s)

- domain (1,338,549 downloads on crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/NLnetLabs/domain/issues/621

<!-- In principle, we do not publish advisories for issues that have
     not been reported upstream. -->

## Severity

Soundness issue: safe parsing bypasses the DNSKEY RDATA 16-bit length invariant, allowing construction of invalid records and violating new_unchecked safety preconditions, which can undermine memory safety assumptions.

<!-- Briefly describe the risk and potential effect of the vulnerability.
     For example: allows remote denial-of-service via stack exhaustion,
     or: use-after-free that can lead to arbitrary code execution. -->

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate

The mentioned issue is open for more than two months and no response has been received so far.