### PR TITLE
Add advisory for `structopt`: unmaintained (really in "maintenance mode", migration to clap recommended)

### DIFF
--- a/crates/structopt/RUSTSEC-0000-0000.md
+++ b/crates/structopt/RUSTSEC-0000-0000.md
@@ -6,8 +6,7 @@ date = "2022-02-08"
 url = "https://github.com/TeXitoi/structopt#maintenance"
 references = ["https://github.com/TeXitoi/structopt/issues/525"]
 informational = "unmaintained"
-# 'unmaintained' advisories for crates in the dependency tree of `structopt`
-related = ["RUSTSEC-2021-0139","RUSTSEC-2024-0370","RUSTSEC-2024-0375"]
+related = []
 license = "CC0-1.0"
 
 [versions]
@@ -16,7 +15,7 @@ patched = []
 
 # `structopt` is in maintenance mode
 
-`structopt` has been in maintenance mode, with no new development planned, since at least February of 2022. Several dependencies of `structopt` ([`ansi_term`][RUSTSEC-2021-0139], [`proc-macro-error`][RUSTSEC-2024-0370], and [`attty`][RUSTSEC-2024-0375]) are considered unmaintained.
+`structopt` has been in maintenance mode, with no new development planned, since at least February of 2022.
 
 The status of `structopt` is discussed in a [pinned issue](https://github.com/TeXitoi/structopt/issues/525).
 

--- a/crates/structopt/RUSTSEC-0000-0000.md
+++ b/crates/structopt/RUSTSEC-0000-0000.md
@@ -1,0 +1,30 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "structopt"
+date = "2026-06-17"
+url = "https://github.com/TeXitoi/structopt#maintenance"
+references = ["https://github.com/TeXitoi/structopt/issues/525"]
+informational = "unmaintained"
+# 'unmaintained' advisories for crates in the dependency tree of `structopt`
+related = ["RUSTSEC-2021-0139","RUSTSEC-2024-0370","RUSTSEC-2024-0375"]
+license = "CC0-1.0"
+
+[versions]
+patched = []
+```
+
+# `structopt` is in maintenance mode
+
+`structopt` has been in maintenance mode, with no new development planned, since at least February of 2022. Several dependencies of `structopt` ([`ansi_term`][RUSTSEC-2021-0139], [`proc-macro-error`][RUSTSEC-2024-0370], and [`attty`][RUSTSEC-2024-0375]) are considered unmaintained.
+
+The status of `structopt` is discussed in a [pinned issue](https://github.com/TeXitoi/structopt/issues/525).
+
+## Recommended alternative
+
+The `structopt` derive wrapper was incorporated into `clap` v3. There is [a migration guide][clap-migration] for switching from `structopt` to `clap`.
+
+[RUSTSEC-2021-0139]: https://rustsec.org/advisories/RUSTSEC-2021-0139.html
+[RUSTSEC-2024-0370]: https://rustsec.org/advisories/RUSTSEC-2024-0370.html
+[RUSTSEC-2024-0375]: https://rustsec.org/advisories/RUSTSEC-2024-0375.html
+[clap-migration]: https://github.com/clap-rs/clap/blob/v4.6.0/CHANGELOG.md#migrating-1

--- a/crates/structopt/RUSTSEC-0000-0000.md
+++ b/crates/structopt/RUSTSEC-0000-0000.md
@@ -23,7 +23,4 @@ The status of `structopt` is discussed in a [pinned issue](https://github.com/Te
 
 The `structopt` derive wrapper was incorporated into `clap` v3. There is [a migration guide][clap-migration] for switching from `structopt` to `clap`.
 
-[RUSTSEC-2021-0139]: https://rustsec.org/advisories/RUSTSEC-2021-0139.html
-[RUSTSEC-2024-0370]: https://rustsec.org/advisories/RUSTSEC-2024-0370.html
-[RUSTSEC-2024-0375]: https://rustsec.org/advisories/RUSTSEC-2024-0375.html
 [clap-migration]: https://github.com/clap-rs/clap/blob/v4.6.0/CHANGELOG.md#migrating-1

--- a/crates/structopt/RUSTSEC-0000-0000.md
+++ b/crates/structopt/RUSTSEC-0000-0000.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "structopt"
-date = "2026-06-17"
+date = "2022-02-08"
 url = "https://github.com/TeXitoi/structopt#maintenance"
 references = ["https://github.com/TeXitoi/structopt/issues/525"]
 informational = "unmaintained"


### PR DESCRIPTION
Resolves #2975.

## Affected crate(s)

- `structopt`

## Links to upstream issue(s) or PR(s)

- https://github.com/TeXitoi/structopt/issues/525

## Severity

Unmaintained; no actual security risk known.

Depends on several other crates that already have "unmaintained" advisories.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date [date of the opening of the pinned "unmaintained" issue; I hope this is correct]
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate - yes, but did not wait to hear back. When discussed in early 2022, they weren't sure rustsec was the right place for "unmaintained" advisories.
