### PR TITLE
Add advisory for xjbutil ZeroVec unsoundness

### DIFF
--- a/crates/xjbutil/RUSTSEC-0000-0000.md
+++ b/crates/xjbutil/RUSTSEC-0000-0000.md
@@ -1,0 +1,30 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "xjbutil"
+date = "2025-04-23"
+url = "https://github.com/chuigda/xjbutil/issues/4"
+references = [
+    "https://github.com/chuigda/xjbutil/pull/5",
+    "https://github.com/chuigda/xjbutil/commit/68628f33b5e8b79dccb3cacdb26661e985137559"
+]
+informational = "unsound"
+categories = ["memory-corruption"]
+
+[affected.functions]
+"xjbutil::zvec::ZeroVec::get_unchecked" = ["<= 0.9.0-FOXTROT"]
+"xjbutil::zvec::ZeroVec::get_unchecked_mut" = ["<= 0.9.0-FOXTROT"]
+
+[versions]
+patched = []
+```
+
+# `ZeroVec::get_unchecked` and `get_unchecked_mut` may allow out-of-bounds memory access from safe code
+
+`ZeroVec::get_unchecked` and `ZeroVec::get_unchecked_mut` were publicly accessible safe functions. They accepted an arbitrary `idx` and used it directly in unsafe pointer arithmetic with `ptr.add(idx)`.
+
+Affected versions did not check whether `idx` was within bounds before creating a shared or mutable reference from the computed pointer. Safe Rust code could therefore trigger an out-of-bounds read or write by passing an index outside the allocation.
+
+This makes the safe API unsound, since callers can trigger undefined behavior without using `unsafe`.
+
+The upstream repository fixed this by marking both methods as `unsafe` and documenting the caller's safety requirements. No patched version has been published to crates.io yet.


### PR DESCRIPTION
## Affected crate(s)

- `xjbutil` (401 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- Upstream issue: https://github.com/chuigda/xjbutil/issues/4
- Fix PR: https://github.com/chuigda/xjbutil/pull/5
- Fix commit: https://github.com/chuigda/xjbutil/commit/68628f33b5e8b79dccb3cacdb26661e985137559

## Severity

Soundness issue in a safe public API. `ZeroVec::get_unchecked` and `ZeroVec::get_unchecked_mut` accepted an arbitrary index and used it in unchecked pointer arithmetic. Safe callers could trigger out-of-bounds reads or writes without using `unsafe`.

The fix has been merged upstream, but no patched version has been published to crates.io yet.


## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate
