### PR TITLE
Add malware advisory for onering 1.4.1

### DIFF
--- a/crates/onering/RUSTSEC-0000-0000.md
+++ b/crates/onering/RUSTSEC-0000-0000.md
@@ -7,6 +7,7 @@ categories = ["malicious"]
 
 [versions]
 unaffected = ["< 1.4.1", "> 1.4.1"]
+patched = []
 ```
 
 # `onering` 1.4.1 was removed from crates.io for malicious code

--- a/crates/onering/RUSTSEC-0000-0000.md
+++ b/crates/onering/RUSTSEC-0000-0000.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "onering"
+date = "2026-06-10"
+categories = ["malicious"]
+
+[versions]
+unaffected = ["< 1.4.1", "> 1.4.1"]
+```
+
+# `onering` 1.4.1 was removed from crates.io for malicious code
+
+A new version of the `onering` crate was published with code that attempted to
+exfiltrate both metadata and code from the project it was included within.
+
+One malicious version was published on 2026-06-10, approximately six hours
+before removal. This crate has no dependencies on crates.io, and there is no
+evidence of actual usage of the compromised version.
+
+Thanks to Charlie Eriksen for the report.


### PR DESCRIPTION
This one's a little unusual in that it's only for one version. Since I don't think `semver` has a way to express a straight `not`, I've expressed the unaffected versions in the negative using less and greater than operators. Note that there's also no `expect-deleted` as a result.