### PR TITLE
Add advisory for http-types: violated ASCII invariants

### DIFF
--- a/crates/http-types/RUSTSEC-0000-0000.md
+++ b/crates/http-types/RUSTSEC-0000-0000.md
@@ -1,0 +1,53 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "http-types"
+date = "2026-03-11"
+url = "https://github.com/http-rs/http-types/issues/534"
+informational = "notice"
+keywords = ["header", "ascii", "invalid utf-8"]
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# `Authorization::value` and `WwwAuthenticate::value` can violate ASCII invariants
+
+`Authorization::value` uses `HeaderValue::value` with the claim
+that the internal string is ASCII, but `Authorization::new` and
+`Authorization::set_credentials` accept arbitrary `String` credentials without
+validation. As a result, safe code can construct a header value containing
+non-ASCII UTF-8 while the implementation assumes ASCII.
+
+`WwwAuthenticate::new` and `WwwAuthenticate::set_realm` similarly accepts arbitrary `String` input, so `WwwAuthenticate::value` can also produce a header value that violates the crate’s documented ASCII invariants. 
+
+The issue is reported for version `2.12.0`, and no patched version is currently available. This issue has been open more than two months but no reply is received, although this repo is active.
+
+This issue has not been confirmed as Undefined Behavior, but the unsafe
+justification in `Authorization::value` and `WwwAuthenticate::value` appears incorrect and can produce values outside the expected ASCII-only constraints.
+
+## Example
+
+```rust
+use http_types::auth::Authorization;
+use http_types::auth::AuthenticationScheme;
+
+fn main() {
+    let mut auth = Authorization::new(AuthenticationScheme::Basic, String::new());
+    auth.set_credentials("α".to_string());
+
+    let header = auth.value();
+    println!("{:?}", header.as_str().as_bytes());
+
+    let 
+}
+```
+The output is:
+
+```text
+[66, 97, 115, 105, 99, 32, 206, 177]
+[66, 97, 115, 105, 99, 32, 114, 101, 97, 108, 109, 61, 34, 206, 177, 34, 44, 32, 99, 104, 97, 114, 115, 101, 116, 61, 34, 85, 84, 70, 45, 56, 34]
+```
+
+The child slice [206, 177] is the representation of "α"

--- a/crates/http-types/RUSTSEC-0000-0000.md
+++ b/crates/http-types/RUSTSEC-0000-0000.md
@@ -22,32 +22,7 @@ non-ASCII UTF-8 while the implementation assumes ASCII.
 
 `WwwAuthenticate::new` and `WwwAuthenticate::set_realm` similarly accepts arbitrary `String` input, so `WwwAuthenticate::value` can also produce a header value that violates the crate’s documented ASCII invariants. 
 
-The issue is reported for version `2.12.0`, and no patched version is currently available. This issue has been open more than two months but no reply is received, although this repo is active.
-
 This issue has not been confirmed as Undefined Behavior, but the unsafe
 justification in `Authorization::value` and `WwwAuthenticate::value` appears incorrect and can produce values outside the expected ASCII-only constraints.
 
-## Example
-
-```rust
-use http_types::auth::Authorization;
-use http_types::auth::AuthenticationScheme;
-
-fn main() {
-    let mut auth = Authorization::new(AuthenticationScheme::Basic, String::new());
-    auth.set_credentials("α".to_string());
-
-    let header = auth.value();
-    println!("{:?}", header.as_str().as_bytes());
-
-    let 
-}
-```
-The output is:
-
-```text
-[66, 97, 115, 105, 99, 32, 206, 177]
-[66, 97, 115, 105, 99, 32, 114, 101, 97, 108, 109, 61, 34, 206, 177, 34, 44, 32, 99, 104, 97, 114, 115, 101, 116, 61, 34, 85, 84, 70, 45, 56, 34]
-```
-
-The child slice [206, 177] is the representation of "α"
+The http-types crate is unmaintained and the issue is unlikely to be fixed.


### PR DESCRIPTION
## Affected crate(s)

- http-types(5,354,945downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/http-rs/http-types/issues/534
<!-- In principle, we do not publish advisories for issues that have
     not been reported upstream. -->

## Severity


Soundness issue: safe parsing bypasses the DNSKEY RDATA 16-bit length invariant, allowing construction of invalid records and violating new_unchecked safety preconditions, which can undermine memory safety assumptions.

<!-- Briefly describe the risk and potential effect of the vulnerability.
     For example: allows remote denial-of-service via stack exhaustion,
     or: use-after-free that can lead to arbitrary code execution. -->

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate

This repo is active, but the issue has no reply for more than two months. Although this crate has published new version, the ths same soundness issues exist.