### PR TITLE
Add unmaintained advisory for proc-macro-error2

### DIFF
--- a/crates/proc-macro-error/RUSTSEC-2024-0370.md
+++ b/crates/proc-macro-error/RUSTSEC-2024-0370.md
@@ -19,5 +19,4 @@ proc-macro-error also depends on `syn 1.x`, which may be bringing duplicate depe
 ## Possible Alternative(s)
 
 - [manyhow](https://crates.io/crates/manyhow)
-- [proc-macro-error2](https://crates.io/crates/proc-macro-error2)
 - [proc-macro2-diagnostics](https://github.com/SergioBenitez/proc-macro2-diagnostics)

--- a/crates/proc-macro-error2/RUSTSEC-0000-0000.md
+++ b/crates/proc-macro-error2/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "proc-macro-error2"
+date = "2026-06-07"
+informational = "unmaintained"
+url = "https://github.com/GnomedDev/proc-macro-error-2/issues/17"
+
+[versions]
+patched = []
+```
+
+# proc-macro-error2 is unmaintained
+
+The author of `proc-macro-error2` has [confirmed](https://github.com/GnomedDev/proc-macro-error-2/issues/17#issuecomment-4643215473) that the crate is no longer maintained and recommends that users migrate away from it.
+
+`proc-macro-error2` was originally created as a maintained fork of [`proc-macro-error`](https://crates.io/crates/proc-macro-error) (see [RUSTSEC-2024-0370](https://rustsec.org/advisories/RUSTSEC-2024-0370)). Both the original crate and this fork are now unmaintained.
+
+## Possible Alternative(s)
+
+- [manyhow](https://crates.io/crates/manyhow)
+- [proc-macro2-diagnostics](https://github.com/SergioBenitez/proc-macro2-diagnostics)


### PR DESCRIPTION
## Affected crate(s)

- [proc-macro-error2](https://crates.io/crates/proc-macro-error2) (103,451,997 downloads)

## Links to upstream issue(s) or PR(s)

https://github.com/GnomedDev/proc-macro-error-2/issues/17

## Severity

Informational: unmaintained

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
