### PR TITLE
Add advisory for bitm RankSimple unsoundness

### DIFF
--- a/crates/bitm/RUSTSEC-0000-0000.md
+++ b/crates/bitm/RUSTSEC-0000-0000.md
@@ -1,0 +1,27 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "bitm"
+date = "2025-05-22"
+url = "https://github.com/beling/bsuccinct-rs/issues/10"
+references = [
+    "https://github.com/beling/bsuccinct-rs/commit/f281461b9167a9a448d1f3ce24eec27d847521b2",
+]
+informational = "unsound"
+
+[affected.functions]
+"bitm::RankSimple::try_rank" = ["< 0.5.2"]
+
+[versions]
+patched = [">= 0.5.2"]
+```
+
+# `RankSimple::try_rank` may read out of bounds due to public fields
+
+In affected versions, `bitm::RankSimple` exposed its `content` and `ranks` fields publicly. The safe method `try_rank` relies on an internal invariant established by `RankSimple::build`: `ranks` is sized to match `content`.
+
+Because the fields were public, safe code could modify `ranks` independently after construction and break this invariant. `try_rank` first checked bounds against `content`, but then used `get_unchecked` to access `ranks`. If `ranks` had been replaced with a shorter array, calling `try_rank` could perform an out-of-bounds read.
+
+Calling `slice::get_unchecked` with an out-of-bounds index is undefined behavior. Since this could be triggered through a safe public API, the affected versions were unsound.
+
+The issue was fixed in `0.5.2` by making the `content` and `ranks` fields private.


### PR DESCRIPTION
## Affected crate(s)

- `bitm` (129557 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- Upstream issue: https://github.com/beling/bsuccinct-rs/issues/10
- Fix commit: https://github.com/beling/bsuccinct-rs/commit/f281461b9167a9a448d1f3ce24eec27d847521b2

## Severity

Soundness issue in a safe public API. In affected versions, safe code could violate `RankSimple`'s internal invariants and cause `try_rank` to perform an out-of-bounds `get_unchecked` read, which is undefined behavior.

The issue has been fixed in `0.5.2` by making the `RankSimple` fields private.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate
