### PR TITLE
Add advisory for git2: DiffBinaryFile::data() for empty data triggers UB

### DIFF
--- a/crates/git2/RUSTSEC-0000-0000.md
+++ b/crates/git2/RUSTSEC-0000-0000.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "git2"
+date = "2026-06-12"
+url = "https://github.com/rust-lang/git2-rs/pull/1279"
+informational = "unsound"
+keywords = ["git2"]
+
+[versions]
+patched = ["> 0.21.0"]
+```
+
+# Potential undefined behavior when calling DiffBinaryFile::data()
+
+Git diffs with binary file changes do not always include the raw data of such changes, but sometimes just report *that* a change was made (e.g. with a line `Binary files /dev/null and b/binary.pdf differ` for a new file addition). When examining such a diff, `DiffBinaryFile::data()` caused git2 to pass a null pointer to the unsafe function `slice::from_raw_parts()`. Based on the safety section documentation of function, data must be non-null even for slices of length zero. Thus, the use of a null pointer leads to undefined behavior.


### PR DESCRIPTION
## Affected crate(s)

- git2

## Links to upstream issue(s) or PR(s)

rust-lang/git2-rs#1278, rust-lang/git2-rs#1279

## Severity

Low? Potential UB from misuse of an unsafe function

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [ ] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate
