### PR TITLE
Add advisory for i_triangle unsound triangle accessors

### DIFF
--- a/crates/i_triangle/RUSTSEC-0000-0000.md
+++ b/crates/i_triangle/RUSTSEC-0000-0000.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "i_triangle"
+date = "2025-04-24"
+url = "https://github.com/iShape-Rust/iTriangle/issues/4"
+references = [
+    "https://github.com/iShape-Rust/iTriangle/commit/13e0e9f4d5333e3a815191e5f6f402641997f91b"
+]
+informational = "unsound"
+
+[affected.functions]
+"i_triangle::delaunay::triangle::DTriangle::neighbor_by_order" = [">= 0.24.0", "< 0.29.0"]
+"i_triangle::delaunay::triangle::DTriangle::vertex_by_order" = [">= 0.24.0", "< 0.29.0"]
+
+[versions]
+patched = [">= 0.29.0"]
+```
+
+# `DTriangle` accessors may read out of bounds in affected versions
+
+In affected versions, `DTriangle::neighbor_by_order` and `DTriangle::vertex_by_order` were public safe functions that accepted an
+arbitrary `order` value. These functions used `order` to access fixed-size internal arrays with `get_unchecked`, without checking whether `order` was within bounds. Calling these methods with an out-of-bounds `order` could cause an out-of-bounds read from safe Rust code. This made the old APIs unsound, since safe callers could trigger undefined behavior without using `unsafe`.
+
+The issue was fixed in version `0.29.0` as part of a broader rewrite that replaced the old triangle implementation with `IntTriangle` and removed the affected accessor methods.


### PR DESCRIPTION
## Affected crate(s)

- `i_triangle` (4094 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- Upstream issue: https://github.com/iShape-Rust/iTriangle/issues/4
- Rewrite commit: https://github.com/iShape-Rust/iTriangle/commit/13e0e9f4d5333e3a815191e5f6f402641997f91b
- Maintainer confirmation: https://github.com/iShape-Rust/iTriangle/issues/4#issuecomment-4768078301

## Severity

This advisory classifies the issue as informational `unsound`. In the affected versions, `DTriangle::neighbor_by_order` and `DTriangle::vertex_by_order` were public safe functions that accepted an arbitrary `order` value and used it with `get_unchecked` to access fixed-size internal arrays. Calling these methods with an out-of-bounds `order` could cause an out-of-bounds read from safe Rust code.

The affected APIs were removed in `0.29.0` as part of a broader rewrite that replaced the old triangle implementation with `IntTriangle`.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate