### PR TITLE
Add advisory for psd: panic via out-of-bounds slice on crafted PSD

### DIFF
--- a/crates/psd/RUSTSEC-0000-0000.md
+++ b/crates/psd/RUSTSEC-0000-0000.md
@@ -1,0 +1,40 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "psd"
+date = "2026-06-21"
+categories = ["denial-of-service"]
+keywords = ["dos", "panic", "out-of-bounds", "untrusted-input", "psd"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+references = ["https://github.com/chinedufn/psd"]
+
+[versions]
+patched = []
+```
+
+# Panic via out-of-bounds slice in `psd` when parsing a crafted PSD file
+
+`Psd::from_bytes` slices the image-data section using a length taken from the file header without
+validating it against the actual remaining buffer length. A 54-byte crafted PSD triggers an
+out-of-bounds slice and panics in `src/sections/mod.rs`
+(`range end index 18 out of range for slice of length 16`).
+
+A caller that parses untrusted PSD input and does not wrap the call in `catch_unwind` will have
+the panicking thread torn down (and, in a single-threaded program or under `panic = "abort"`,
+the whole process), so this is a denial of service on untrusted input.
+
+Re-confirmed on `psd` 0.3.5 (latest at time of writing), default configuration.
+
+## Proof of concept
+
+```rust
+fn main() {
+    let bytes = std::fs::read("poc.psd").unwrap(); // 54-byte crafted PSD
+    let _ = psd::Psd::from_bytes(&bytes);          // panic: range end index out of range
+}
+```
+
+## Suggested fix
+
+Bounds-check the declared section length against the remaining buffer before slicing, and return
+`Err(PsdError)` instead of indexing out of range.


### PR DESCRIPTION
## Affected crate(s)

- psd (20,138 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/chinedufn/psd/issues/70

## Severity

Denial-of-service via panic. `Psd::from_bytes` slices the image-data section using an unvalidated header length; a 54-byte crafted PSD triggers an out-of-bounds slice and panics in `src/sections/mod.rs` on psd 0.3.5. A caller parsing untrusted PSD input without `catch_unwind` has the thread (or process) torn down.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
