### PR TITLE
Update RUSTSEC-2026-0173, RUSTSEC-2024-0370 with proc-macro-error3 as alternative

### DIFF
--- a/crates/proc-macro-error/RUSTSEC-2024-0370.md
+++ b/crates/proc-macro-error/RUSTSEC-2024-0370.md
@@ -20,3 +20,4 @@ proc-macro-error also depends on `syn 1.x`, which may be bringing duplicate depe
 
 - [manyhow](https://crates.io/crates/manyhow)
 - [proc-macro2-diagnostics](https://github.com/SergioBenitez/proc-macro2-diagnostics)
+- [proc-macro-error3](https://github.com/gamma0987/proc-macro-error3)

--- a/crates/proc-macro-error2/RUSTSEC-2026-0173.md
+++ b/crates/proc-macro-error2/RUSTSEC-2026-0173.md
@@ -20,3 +20,4 @@ The author of `proc-macro-error2` has [confirmed](https://github.com/GnomedDev/p
 
 - [manyhow](https://crates.io/crates/manyhow)
 - [proc-macro2-diagnostics](https://github.com/SergioBenitez/proc-macro2-diagnostics)
+- [proc-macro-error3](https://github.com/gamma0987/proc-macro-error3)


### PR DESCRIPTION
## Affected crate(s)

- proc-macro-error (40,369,775)
- proc-macro-error2 (35,084,645)

## Affected Advisories

RUSTSEC-2024-0370
RUSTSEC-2026-0173

proc-macro-error3 is a maintained fork of the proc-macro-error2 crate, which also was a fork and drop-in replacement for proc-macro-error.