### PR TITLE
Add advisory for unsound unchecked node accessors in i_tree

### DIFF
--- a/crates/i_tree/RUSTSEC-0000-0000.md
+++ b/crates/i_tree/RUSTSEC-0000-0000.md
@@ -1,0 +1,28 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "i_tree"
+date = "2025-07-04"
+url = "https://github.com/iShape-Rust/iTree/issues/1"
+references = [
+    "https://github.com/iShape-Rust/iTree/commit/a948b891cf159233bfed5b16bf185268fd9e1985",
+    "https://github.com/iShape-Rust/iTree/compare/0.9.0...0.10.0",
+]
+informational = "unsound"
+
+[affected.functions]
+"i_tree::tree::Tree::node" = ["< 0.10.0"]
+"i_tree::tree::Tree::mut_node" = ["< 0.10.0"]
+
+[versions]
+patched = [">= 0.10.0"]
+
+```
+
+# i_tree allowed out-of-bounds access through safe public node accessors
+
+Affected versions of `i_tree` exposed safe public `Tree::node` and `Tree::mut_node` methods in the public `tree` module. These methods accepted an arbitrary `u32` index and passed it directly to `Vec::get_unchecked` / `get_unchecked_mut` on the internal node buffer, without validating that the index was in bounds.
+
+Because these methods were safe and public, a caller could pass an out-of-bounds index without writing any `unsafe` code, producing an out-of-bounds shared or mutable reference and triggering undefined behavior.
+
+Starting with `0.10.0` the crate was restructured and these accessors are no longer reachable from outside the crate.


### PR DESCRIPTION
## Affected crate(s)

- `i_tree` (1,771,347 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- Upstream issue: https://github.com/iShape-Rust/iTree/issues/1
- Fix commit (restructure released as 0.10.0): https://github.com/iShape-Rust/iTree/commit/a948b891cf159233bfed5b16bf185268fd9e1985

## Severity

This advisory is proposed as informational `unsound`. In affected versions, `Tree::node` / `Tree::mut_node` were safe public methods that called `get_unchecked` / `get_unchecked_mut` with a caller-supplied index and no bounds check. Safe callers could therefore create out-of-bounds shared or mutable references, which is undefined behavior.

The issue was addressed in the `0.10.0` restructuring, where these accessors are no longer exposed as part of the public API.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate