### PR TITLE
Add advisory for triton-vm

### DIFF
--- a/crates/triton-vm/RUSTSEC-0000-0000.md
+++ b/crates/triton-vm/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "triton-vm"
+date = "2021-06-11"
+categories = ["crypto-failure"]
+keywords = ["proof-system", "unsound"]
+
+[affected.functions]
+"triton_vm::verify" = ["< 4.0.0, >= 0.42.0-alpha.4"]
+
+[versions]
+patched = [">= 4.0.0"]
+unaffected = ["< 0.42.0-alpha.4"]
+```
+
+# Triton VM Soundness Vulnerability due to Missing Constraint
+
+The instruction `sponge_absorb_mem` Triton VM fails to verify that hashed values come from the claimed memory location. Malicious provers can substitute arbitrary data instead of actual memory contents.
+
+Any application using instruction `sponge_absorb_mem` to hash memory data can be given a proof for a forged hash that doesn't correspond to the actual memory. This breaks the security of memory-based commitments.
+
+The flaw was corrected in commits `17c7ba0a` and `ef9d9e72` by including the appropriate constraints.


### PR DESCRIPTION
## Affected crate(s)

- [triton-vm](https://crates.io/crates/triton-vm)

## Links to upstream issue(s) or PR(s)

None; [here](https://github.com/TritonVM/triton-vm/commit/17c7ba0a19f31793f1c807a58afaf9504342aac5)'s the commit of the fix, though.

> In principle, we do not publish advisories for issues that have not been reported upstream.

The report did not happen through public channels.

## Severity

Any Triton VM application using instruction `sponge_absorb_mem` to hash memory data can be given a proof for a forged hash that doesn't correspond to the actual memory. This breaks soundness of Triton VM's proof system.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
