### PR TITLE
Add advisory for lopdf: stack overflow via deeply nested PDF objects

### DIFF
--- a/crates/lopdf/RUSTSEC-0000-0000.md
+++ b/crates/lopdf/RUSTSEC-0000-0000.md
@@ -1,0 +1,43 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "lopdf"
+date = "2026-06-21"
+categories = ["denial-of-service"]
+keywords = ["dos", "stack-overflow", "recursion", "untrusted-input", "pdf"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+references = ["https://github.com/J-F-Liu/lopdf"]
+
+[versions]
+patched = []
+```
+
+# Stack overflow in lopdf via deeply nested PDF objects
+
+`lopdf::Document::load_mem` (and the other `load*` entry points) parses nested PDF arrays and
+dictionaries with unbounded recursion. A small crafted PDF whose Catalog contains a deeply nested
+array (`/X [[[ … ]]]`, on the order of 10,000 levels) exhausts the call stack and aborts the
+process with `SIGABRT`.
+
+Because this is a stack-overflow abort rather than a `panic!`, it cannot be caught with
+`catch_unwind`: any service that parses untrusted PDF input with lopdf can be crashed by a
+~21 KB file, resulting in a denial of service.
+
+Re-confirmed on lopdf 0.41.0 (latest at time of writing). Default configuration, no features
+changed.
+
+## Proof of concept
+
+```rust
+fn main() {
+    let bytes = std::fs::read("poc.pdf").unwrap(); // ~10,380-deep nested array in the Catalog
+    let _ = lopdf::Document::load_mem(&bytes);     // stack overflow -> SIGABRT
+}
+```
+
+An equivalent PoC is a minimal PDF whose Catalog `/X` value is `"[" * 10380 + "]" * 10380`.
+
+## Suggested fix
+
+Enforce a maximum object-nesting depth in the parser and return an `Err` instead of recursing
+without bound.

--- a/crates/lopdf/RUSTSEC-0000-0000.md
+++ b/crates/lopdf/RUSTSEC-0000-0000.md
@@ -6,25 +6,20 @@ date = "2026-06-21"
 categories = ["denial-of-service"]
 keywords = ["dos", "stack-overflow", "recursion", "untrusted-input", "pdf"]
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
-references = ["https://github.com/J-F-Liu/lopdf"]
+references = ["https://github.com/J-F-Liu/lopdf/issues/502", "https://github.com/J-F-Liu/lopdf/pull/503", "https://github.com/J-F-Liu/lopdf/commit/c755394"]
 
 [versions]
+# Fix merged to main in c755394 (PR #503); update to ">= X.Y.Z" once released to crates.io.
 patched = []
 ```
 
 # Stack overflow in lopdf via deeply nested PDF objects
 
-`lopdf::Document::load_mem` (and the other `load*` entry points) parses nested PDF arrays and
-dictionaries with unbounded recursion. A small crafted PDF whose Catalog contains a deeply nested
-array (`/X [[[ … ]]]`, on the order of 10,000 levels) exhausts the call stack and aborts the
-process with `SIGABRT`.
+`lopdf::Document::load_mem` (and the other `load*` entry points) parses nested PDF arrays and dictionaries with unbounded recursion. A small crafted PDF whose Catalog contains a deeply nested array (`/X [[[ … ]]]`, on the order of 10,000 levels) exhausts the call stack and aborts the process with `SIGABRT`.
 
-Because this is a stack-overflow abort rather than a `panic!`, it cannot be caught with
-`catch_unwind`: any service that parses untrusted PDF input with lopdf can be crashed by a
-~21 KB file, resulting in a denial of service.
+Because this is a stack-overflow abort rather than a `panic!`, it cannot be caught with `catch_unwind`: any service that parses untrusted PDF input with lopdf can be crashed by a ~21 KB file, resulting in a denial of service.
 
-Re-confirmed on lopdf 0.41.0 (latest at time of writing). Default configuration, no features
-changed.
+Re-confirmed on lopdf 0.41.0 (latest at time of writing). Default configuration, no features changed.
 
 ## Proof of concept
 
@@ -39,5 +34,4 @@ An equivalent PoC is a minimal PDF whose Catalog `/X` value is `"[" * 10380 + "]
 
 ## Suggested fix
 
-Enforce a maximum object-nesting depth in the parser and return an `Err` instead of recursing
-without bound.
+Enforce a maximum object-nesting depth in the parser and return an `Err` instead of recursing without bound.

--- a/crates/lopdf/RUSTSEC-0000-0000.md
+++ b/crates/lopdf/RUSTSEC-0000-0000.md
@@ -9,8 +9,7 @@ cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 references = ["https://github.com/J-F-Liu/lopdf/issues/502", "https://github.com/J-F-Liu/lopdf/pull/503", "https://github.com/J-F-Liu/lopdf/commit/c755394"]
 
 [versions]
-# Fix merged to main in c755394 (PR #503); update to ">= X.Y.Z" once released to crates.io.
-patched = []
+patched = [">= 0.42.0"]
 ```
 
 # Stack overflow in lopdf via deeply nested PDF objects
@@ -19,7 +18,7 @@ patched = []
 
 Because this is a stack-overflow abort rather than a `panic!`, it cannot be caught with `catch_unwind`: any service that parses untrusted PDF input with lopdf can be crashed by a ~21 KB file, resulting in a denial of service.
 
-Re-confirmed on lopdf 0.41.0 (latest at time of writing). Default configuration, no features changed.
+Confirmed on lopdf 0.41.0 and earlier; fixed in 0.42.0. Default configuration, no features changed.
 
 ## Proof of concept
 


### PR DESCRIPTION
## Affected crate(s)

- lopdf (5,196,354 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/J-F-Liu/lopdf/issues/502

## Severity

Remote denial-of-service via stack exhaustion. `Document::load_mem` recurses without bound on nested PDF arrays/dictionaries; a ~21 KB PDF whose Catalog contains a ~10,380-deep nested array overflows the stack and aborts the process (SIGABRT) on lopdf 0.41.0. The abort is not catchable with `catch_unwind`, so any service parsing untrusted PDFs can be crashed.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
