### PR TITLE
CVE-2019-16760.md: update gist link

### DIFF
--- a/rust/cargo/CVE-2019-16760.md
+++ b/rust/cargo/CVE-2019-16760.md
@@ -111,5 +111,5 @@ with our [security policy][5].
 [1]: https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html#cargo-features
 [2]: https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#renaming-dependencies-in-cargotoml
 [3]: https://github.com/rust-lang/cargo/pull/4953
-[4]: https://gist.github.com/pietroalbini/0d293b24a44babbeb6187e06eebd4992
+[4]: https://gist.github.com/emilyalbini/0d293b24a44babbeb6187e06eebd4992
 [5]: https://www.rust-lang.org/policies/security


### PR DESCRIPTION
CC @emilyalbini
@djc should links to individual gists to replaced with copies so that they don't break in the future?