### PR TITLE
Add advisory for stainless_ffmpeg FormatContext stream_index unsoundness

### DIFF
--- a/crates/stainless_ffmpeg/RUSTSEC-0000-0000.md
+++ b/crates/stainless_ffmpeg/RUSTSEC-0000-0000.md
@@ -1,0 +1,28 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "stainless_ffmpeg"
+date = "2025-04-24"
+url = "https://github.com/nomalab/stainless-ffmpeg/issues/63"
+references = [
+    "https://github.com/nomalab/stainless-ffmpeg/pull/64",
+    "https://github.com/nomalab/stainless-ffmpeg/commit/a649e8cb4e7c9859279d1dc85051df5e7a4932f7"
+]
+informational = "unsound"
+
+[affected.functions]
+"stainless_ffmpeg::format_context::FormatContext::get_stream" = ["< 0.6.0"]
+"stainless_ffmpeg::format_context::FormatContext::get_stream_type" = ["< 0.6.0"]
+"stainless_ffmpeg::format_context::FormatContext::get_stream_type_name" = ["< 0.6.0"]
+"stainless_ffmpeg::format_context::FormatContext::get_codec_id" = ["< 0.6.0"]
+
+[versions]
+patched = [">= 0.6.0"]
+```
+
+# `FormatContext` stream accessors can cause undefined behavior from safe code
+
+Affected versions of `stainless_ffmpeg` exposed several safe public methods on `FormatContext` that accepted a `stream_index` parameter and used it in unsafe pointer operations without checking whether the index was valid. These methods performed pointer arithmetic and dereferenced the resulting stream pointer. Safe callers could pass a negative or out-of-bounds `stream_index`, which could cause out-of-bounds pointer access and undefined behavior from safe Rust code.
+
+The issue was fixed in version `0.6.0` by marking the affected stream accessor methods as `unsafe` and documenting that callers must ensure `stream_index` is a valid stream index.
+


### PR DESCRIPTION
## Affected crate(s)

- `stainless_ffmpeg` (634 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- Upstream issue: https://github.com/nomalab/stainless-ffmpeg/issues/63
- Fix PR: https://github.com/nomalab/stainless-ffmpeg/pull/64
- Fix commit: https://github.com/nomalab/stainless-ffmpeg/commit/a649e8cb4e7c9859279d1dc85051df5e7a4932f7

## Severity

This advisory classifies the issue as informational `unsound`. Affected versions exposed safe public `FormatContext` methods that accepted a `stream_index` parameter and used it in unsafe pointer operations without checking whether the index was valid. Safe callers could pass a negative or out-of-bounds `stream_index`, which could trigger undefined behavior without using `unsafe`.

The issue was fixed upstream in `0.6.0` by marking the affected methods as `unsafe` and documenting the caller's safety requirement.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate
