### PR TITLE
Add advisory for rmcp DNS rebinding

### DIFF
--- a/crates/rmcp/RUSTSEC-0000-0000.md
+++ b/crates/rmcp/RUSTSEC-0000-0000.md
@@ -1,0 +1,51 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rmcp"
+date = "2026-04-29"
+url = "https://github.com/modelcontextprotocol/rust-sdk/security/advisories/GHSA-89vp-x53w-74fx"
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+keywords = ["dns-rebinding", "mcp", "http"]
+aliases = ["CVE-2026-42559", "GHSA-89vp-x53w-74fx"]
+related = ["RUSTSEC-2026-0140", "GHSA-fvh2-gm75-j4j7"]
+references = [
+    "https://github.com/modelcontextprotocol/rust-sdk/pull/764",
+    "https://github.com/modelcontextprotocol/rust-sdk/issues/815",
+    "https://github.com/modelcontextprotocol/rust-sdk/issues/822",
+    "https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#security-warning",
+]
+
+[versions]
+patched = [">= 1.4.0"]
+```
+
+# DNS rebinding vulnerability in rmcp Streamable HTTP server transport
+
+Prior to version 1.4.0, the `rmcp` crate's Streamable HTTP server transport did
+not validate the incoming `Host` header.
+
+This allowed a malicious public website, via a DNS rebinding attack, to send
+requests to an MCP server running on the victim's loopback or private-network
+interface.
+
+An attacker who convinced a victim to visit a malicious page could enumerate and
+invoke tools exposed by a locally running rmcp-based MCP server, read resources
+and prompts, and trigger side effects limited by the tools exposed by that
+server.
+
+Non-HTTP transports such as stdio and child-process transports are not affected.
+
+## Patches
+
+The issue was fixed in `rmcp` 1.4.0 by adding default loopback-only host
+allowlist validation for the Streamable HTTP server transport. Incoming HTTP
+requests now validate the `Host` header and return HTTP 403 when the host is not
+allowed.
+
+Users should upgrade to `rmcp >= 1.4.0`.
+
+## Workarounds
+
+If upgrading is not possible, place the MCP server behind a reverse proxy
+configured to reject requests whose `Host` header is not one of the expected
+hostnames. Do not bind the MCP server to `0.0.0.0` without such validation.


### PR DESCRIPTION
## Affected crate(s)

- `rmcp` (13,797,440 total downloads; 7,472,054 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- GitHub Security Advisory: https://github.com/modelcontextprotocol/rust-sdk/security/advisories/GHSA-89vp-x53w-74fx
- Fix PR: https://github.com/modelcontextprotocol/rust-sdk/pull/764
- Upstream issue requesting a RustSec counterpart: https://github.com/modelcontextprotocol/rust-sdk/issues/846

## Severity

High. A malicious public website could use DNS rebinding to send requests to a locally running rmcp Streamable HTTP server, allowing it to enumerate and invoke exposed MCP tools and access resources or prompts available through that server. The upstream GHSA uses CVSS 3.1 score 8.8.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate

## Testing

- Added the advisory under `crates/rmcp/RUSTSEC-0000-0000.md` using the RustSec template.
- Ran `rustsec-admin lint`; it currently stops on an existing `pnet` advisory before reaching this new file (`crates.io package name does not match package name in advisory for pnet in RUSTSEC-2019-0037`).