### PR TITLE
Add CVE-2026-45056 for matrix-sdk-crypto

### DIFF
--- a/crates/matrix-sdk-crypto/RUSTSEC-0000-0000.md
+++ b/crates/matrix-sdk-crypto/RUSTSEC-0000-0000.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "matrix-sdk-crypto"
+date = "2026-06-03"
+url = "https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-wfq4-36m3-9g42"
+aliases = ["CVE-2026-45056", "GHSA-wfq4-36m3-9g42"]
+
+[versions]
+patched = [">= 0.16.1"]
+unaffected = ["< 0.12.0"]
+```
+
+# Sender-binding gaps in to-device messages
+
+The matrix-sdk-crypto crate before 0.16.1 is missing a check for the sender's
+user ID when decrypting an Olm-encrypted to-device message containing the
+sender_device_keys property.
+
+This could be exploited to spoof the sender of an encrypted to-device message,
+but only if the attacker colludes with (or is) the homeserver operator.


### PR DESCRIPTION
## Affected crate(s)

matrix-sdk-crypto

## Links to upstream issue(s) or PR(s)

https://github.com/matrix-org/matrix-rust-sdk/security/advisories/GHSA-wfq4-36m3-9g42

## Severity

The matrix-sdk-crypto crate before 0.16.1 is missing a check for the sender's
user ID when decrypting an Olm-encrypted to-device message containing the
sender_device_keys property.

This could be exploited to spoof the sender of an encrypted to-device message,
but only if the attacker colludes with (or is) the homeserver operator.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate