### PR TITLE
chore: add security advisory for `vibeio-http` chunked encoding DoS

### DIFF
--- a/crates/vibeio-http/RUSTSEC-0000-0000.md
+++ b/crates/vibeio-http/RUSTSEC-0000-0000.md
@@ -1,0 +1,18 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "vibeio-http"
+date = "2026-06-06"
+url = "https://github.com/ferronweb/vibeio-http/blob/main/CHANGELOG.md#vibeio-http-032"
+categories = ["denial-of-service"]
+keywords = ["http", "DoS"]
+
+[versions]
+patched = [">= 0.3.2"]
+```
+
+# DoS vulnerability in HTTP/1.x chunked encoding parser triggered by maliciously crafted chunk lengths
+
+When using the affected versions of the `vibeio-http` crate, an attacker could craft a malicious HTTP/1.x request with a large chunk length (between `usize::MAX - 1` and `usize::MAX` inclusive) and send it, causing the server to crash (integer overflow panic in debug builds, split_to out of bounds panic in release builds).
+
+This was fixed in `vibeio-http` 0.3.2 by erroring on the chunk length if it exceeds `usize::MAX - 2` (using `checked_add()` instead of `+` operator), preventing integer overflow.


### PR DESCRIPTION
## Affected crate(s)

- vibeio-http (7413 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

There was no upstream issue or PR, however there was a commit: https://github.com/ferronweb/vibeio-http/commit/fc704f918c523ef9930842fdaec22c338bf09e5c

## Severity

This vulnerability allows attackers to remotely crash any server that uses affected versions of `vibeio-http` parser, for example using `nc` or `openssl s_client`.

## Checklist

- [X] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [X] `date` field is set to the public disclosure date
- [X] Contains a concise and descriptive title after advisory metadata
- [X] Asked maintainer(s) if publishing an advisory is appropriate
