### PR TITLE
Add advisory for hugepage-rs dealloc unsoundness

### DIFF
--- a/crates/hugepage-rs/RUSTSEC-0000-0000.md
+++ b/crates/hugepage-rs/RUSTSEC-0000-0000.md
@@ -1,0 +1,31 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "hugepage-rs"
+date = "2025-04-24"
+url = "https://github.com/cppcoffee/hugepage-rs/issues/5"
+references = [
+    "https://github.com/cppcoffee/hugepage-rs/pull/6",
+    "https://github.com/cppcoffee/hugepage-rs/commit/2b30bdf227f39b1c9ed7af16ea0cc3957f88da18"
+]
+informational = "unsound"
+categories = ["memory-corruption"]
+
+[affected.functions]
+"hugepage_rs::dealloc" = ["<= 0.1.0"]
+
+[versions]
+patched = [">= 0.1.1"]
+```
+
+# `hugepage_rs::dealloc` may allow invalid memory deallocation from safe code
+
+`hugepage_rs::dealloc` was a publicly accessible safe function. It accepted an arbitrary raw pointer and `Layout`, then forwarded them to the hugepage allocator's `GlobalAlloc::dealloc` implementation.
+
+`GlobalAlloc::dealloc` requires callers to ensure that the pointer denotes a block of memory currently allocated by the allocator and that the layout is the same layout used for the allocation. The safe wrapper neither verified these requirements nor marked them as
+unsafe preconditions for callers.
+
+Affected versions therefore allowed safe Rust code to call `dealloc` with an invalid pointer, a pointer not allocated by the hugepage allocator, or an incorrect layout, which could cause undefined behavior.
+
+The upstream repository fixed this in version `0.1.1` by marking `dealloc` as unsafe and documenting the caller's safety requirements.
+


### PR DESCRIPTION
## Affected crate(s)

- `hugepage-rs` (5,405 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- Upstream issue: https://github.com/cppcoffee/hugepage-rs/issues/5
- Fix PR: https://github.com/cppcoffee/hugepage-rs/pull/6
- Fix commit: https://github.com/cppcoffee/hugepage-rs/commit/2b30bdf227f39b1c9ed7af16ea0cc3957f88da18

## Severity

Soundness issue in a safe public API. `hugepage_rs::dealloc` accepted an arbitrary raw pointer and `Layout`, then forwarded them to `GlobalAlloc::dealloc`, whose safety contract requires the pointer and layout to match an allocation from the same allocator.

Safe callers could therefore trigger undefined behavior without using `unsafe`.

The issue was fixed upstream by marking `dealloc` as `unsafe`, and the fix has been published in `0.1.1`.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate