### PR TITLE
`downcast_mut` unsoundness advisory for `anyhow`

### DIFF
--- a/crates/anyhow/RUSTSEC-0000-0000.md
+++ b/crates/anyhow/RUSTSEC-0000-0000.md
@@ -1,0 +1,70 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "anyhow"
+date = "2026-06-25"
+url = "https://github.com/dtolnay/anyhow/issues/451"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["unsound", "downcast_mut"]
+
+[affected.functions]
+"anyhow::Error::downcast_mut" = ["< 1.0.103"]
+
+[versions]
+patched = [">= 1.0.103"]
+```
+
+# Unsoundness in `Error::downcast_mut()`
+
+Affected versions of this crate violate borrow rules, resulting in undefined behavior, when the user adds context to an error via `Error::context` and then later calls `Error::downcast_mut` on the returned `Error`.
+
+The flaw was corrected in commit `6e8c000` by revising how the mutable reference is constructed, avoiding inclusion of a shared reference in the resulting borrow chain.
+
+## Example
+
+```rust
+use anyhow::Error;
+use std::fmt;
+
+#[derive(Debug)]
+struct ErrorContext(&'static str);
+
+impl fmt::Display for ErrorContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+fn main() {
+    let mut error = Error::msg("inner error").context(ErrorContext("old context"));
+    let context: &mut ErrorContext = error.downcast_mut().unwrap();
+    context.0 = "new context";
+    println!("{:?}", error);
+}
+```
+
+## Miri output
+
+```
+error: Undefined Behavior: trying to retag from <1538> for Unique permission at alloc602[0x38], but that tag only grants SharedReadOnly permission for this location
+   --> src/ptr.rs:170:18
+    |
+170 |         unsafe { &mut *self.ptr.as_ptr() }
+    |                  ^^^^^^^^^^^^^^^^^^^^^^^ this error occurs as part of retag at alloc602[0x38..0x48]
+    |
+    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
+    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
+help: <1538> was created by a SharedReadOnly retag at offsets [0x38..0x48]
+   --> src/ptr.rs:89:18
+    |
+ 89 |             ptr: NonNull::from(ptr),
+    |                  ^^^^^^^^^^^^^^^^^^
+    = note: stack backtrace:
+            0: anyhow::ptr::Mut::<'_, ErrorContext>::deref_mut
+                at src/ptr.rs:170:18: 170:41
+            1: anyhow::error::<impl anyhow::Error>::downcast_mut::<ErrorContext>
+                at src/error.rs:560:18: 560:46
+            2: main
+                at examples/downcast_mut.rs:15:38: 15:58
+```


### PR DESCRIPTION
The same unsoundness bug occurs in three popular error-handling crates. The unsound code originally appeared in `anyhow`. `eyre` copied it, and then `miette` copied it from `eyre`. This PR originally contained advisories for all three crates, and then was split to contain just `anyhow`. I'll continue to use this thread to track progress on the other two crates.

## Affected crate(s)

- anyhow (163,113,997)
- eyre (16,375,087)
- miette (12,898,466)

## Links to upstream issue(s) or PR(s)

* `anyhow`: [Issue](https://github.com/dtolnay/anyhow/issues/451), [PR](https://github.com/dtolnay/anyhow/pull/452)
* `eyre`: [Issue](https://github.com/eyre-rs/eyre/issues/285), [PR](https://github.com/eyre-rs/eyre/pull/286)
* `miette`: [Issue](https://github.com/zkat/miette/issues/469)

## Severity

Informational advisory for soundness issues in safe public APIs. Advisories include example code that crashes in MIRI, but in my limited testing I was unable to find any evidence that rustc currently exploits the UB or compiles the code according to other than its author-intended semantics.

## Checklist

- [X] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [X] `date` field is set to the public disclosure date
- [X] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate - see timeline

## Communication timeline

* 2026-05-31: @Shnatsel reported the issue to `miette`.
* 2026-06-25: I reported the issue to `anyhow`. Fixed released on the same day by @dtolnay and okayed a RustSec advisory.
* 2026-06-26: I reported the issue to `eyre` and opened a PR with a fix.
* 2026-06-29: `eyre` fix merged to master.

I'm currently checking with `eyre` maintainers on release timelines. I'm not sure of `miette`'s intentions, since there has been no maintainer response to the issue thread, but we're past two weeks from public disclosure.