### PR TITLE
GHSA-g9f8-wqj9-fjw5: russh, russh-cryptovec

### DIFF
--- a/crates/russh-cryptovec/RUSTSEC-0000-0000.md
+++ b/crates/russh-cryptovec/RUSTSEC-0000-0000.md
@@ -1,0 +1,55 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "russh-cryptovec"
+date = "2026-05-15"
+url = "https://github.com/Eugeny/russh/security/advisories/GHSA-g9f8-wqj9-fjw5"
+references = ["https://github.com/Eugeny/russh/commit/a2d48a71fe93d18cbd666c8d53d0882f5ce110c4"]
+categories = ["denial-of-service"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+aliases = ["CVE-2026-46673", "GHSA-g9f8-wqj9-fjw5"]
+
+[versions]
+patched = [">=0.60.3"]
+```
+
+# Unchecked `CryptoVec` allocation and growth handling
+
+`CryptoVec` used unchecked capacity growth, unchecked length arithmetic, and
+unsafe allocation and locking paths. In affected `russh` releases,
+attacker-controlled input could reach these code paths through buffer resizing
+operations.
+
+Two affected reachability paths were identified:
+
+* **Current `russh` releases (`0.60.x` before the fix)**
+  Local SSH agent peers could provide attacker-controlled frame lengths that
+  were used to resize internal buffers before validation in:
+
+  * `AgentClient::read_response`
+  * `agent::server::Connection::run`
+
+* **Historical `russh` releases before `0.58.0`**
+  `CryptoVec` was also used for non-secret transport and compression buffers,
+  allowing remote SSH traffic to trigger `CryptoVec` growth through:
+
+  * transport packet reads
+  * zlib decompression output
+
+These remote paths were removed in `0.58.0` when `CryptoVec` stopped being used
+for those buffers.
+
+Under constrained memory conditions, historical `russh` versions prior to
+`0.58.0` can abort the process when remote compressed payload expansion causes
+allocation failure in `CryptoVec`. This was reproduced through the compression
+path and resulted in process termination in the Unix allocation/locking
+implementation after null pointer allocation failure.
+
+For current affected releases, oversized local SSH agent frame lengths could
+trigger untrusted-input-driven buffer growth prior to validation.
+
+No practical remote code execution, integrity or confidentiality impact has
+been demonstrated.
+
+Fixed by validating CryptoVec growth operations and rejecting oversized SSH
+agent frame lengths before buffer allocation.

--- a/crates/russh/RUSTSEC-0000-0000.md
+++ b/crates/russh/RUSTSEC-0000-0000.md
@@ -1,0 +1,27 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "russh"
+date = "2026-05-15"
+url = "https://github.com/Eugeny/russh/security/advisories/GHSA-g9f8-wqj9-fjw5"
+references = ["https://github.com/Eugeny/russh/commit/a2d48a71fe93d18cbd666c8d53d0882f5ce110c4"]
+categories = ["denial-of-service"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+aliases = ["CVE-2026-46673", "GHSA-g9f8-wqj9-fjw5"]
+
+[versions]
+patched = [">=0.60.3"]
+```
+
+# Unbounded 32-bit allocation
+
+Both the SSH agent server and client accepted peer-controlled frame lengths
+without enforcing a maximum frame size. This could cause large memory
+allocations while parsing a maliciously crafted agent frame.
+
+A malicious peer could advertise an oversized frame length, causing the client
+or server to attempt a large memory allocation before validating the frame,
+potentially leading to memory exhaustion or process termination.
+
+This is fixed by enforcing a maximum agent frame size of 256 KiB and
+rejecting oversized frames before buffer allocation.


### PR DESCRIPTION
## Affected crate(s)

- russh
- russh-cryptovec

## Links to upstream issue(s) or PR(s)

<!-- In principle, we do not publish advisories for issues that have
     not been reported upstream. -->

- https://github.com/Eugeny/russh/security/advisories/GHSA-g9f8-wqj9-fjw5
- https://github.com/Eugeny/russh/commit/a2d48a71fe93d18cbd666c8d53d0882f5ce110c4

## Severity

<!-- Briefly describe the risk and potential effect of the vulnerability.
     For example: allows remote denial-of-service via stack exhaustion,
     or: use-after-free that can lead to arbitrary code execution. -->

denial-of-service through unchecked allocations

## Checklist

- [X] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [X] `date` field is set to the public disclosure date
- [X] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate

Fixes #2892