### PR TITLE
Add advisory for jomini BufferWindow unsoundness

### DIFF
--- a/crates/jomini/RUSTSEC-0000-0000.md
+++ b/crates/jomini/RUSTSEC-0000-0000.md
@@ -1,0 +1,38 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "jomini"
+date = "2025-04-24"
+url = "https://github.com/rakaly/jomini/issues/178"
+references = [
+    "https://github.com/rakaly/jomini/pull/179",
+    "https://github.com/rakaly/jomini/commit/1f68766666aecdb3cfb99527240f2e4305b7104b"
+]
+informational = "unsound"
+
+[versions]
+patched = [">= 0.29.0"]
+```
+
+# `BufferWindow` safe methods relied on insufficiently encapsulated pointer invariants
+
+Affected versions of `jomini` used `BufferWindow` to track a window into
+an underlying byte buffer using raw pointers, including `start_buf`,`start`,
+and `end`.
+
+Several safe methods performed unsafe pointer and slice operations based on
+these fields. These operations included pointer arithmetic with `add`,
+pointer-distance calculations with `offset_from`, and slice construction with
+`from_raw_parts`.
+
+The safety of these operations relied on internal invariants, including that
+the pointers belonged to the same allocation, that `start` did not advance
+past `end`, and that constructed slices remained within a valid readable
+range. These invariants were not fully checked by the methods themselves and
+were exposed across multiple internal modules.
+
+The affected type was internal to the crate. The issue was addressed by making the intended 
+crate-internal visibility explicit and by moving direct slice construction 
+in the binary and text readers behind a `BufferWindow::split` helper.
+
+The issue was fixed in `jomini` version 0.29.0. 


### PR DESCRIPTION
## Affected crate(s)

- `jomini`

## Links to upstream issue(s) or PR(s)

- Upstream issue: https://github.com/rakaly/jomini/issues/178
- Fix PR: https://github.com/rakaly/jomini/pull/179
- Fix commit: https://github.com/rakaly/jomini/commit/1f68766666aecdb3cfb99527240f2e4305b7104b

## Severity

This is proposed as an informational unsound advisory.

Although `BufferWindow` was crate-internal, it was used internally by public 
reader APIs, and its safe methods performed unsafe pointer and slice operations 
that depended on internal invariants. If those invariants were broken, 
these operations could cause undefined behavior.

No concrete malformed-input path has been identified, so the advisory is
intentionally scoped conservatively. The issue was fixed in `jomini` 0.29.0.

I would appreciate feedback on whether this crate-internal pointer-invariant
issue is appropriate for an informational RustSec advisory.


## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate
