### PR TITLE
Add advisory for hftbacktest DataPtr::at unsoundness

### DIFF
--- a/crates/hftbacktest/RUSTSEC-0000-0000.md
+++ b/crates/hftbacktest/RUSTSEC-0000-0000.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "hftbacktest"
+date = "2025-04-24"
+url = "https://github.com/nkaz001/hftbacktest/issues/212"
+references = ["https://github.com/nkaz001/hftbacktest/commit/69474f8c684db0c304cc885240c8ba5722af68b2"]
+informational = "unsound"
+
+[affected.functions]
+"hftbacktest::backtest::data::DataPtr::at" = ["< 0.8.1"]
+
+[versions]
+patched = [">= 0.8.1"]
+```
+
+# `DataPtr::at` may create out-of-bounds pointers from safe code
+In affected versions, `DataPtr::at` was a publicly accessible safe function that accepted an arbitrary `index` and used it directly in `ptr.add(index)`.
+
+The safety contract of `ptr.add` requires the resulting pointer to remain within, or one past the end of, the same allocated object. Because `DataPtr::at` did not verify the supplied index, safe callers could provide an out-of-bounds offset and violate the safety requirements of the pointer arithmetic, resulting in undefined behavior.
+
+The issue was fixed in version `0.8.1` by marking `DataPtr::at` as `unsafe`, making callers responsible for upholding the pointer arithmetic safety requirements.
+
+


### PR DESCRIPTION
## Affected crate(s)

- `hftbacktest` (597 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- Upstream issue: https://github.com/nkaz001/hftbacktest/issues/212
- Fix commit: https://github.com/nkaz001/hftbacktest/commit/69474f8c684db0c304cc885240c8ba5722af68b2

## Severity

Soundness issue in a safe public API. `DataPtr::at` accepted an arbitrary index and used it in unsafe pointer arithmetic via `ptr.add(index)`. Safe callers could pass an out-of-bounds index and trigger undefined behavior without using `unsafe`.

The issue was fixed upstream by marking `DataPtr::at` as `unsafe`. The fix is included in `hftbacktest` version `0.8.1`.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate
