### PR TITLE
Add CVE-2026-45057 for matrix-sdk-ui

### DIFF
--- a/crates/matrix-sdk-ui/RUSTSEC-0000-0000.md
+++ b/crates/matrix-sdk-ui/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "matrix-sdk-ui"
+date = "2026-06-03"
+url = "https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-h97m-27fx-42rx"
+aliases = ["GHSA-h97m-27fx-42rx", "CVE-2026-45057"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:H/UI:N/S:U/C:N/I:H/A:N"
+
+[versions]
+patched = [">= 0.16.1"]
+```
+
+# Incomplete message edit validation in matrix-sdk-ui
+
+The message edit validation logic in the matrix-sdk-ui crate before 0.16.1 is
+missing a check: when replacing an encrypted event, the replacement event itself
+is not required to be encrypted. This enables a malicious homeserver
+administrator (or an actor with equivalent power) to impersonate or spoof
+messages as if they were sent by a victim user.


### PR DESCRIPTION
## Affected crate(s)

- matrix-sdk-ui

## Links to upstream issue(s) or PR(s)

https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-h97m-27fx-42rx

## Severity

matrix-sdk-ui contains incomplete message edit validation. This enables a malicious homeserver administrator (or an actor with equivalent power) to impersonate or spoof messages as if they were sent by a victim user.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
