### PR TITLE
add upper bounds to (patched) affected functions in PyO3 nth_back report

### DIFF
--- a/crates/pyo3/RUSTSEC-2026-0176.md
+++ b/crates/pyo3/RUSTSEC-2026-0176.md
@@ -8,10 +8,10 @@ categories = ["memory-exposure"]
 keywords = ["out-of-bounds-read", "integer-overflow"]
 
 [affected.functions]
-"pyo3::types::list::BoundListIterator::nth" = [">= 0.24.0"]
-"pyo3::types::list::BoundListIterator::nth_back" = [">= 0.24.0"]
-"pyo3::types::tuple::BoundTupleIterator::nth" = [">= 0.24.0"]
-"pyo3::types::tuple::BoundTupleIterator::nth_back" = [">= 0.24.0"]
+"pyo3::types::list::BoundListIterator::nth" = [">= 0.24.0, < 0.29.0"]
+"pyo3::types::list::BoundListIterator::nth_back" = [">= 0.24.0, < 0.29.0"]
+"pyo3::types::tuple::BoundTupleIterator::nth" = [">= 0.24.0, < 0.29.0"]
+"pyo3::types::tuple::BoundTupleIterator::nth_back" = [">= 0.24.0, < 0.29.0"]
 
 [versions]
 patched = [">= 0.29.0"]
@@ -34,3 +34,6 @@ of the `list` or `tuple` of elements previously yielded by the iterator.
 In `nth_back` methods, a sufficiently large `n` could cause underflow in a
 similar fashion, however would instead allow reads of arbitrary memory past
 the end of the `list` or `tuple` storage.
+
+PyO3 0.29.0 has corrected these methods to use checked arithmetic at the
+positions which could be at risk of overflow.


### PR DESCRIPTION
With apologies I should have had this detail in #2958 