### PR TITLE
Another Diesel Advisory

### DIFF
--- a/crates/diesel/RUSTSEC-0000-0000.md
+++ b/crates/diesel/RUSTSEC-0000-0000.md
@@ -1,0 +1,28 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "diesel"
+date = "2026-06-05"
+url = "https://github.com/diesel-rs/diesel/commit/1bc2ea46d9840e8d9af844239d3c84f37fe7d84b"
+informational = "unsound"
+
+[affected.functions]
+"diesel::sqlite::SqliteConnection::deserialize_readonly_database" = ["<2.3.10"]
+
+[versions]
+patched = [">= 2.3.10"]
+```
+
+# Possible use after free when deserializing a SQLite database via `SqliteConnection::deserialize_readonly_database`
+
+Diesel allows loading a SQLite database from a byte buffer, represented as `&[u8]`, at runtime via the `SqliteConnection::deserialize_readonly_database` function. In previous versions of Diesel, this buffer was passed directly to libsqlite3. Since libsqlite3 requires the buffer to remain alive for as long as the database connection is open and Diesel did not ensure this as part of its safe API, callers of `SqliteConnection::deserialize_readonly_database` could drop the buffer prematurely. This prematurely drop caused libsqlite3 to operate on freed memory.
+
+This vulnerability affects users of `SqliteConnection::deserialize_readonly_database` who drop the buffer passed to the function before they drop the database connection.
+
+## Mitigation
+
+The preferred mitigation to the outlined problem is to update to Diesel version 2.3.10 or newer, which includes a fix for the problem. Alternatively users need to take to keep the buffer alive until the connection is dropped.
+
+## Resolution
+
+Diesel now stores a copy of the buffer inside of the `SqliteConnection` object itself to keep it alive as long as the underlying libsqlite3 connection exists.


### PR DESCRIPTION
This fills another advisory for another Diesel issue recently uncovered by LLM/AI.

## Affected crate(s)

- Diesel

## Links to upstream issue(s) or PR(s)

https://github.com/diesel-rs/diesel/commit/1bc2ea46d9840e8d9af844239d3c84f37fe7d84b
https://github.com/diesel-rs/diesel/pull/5056

## Severity

The API provided by Diesel allowed an unsound usage of `SqliteConnection::deserialize_readonly_database` as it did not ensure that the passed buffer is not dropped before the created connection is dropped. This could lead to an use-after-free issue, but only if the user actively keeps around the connection for longer than the buffer. Whether or not that's an issue depends on the users code calling this function, therefore I filled this as informal unsound advisory rather than as "real" vulnerability.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
