### PR TITLE
quinn-proto: remote memory exhaustion

### DIFF
--- a/crates/quinn-proto/RUSTSEC-0000-0000.md
+++ b/crates/quinn-proto/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "quinn-proto"
+date = "2026-06-22"
+url = "https://github.com/quinn-rs/quinn/pull/2694"
+categories = ["denial-of-service"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+keywords = ["oom"]
+aliases = ["GHSA-4w2j-m93h-cj5j"]
+
+[versions]
+patched = [">= 0.11.15"]
+```
+
+#  Remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly
+
+The `Assembler` component that assembles unordered stream fragments into consecutive chunks of the
+stream incurs some overhead for non-contiguous fragments. Readers that read from a RecvStream in
+order (through an `AsyncRead` impl for example) will be sensitive to peers that send fragments
+while leaving out early parts of the stream, and in particular, fragments with many gaps (because
+these cannot be defragmented). In such a scenario, the receiving connection suffers from high
+buffer overhead, enabling memory exhaustion.


### PR DESCRIPTION
## Affected crate(s)

- quinn-proto (67M recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/quinn-rs/quinn/pull/2694

## Severity

Remote memory exhaustion due to lack of restrictions on fragmented stream frames.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate (I am the maintainer)
