### PR TITLE
Mark pqcrypto crates as unmaintained

### DIFF
--- a/crates/pqcrypto-classicmceliece/RUSTSEC-0000-0000.md
+++ b/crates/pqcrypto-classicmceliece/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "pqcrypto-classicmceliece"
+date = "2026-06-04"
+url = "https://github.com/rustpq/pqcrypto/issues/97"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `pqcrypto-classicmceliece` is unmaintained: upstream PQClean project being archived
+
+This crate provides Rust bindings to the Classic McEliece key encapsulation
+mechanism via C implementations from
+[PQClean](https://github.com/PQClean/PQClean). The PQClean project is being
+archived in or after July 2026 (see [PQClean/PQClean#604](https://github.com/PQClean/PQClean/issues/604)),
+after which no further security patches or bug fixes will be applied to the
+upstream implementations.
+
+As a result, this crate will no longer receive updates. Users should migrate
+to actively maintained alternatives.

--- a/crates/pqcrypto-falcon/RUSTSEC-0000-0000.md
+++ b/crates/pqcrypto-falcon/RUSTSEC-0000-0000.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "pqcrypto-falcon"
+date = "2026-06-04"
+url = "https://github.com/rustpq/pqcrypto/issues/97"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `pqcrypto-falcon` is unmaintained: upstream PQClean project being archived
+
+This crate provides Rust bindings to the Falcon (FN-DSA) signature scheme
+via C implementations from
+[PQClean](https://github.com/PQClean/PQClean). The PQClean project is being
+archived in or after July 2026 (see [PQClean/PQClean#604](https://github.com/PQClean/PQClean/issues/604)),
+after which no further security patches or bug fixes will be applied to the
+upstream implementations.
+
+As a result, this crate will no longer receive updates. Users should migrate
+to the [`fn-dsa`](https://crates.io/crates/fn-dsa) crate, which provides a
+pure-Rust implementation of FN-DSA (FIPS 206).

--- a/crates/pqcrypto-hqc/RUSTSEC-0000-0000.md
+++ b/crates/pqcrypto-hqc/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "pqcrypto-hqc"
+date = "2026-06-04"
+url = "https://github.com/rustpq/pqcrypto/issues/97"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `pqcrypto-hqc` is unmaintained: upstream PQClean project being archived
+
+This crate provides Rust bindings to the HQC key encapsulation mechanism
+via C implementations from
+[PQClean](https://github.com/PQClean/PQClean). The PQClean project is being
+archived in or after July 2026 (see [PQClean/PQClean#604](https://github.com/PQClean/PQClean/issues/604)),
+after which no further security patches or bug fixes will be applied to the
+upstream implementations.
+
+As a result, this crate will no longer receive updates. Users should migrate
+to actively maintained alternatives.

--- a/crates/pqcrypto-internals/RUSTSEC-0000-0000.md
+++ b/crates/pqcrypto-internals/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "pqcrypto-internals"
+date = "2026-06-04"
+url = "https://github.com/rustpq/pqcrypto/issues/97"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `pqcrypto-internals` is unmaintained: upstream PQClean project being archived
+
+This crate provides internal FFI utilities for the `pqcrypto-*` ecosystem,
+directly wrapping C implementations from
+[PQClean](https://github.com/PQClean/PQClean). The PQClean project is being
+archived in or after July 2026 (see [PQClean/PQClean#604](https://github.com/PQClean/PQClean/issues/604)),
+after which no further security patches or bug fixes will be applied to the
+upstream implementations.
+
+As a result, this crate and the broader `pqcrypto-*` ecosystem will no longer
+receive updates.

--- a/crates/pqcrypto-mldsa/RUSTSEC-0000-0000.md
+++ b/crates/pqcrypto-mldsa/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "pqcrypto-mldsa"
+date = "2026-06-04"
+url = "https://github.com/rustpq/pqcrypto/issues/97"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `pqcrypto-mldsa` is unmaintained: upstream PQClean project being archived
+
+This crate provides Rust bindings to ML-DSA (FIPS 204) via C implementations
+from [PQClean](https://github.com/PQClean/PQClean). The PQClean project is
+being archived in or after July 2026 (see [PQClean/PQClean#604](https://github.com/PQClean/PQClean/issues/604)),
+after which no further security patches or bug fixes will be applied to the
+upstream implementations.
+
+As a result, this crate will no longer receive updates. Users should migrate
+to the [`ml-dsa`](https://crates.io/crates/ml-dsa) crate, which provides a
+pure-Rust implementation of ML-DSA (FIPS 204).

--- a/crates/pqcrypto-mlkem/RUSTSEC-0000-0000.md
+++ b/crates/pqcrypto-mlkem/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "pqcrypto-mlkem"
+date = "2026-06-04"
+url = "https://github.com/rustpq/pqcrypto/issues/97"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `pqcrypto-mlkem` is unmaintained: upstream PQClean project being archived
+
+This crate provides Rust bindings to ML-KEM (FIPS 203) via C implementations
+from [PQClean](https://github.com/PQClean/PQClean). The PQClean project is
+being archived in or after July 2026 (see [PQClean/PQClean#604](https://github.com/PQClean/PQClean/issues/604)),
+after which no further security patches or bug fixes will be applied to the
+upstream implementations.
+
+As a result, this crate will no longer receive updates. Users should migrate
+to the [`ml-kem`](https://crates.io/crates/ml-kem) crate, which provides a
+pure-Rust implementation of ML-KEM (FIPS 203).

--- a/crates/pqcrypto-sphincsplus/RUSTSEC-0000-0000.md
+++ b/crates/pqcrypto-sphincsplus/RUSTSEC-0000-0000.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "pqcrypto-sphincsplus"
+date = "2026-06-04"
+url = "https://github.com/rustpq/pqcrypto/issues/97"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `pqcrypto-sphincsplus` is unmaintained: upstream PQClean project being archived
+
+This crate provides Rust bindings to SPHINCS+/SLH-DSA (FIPS 205) via C
+implementations from [PQClean](https://github.com/PQClean/PQClean). The
+PQClean project is being archived in or after July 2026 (see
+[PQClean/PQClean#604](https://github.com/PQClean/PQClean/issues/604)),
+after which no further security patches or bug fixes will be applied to the
+upstream implementations.
+
+As a result, this crate will no longer receive updates. Users should migrate
+to the [`slh-dsa`](https://crates.io/crates/slh-dsa) crate, which provides a
+pure-Rust implementation of SLH-DSA (FIPS 205).

--- a/crates/pqcrypto-traits/RUSTSEC-0000-0000.md
+++ b/crates/pqcrypto-traits/RUSTSEC-0000-0000.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "pqcrypto-traits"
+date = "2026-06-04"
+url = "https://github.com/rustpq/pqcrypto/issues/97"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `pqcrypto-traits` is unmaintained: upstream PQClean project being archived
+
+This crate provides shared trait definitions for the `pqcrypto-*` ecosystem,
+which wraps C implementations from
+[PQClean](https://github.com/PQClean/PQClean). The PQClean project is being
+archived in or after July 2026 (see [PQClean/PQClean#604](https://github.com/PQClean/PQClean/issues/604)).
+
+As a result, this crate and the broader `pqcrypto-*` ecosystem will no longer
+receive updates. Users should migrate to actively maintained alternatives.

--- a/crates/pqcrypto/RUSTSEC-0000-0000.md
+++ b/crates/pqcrypto/RUSTSEC-0000-0000.md
@@ -1,0 +1,28 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "pqcrypto"
+date = "2026-06-04"
+url = "https://github.com/rustpq/pqcrypto/issues/97"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `pqcrypto` is unmaintained: upstream PQClean project being archived
+
+The `pqcrypto` crate and the entire `pqcrypto-*` ecosystem wrap C implementations
+from [PQClean](https://github.com/PQClean/PQClean). The PQClean project is being
+archived in or after July 2026 (see [PQClean/PQClean#604](https://github.com/PQClean/PQClean/issues/604)),
+after which no further security patches, algorithm updates, or bug fixes will
+be applied to the upstream implementations.
+
+As a result, this crate and all dependent crates in the `pqcrypto-*` ecosystem
+will no longer receive updates. Users should migrate to actively maintained
+alternatives. Pure-Rust replacements are available for several algorithms:
+
+- ML-KEM (FIPS 203): [`ml-kem`](https://crates.io/crates/ml-kem)
+- ML-DSA (FIPS 204): [`ml-dsa`](https://crates.io/crates/ml-dsa)
+- SLH-DSA (FIPS 205): [`slh-dsa`](https://crates.io/crates/slh-dsa)
+- FN-DSA (FIPS 206): [`fn-dsa`](https://crates.io/crates/fn-dsa)


### PR DESCRIPTION
## Affected crate(s)

- pqcrypto (35147)
- pqcrypto-mlkem (79295)
- pqcrypto-mldsa (71438)
- pqcrypto-hqc (71795)
- pqcrypto-falcon (24040)
- pqcrypto-classicmceliece (7666)
- pqcrypto-sphincsplus (36969)

## Links to upstream issue(s) or PR(s)

- https://github.com/rustpq/pqcrypto/issues/97
- https://github.com/PQClean/PQClean/issues/604

## Severity

Using unmaintained cryptographic implementations is risky,
as this means that you will not receive any fixes. There are 
known side-channel concerns in some implementations.

HQC, Falcon and SPHINCS+ are also not up to date with their
latest versions.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
