### PR TITLE
Add advisory for polkavm `write_memory` and `zero_memory` corruption

### DIFF
--- a/crates/polkavm/RUSTSEC-0000-0000.md
+++ b/crates/polkavm/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "polkavm"
+date = "2026-06-26"
+url = "https://github.com/paritytech/polkavm/commit/0ec2c443aad4"
+references = ["https://github.com/paritytech/polkavm/compare/v0.33.0...v0.33.1"]
+categories = ["memory-exposure", "denial-of-service"]
+cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:L/VI:H/VA:N/SC:N/SI:H/SA:L"
+keywords = ["interpreter", "memory", "consensus", "vm"]
+
+[versions]
+patched = [">= 0.33.1"]
+unaffected = ["< 0.32.0"]
+```
+
+# Interpreter guest memory corruption in `write_memory` and `zero_memory`
+
+In `polkavm` `0.32.0` and `0.33.0` the interpreter has a new memory implementation. It mishandles host-initiated memory operations (`write_memory` and `zero_memory`) when the target range already lies within the allocated backing buffer (`rw_data` / `aux`). Such operations fell through to a resize-based code path that placed bytes at the wrong location (or dropped them), and left regions that should have been zeroed un-cleared.
+
+The result is that host writes into guest memory can be silently misplaced or lost, and zeroing can be incomplete.
+
+The flaw was fixed in upstream in 0.33.1 release. 0.32.0 and 0.33.0 were subsequently yanked. Severity is high/critical as the crate is designed to be used in consensus. Any consumers of the crates using 0.32.0 or 0.33.0 risk consensus split. In addition, because `zero_memory` could fail to clear the intended region, a guest may observe stale memory contents they should not have access to.


### PR DESCRIPTION
## Affected crate(s)

- `polkavm`

## Links to upstream issue(s) or PR(s)

* https://github.com/paritytech/polkavm/commit/0ec2c443aad4
* https://github.com/paritytech/polkavm/compare/v0.33.0...v0.33.1

## Severity

High/critical as this crate's consumers commonly use it in blockchain consensus. Anyone who has not yet updated from the yanked versions risk consensus splits.

## Checklist

- [X] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [X] `date` field is set to the public disclosure date
- [X] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate
- [X] Fix already in releases.