### PR TITLE
Added RwLock advisory for spin

### DIFF
--- a/crates/spin/RUSTSEC-0000-0000.md
+++ b/crates/spin/RUSTSEC-0000-0000.md
@@ -1,0 +1,35 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "spin"
+date = "2026-06-24"
+url = "https://codeberg.org/zesterer/spin/issues/189"
+
+# URL to additional helpful references regarding the advisory (optional)
+references = ["https://github.com/mystuff/mycrate/discussions/1"]
+
+informational = "unsound"
+categories = ["thread-safety"]
+keywords = ["soundness", "guard", "data race", "lock"]
+
+[affected.functions]
+"spin::RwLock::try_upgrade" = ["< 0.12.1, >= 0.6.0"]
+
+[versions]
+patched = [">= 0.12.1"]
+unaffected = ["< 0.6.0"]
+```
+
+# Premature release of lock state in `<spin::RwLock as lock_api::RawRwLockUpgrade>::try_upgrade` allows simultaneous shared and mutable aliasing
+
+The `<spin::RwLock as lock_api::RawRwLockUpgrade>::try_upgrade` function is unsound due
+to an undue guard drop, which causes the contents of the `RwLock` to be unprotected by
+the lock guard on the failure path.
+
+Note that this unsoundness only affects you if all of the following apply:
+
+  - You use `RwLock` via the `lock_api` interface specifically
+  - You call `upgradable_read` to create an upgradeable lock guard
+  - You call `try_upgrade` on the upgradeable lock guard
+
+This issue is unlikely to affect the vasty majority of crate users.


### PR DESCRIPTION
## Affected crate(s)

- `spin` (96,170,945 recent downloads)

## Links to upstream issue(s) or PR(s)

https://codeberg.org/zesterer/spin/issues/189

## Severity

While the potential severity of the issue is high (undue guard drop logic being run causes guarded data to be exposed outside of a critical section), the practical severity is medium-low: the code path is incredibly seldom used, perhaps not by anybody, which explains why it took almost 6 years for the issue to be discovered.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
