### PR TITLE
Add advisory for capnp unsoundness

### DIFF
--- a/crates/capnp/RUSTSEC-0000-0000.md
+++ b/crates/capnp/RUSTSEC-0000-0000.md
@@ -1,0 +1,35 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "capnp"
+date = "2026-06-15"
+url = "https://github.com/capnproto/capnproto-rust/issues/667"
+categories = ["memory-corruption"]
+keywords = ["unsoundness", "undefined-behavior"]
+related = ["RUSTSEC-2025-0143"]
+
+[affected.functions]
+"capnp::schema::EnumSchema::new" = ["< 0.26.0"]
+
+[versions]
+patched = [">= 0.26.0"]
+```
+
+# Unsound API of public `EnumSchema`
+
+The safe API function `EnumSchema::new` relies on `PointerReader::get_root_unchecked`, 
+which can cause undefined behavior by constructing arbitrary words or schemas.
+
+## `EnumSchema::new`
+
+```rust
+pub fn new(raw: RawEnumSchema) -> Self {
+    // ...
+    // UNSAFE: access encoded node without validation
+}
+```
+
+This vulnerability allows safe Rust code to trigger undefined behavior, which violates Rust's safety guarantees.
+
+The issue is resolved in version 0.26.0 by making the RawEnumSchema fields crate-visible and using get_root_from_arena instead of get_root_unchecked.
+


### PR DESCRIPTION
## Affected crate(s)

- capnp

## Links to upstream issue(s) or PR(s)
- https://github.com/capnproto/capnproto-rust/issues/667

<!-- In principle, we do not publish advisories for issues that have
     not been reported upstream. -->

## Severity
- Unsoundness of safe public API
<!-- Briefly describe the risk and potential effect of the vulnerability.
     For example: allows remote denial-of-service via stack exhaustion,
     or: use-after-free that can lead to arbitrary code execution. -->

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate

## Comment
This issue has the same underlying cause as RUSTSEC-2025-0143, but it was found in a different API that is not mentioned in the existing advisory.

I would appreciate guidance from the maintainer on whether this would be more appropriately handled as an update to the existing advisory, or as a separate advisory linked through related.

Based on my current understanding of the guidance, I have marked this issue as related by adding `related = ["RUSTSEC-2025-0143"]`, but I would be happy to adjust it if the maintainers recommend a different way to handle this .