### PR TITLE
Add advisory for tract-nnef (NNEF parser integer overflow → OOB read)

### DIFF
--- a/crates/tract-nnef/RUSTSEC-0000-0000.md
+++ b/crates/tract-nnef/RUSTSEC-0000-0000.md
@@ -1,0 +1,52 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tract-nnef"
+date = "2026-06-10"
+url = "https://github.com/sonos/tract/security/advisories/GHSA-x5mv-8wgw-29hg"
+aliases = ["GHSA-x5mv-8wgw-29hg"]
+references = ["https://github.com/sonos/tract/commit/34c7df2c9bd2a36583e09b52f3e6319bf23102e8"]
+categories = ["memory-exposure", "denial-of-service"]
+keywords = ["parsing", "nnef", "integer-overflow", "out-of-bounds-read"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:H"
+
+[versions]
+patched = [">= 0.21.16, < 0.22.0", ">= 0.22.2, < 0.23.0", ">= 0.23.1"]
+
+[affected]
+functions = { "tract_nnef::tensors::read_tensor" = ["< 0.21.16", ">= 0.22.0, < 0.22.2", ">= 0.23.0, < 0.23.1"] }
+```
+
+# Integer overflow in tract-nnef NNEF tensor parser leads to out-of-bounds read on model load
+
+`tract_nnef::tensors::read_tensor` builds a tensor shape from attacker-controlled
+32-bit dimensions and computes both the element count `product(shape)` and the
+byte allocation `product(shape) * size_of(dt)` with **unchecked `usize`
+arithmetic**. In release builds (no `overflow-checks`) both products wrap modulo
+2^64.
+
+A crafted NNEF `.dat` tensor can choose dimensions whose wrapped products
+collapse to a small value that satisfies the header size-consistency check, while
+the true element count stays astronomically large. `read_tensor` then returns a
+`Tensor` whose reported `len` (e.g. `2^61 + 7`) far exceeds its backing heap
+allocation (e.g. 56 bytes). The unchecked accessor `as_slice_unchecked`
+(`slice::from_raw_parts(ptr, self.len())`) subsequently yields a slice spanning
+~18 EiB over the small buffer.
+
+The out-of-bounds read fires automatically during model build (no inference
+required), reachable through the default `DatLoader` resource loader via the
+public `tract_nnef::nnef().model_for_path` / `model_for_read` API when the
+const-folding `as_uniform` fast-path materializes the over-long constant. The
+always-on primitive is a bounded adjacent-heap over-read (information
+disclosure); access further past the mapped region SIGSEGVs (denial of service).
+No out-of-bounds write or code execution was demonstrated.
+
+Affected: every release line prior to the backported fixes — `< 0.21.16`,
+`0.22.0`–`0.22.1`, and `0.23.0`. The block-quant path had already received an
+analogous blob-size guard; the dense `DatLoader` path was missed.
+
+## Mitigation
+
+Upgrade to `0.21.16`, `0.22.2`, or `0.23.1`. The fix computes the shape product
+and byte size with `checked_mul` and rejects the tensor on overflow
+(commit [`34c7df2`](https://github.com/sonos/tract/commit/34c7df2c9bd2a36583e09b52f3e6319bf23102e8)).


### PR DESCRIPTION
# Add advisory for `tract-nnef` (NNEF tensor parser integer overflow → OOB read)

New advisory: `crates/tract-nnef/RUSTSEC-0000-0000.md`.

## Summary

`tract_nnef::tensors::read_tensor` computes a tensor's element count and byte
allocation from attacker-controlled 32-bit dimensions with unchecked `usize`
arithmetic. In release builds both products wrap mod 2^64, so a crafted NNEF
`.dat` tensor can pass the header size-consistency check while the reported
`len` (e.g. `2^61 + 7`) far exceeds the backing allocation (e.g. 56 bytes).
`as_slice_unchecked` then builds an out-of-bounds slice — an adjacent-heap
over-read on model load (info disclosure), with a wild-slice SIGSEGV (DoS) on
further access. Reachable via the public `nnef().model_for_path` /
`model_for_read` load API.

## Coordinates

- **Crate:** `tract-nnef`
- **Fixed in:** `0.21.16`, `0.22.2`, `0.23.1` (backported across all release lines)
- **Fix commit:** sonos/tract@34c7df2c9bd2a36583e09b52f3e6319bf23102e8 (`fix(nnef): reject overflowing tensor dims` — `checked_mul` + reject on overflow)
- **Upstream advisory:** GHSA-x5mv-8wgw-29hg
- **CWE:** CWE-190 → CWE-125
- **CVSS:3.1:** `AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:H` (6.1, Medium)
- **Reporter:** s1ko (s1ko@riseup.net)

ID placeholder `RUSTSEC-0000-0000` per CONTRIBUTING — please assign on merge.
