### PR TITLE
create rustsec advisory for wasmtime-wasi crate: wasmtime project's GHSA-4ch3-9j33-3pmj

### DIFF
--- a/crates/wasmtime-wasi/RUSTSEC-0000-0000.md
+++ b/crates/wasmtime-wasi/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "wasmtime-wasi"
+date = "2026-06-24"
+url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-4ch3-9j33-3pmj"
+categories = []
+keywords = []
+aliases = ["GHSA-4ch3-9j33-3pmj"]
+license = "CC0-1.0"
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:N/I:H/A:N"
+
+[versions]
+patched = [">= 46.0.1", ">= 45.0.3, < 46.0.0", ">= 36.0.12, < 37.0.0", ">= 24.0.11, < 25.0.0"]
+unaffected = []
+```
+
+# WASI hard links and renames bypass wasmtime-wasi's FilePerms for destination
+
+This is an entry in the RustSec database for the Wasmtime security advisory
+located at
+https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-4ch3-9j33-3pmj
+For more information see the GitHub-hosted security advisory.


### PR DESCRIPTION

## Affected crate(s)

- wasmtime-wasi (7,781,543)

## Links to upstream issue(s) or PR(s)

Fix in main https://github.com/bytecodealliance/wasmtime/pull/13725
which contains links to all of the backports to release branches.

Security Advisory https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-4ch3-9j33-3pmj

## Severity

Filesystem access control: bug permits write access to existing files in the filesystem where wasmtime-wasi was configured to provide read-only access, when wasmtime also provides a directory configured as read-write.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
