### PR TITLE
Add advisories for rust-progres (postgres-protocol and tokio-postgres) issues

### DIFF
--- a/crates/postgres-protocol/RUSTSEC-0000-0000.1.md
+++ b/crates/postgres-protocol/RUSTSEC-0000-0000.1.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "postgres-protocol"
+date = "2026-06-12"
+url = "https://github.com/rust-postgres/rust-postgres/commit/a7cf84b5c46431cbca9d8ff50508c23f446efa7d"
+categories = ["denial-of-service"]
+cvss = "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N"
+keywords = ["hstore"]
+
+[affected.functions]
+"postgres_protocol::types::hstore_from_sql" = ["< 0.6.12"]
+
+[versions]
+patched = [">= 0.6.12"]
+```
+
+# Panic decoding a malformed `hstore` value allows denial of service
+
+A malicious or compromised server can return a binary `hstore` value with an
+invalid internal length field, causing the client to panic while decoding it.
+
+Applications that connect only to a trusted database are not exposed; the risk
+applies to clients that may connect to untrusted or user-supplied servers, or
+whose connection can be intercepted by a man-in-the-middle.

--- a/crates/postgres-protocol/RUSTSEC-0000-0000.md
+++ b/crates/postgres-protocol/RUSTSEC-0000-0000.md
@@ -1,0 +1,29 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "postgres-protocol"
+date = "2026-06-12"
+url = "https://github.com/rust-postgres/rust-postgres/commit/d40097a36a85068ea50a3afbf0ce154ba439e7f0"
+references = ["https://github.com/pgjdbc/pgjdbc/security/advisories/GHSA-98qh-xjc8-98pq"]
+categories = ["denial-of-service"]
+cvss = "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
+keywords = ["scram", "pbkdf2"]
+
+[affected.functions]
+"postgres_protocol::authentication::sasl::ScramSha256::update" = ["< 0.6.12"]
+
+[versions]
+patched = [">= 0.6.12"]
+unaffected = ["< 0.3.0"]
+```
+
+# Unbounded SCRAM iteration count allows a malicious server to cause CPU-exhaustion denial of service
+
+A malicious, compromised, or man-in-the-middle server can supply an arbitrarily
+large SCRAM-SHA-256 PBKDF2 iteration count during authentication. The client
+runs it inline with no upper bound, pinning a `tokio` worker thread for minutes
+per connection, possibly stalling the whole async runtime.
+
+Applications that connect only to a trusted database are not exposed; the risk
+applies to clients that may connect to untrusted or user-supplied servers, or
+whose connection can be intercepted by a man-in-the-middle.

--- a/crates/tokio-postgres/RUSTSEC-0000-0000.md
+++ b/crates/tokio-postgres/RUSTSEC-0000-0000.md
@@ -1,0 +1,31 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tokio-postgres"
+date = "2026-06-12"
+url = "https://github.com/rust-postgres/rust-postgres/commit/7a00ffa9ad4d951ec0a4564b52f1780fa9d353c1"
+categories = ["denial-of-service"]
+cvss = "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N"
+keywords = ["datarow"]
+
+[affected.functions]
+"tokio_postgres::Row::get" = ["< 0.7.18"]
+"tokio_postgres::Row::try_get" = ["< 0.7.18"]
+"tokio_postgres::SimpleQueryRow::get" = ["< 0.7.18"]
+"tokio_postgres::SimpleQueryRow::try_get" = ["< 0.7.18"]
+
+[versions]
+patched = [">= 0.7.18"]
+unaffected = ["< 0.4.0"]
+```
+
+# Panic on a `DataRow` with fewer fields than columns allows denial of service
+
+A malicious or compromised server can send a row containing fewer fields than
+its row description declares columns. Reading one of the missing columns then
+panics with an out-of-bounds index, aborting the calling task. This affects even
+the otherwise non-panicking `try_get`, and both `Row` and `SimpleQueryRow`.
+
+Applications that connect only to a trusted database are not exposed; the risk
+applies to clients that may connect to untrusted or user-supplied servers, or
+whose connection can be intercepted by a man-in-the-middle.


### PR DESCRIPTION
## Affected crate(s)

- postgres-protocol (~12.4M recent downloads per crates.io)
- tokio-postgres (~11.8M recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

https://github.com/rust-postgres/rust-postgres/pull/1364

## Severity

Three denial-of-service issues exploitable by a malicious, compromised, or man-in-the-middle PostgreSQL server.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate (I'm the maintainer)
