### PR TITLE
Report thread safety issue with PyO3's `PyCFunction::new_closure`

### DIFF
--- a/crates/pyo3/RUSTSEC-0000-0000.md
+++ b/crates/pyo3/RUSTSEC-0000-0000.md
@@ -1,0 +1,34 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "pyo3"
+date = "2026-06-11"
+url = "https://github.com/PyO3/pyo3/pull/6096"
+categories = ["thread-safety"]
+keywords = ["thread-safety", "unsound"]
+
+[affected.functions]
+"pyo3::types::PyCFunction::new_closure" = [">= 0.15.0, < 0.29.0"]
+"pyo3::types::PyCFunction::new_closure_bound" = [">= 0.21.0, < 0.23.0"]
+
+[versions]
+patched = [">= 0.29.0"]
+```
+
+# Missing `Sync` bound on `PyCFunction::new_closure` closures
+
+`PyCFunction::new_closure` (and the temporary `new_closure_bound` complement in
+the 0.21–0.22 series) required the supplied closure to be `Send + 'static` but
+not `Sync`. The resulting `PyCFunction` is a Python callable that can be
+invoked from any Python thread, which means the closure may be called
+concurrently from multiple threads, and needs a `Sync` bound to prevent
+possible data races.
+
+The problem exists under all Python versions but is particularly vulnerable under
+the newer free-threaded Python variant, which do not have serial execution
+imposed by the Global Interpreter Lock. Under releases protected by the GIL,
+the ability to "detach" from the Python interpreter temporarily inside the closure
+(e.g. by `Python::detach`) makes it possible for interleaved and/or concurrent
+execution of various portions of the closure.
+
+PyO3 0.29.0 added a `Sync` bound to close this thread-safety bug.


### PR DESCRIPTION
## Affected crate(s)

- `pyo3` (40M recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

https://github.com/PyO3/pyo3/pull/6096

## Severity

`PyCFunction::new_closure` missed a `Sync` bound on the closure to be wrapped as a Python callable. Older Python releases would have been less likely to observe data races due to partial serial execution imposed by the Global Interpreter Lock. As the Python ecosystem transitions to free-threaded Python, the `Sync` bound is critical for thread safety.

This API is not the primary mechanism by which user code produces Python callables (typically done by `#[pyfunction]` and `#[pymethods]` proc macros), however it seems highly likely that users will have written thread-unsafe code using this API. PyO3 happened to have such a case in its own test suite! (Was using a `RefCell` inside the closure in question.)

## Checklist

- [ ] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [ ] `date` field is set to the public disclosure date
- [ ] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate
