### PR TITLE
Mark surf and tide as unmaintained

### DIFF
--- a/crates/surf/RUSTSEC-0000-0000.md
+++ b/crates/surf/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "surf"
+date = "2026-06-04"
+informational = "unmaintained"
+url = "https://github.com/http-rs/surf/issues/352"
+
+[versions]
+patched = []
+```
+
+# surf is unmaintained
+
+The surf crate is unmaintained, and all versions are affected.
+
+For alternatives, consider using [reqwest](https://crates.io/crates/reqwest)
+or [ureq](https://crates.io/crates/ureq).
+
+See [this issue](https://github.com/http-rs/surf/issues/352) for more context.

--- a/crates/tide/RUSTSEC-0000-0000.md
+++ b/crates/tide/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tide"
+date = "2026-06-04"
+informational = "unmaintained"
+url = "https://github.com/http-rs/tide/issues/922"
+
+[versions]
+patched = []
+```
+
+# tide is unmaintained
+
+The tide crate is unmaintained, and all versions are affected.
+
+The closest maintained alternative might be [trillium](https://crates.io/crates/trillium).
+
+See [this issue](https://github.com/http-rs/tide/issues/922) for more context.


### PR DESCRIPTION
## Affected crate(s)

- tide (290k recent downloads per crates.io)
- surf (386k recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/http-rs/tide/issues/922
- https://github.com/http-rs/surf/issues/352

## Severity

After discussing with @yoshuawuyts, it appears to make sense that all crates in the [http-rs](https://github.com/http-rs) GitHub org are effectively unmaintained. The lower-level http-types crate is covered here:

- https://github.com/rustsec/advisory-db/pull/2923

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
