### PR TITLE
Add advisory for stackvector public length field unsoundness

### DIFF
--- a/crates/stackvector/RUSTSEC-0000-0000.md
+++ b/crates/stackvector/RUSTSEC-0000-0000.md
@@ -7,17 +7,20 @@ url = "https://github.com/Alexhuszagh/rust-stackvector/issues/3"
 references = [
     "https://github.com/Alexhuszagh/rust-stackvector/pull/6",
     "https://github.com/Alexhuszagh/rust-stackvector/commit/02b947afdeeb1be95ec0888354aa76afdd9d0357",
+    "https://github.com/Alexhuszagh/rust-stackvector/issues/5",
 ]
 informational = "unsound"
 
 [versions]
-patched = []
+patched = [">= 2.0.0"]
 ```
 
-# stackvector's public `length` field allows memory safety violations from safe code
+# Multiple soundness issues in `stackvector`
 
-Affected versions of `stackvector` expose the `StackVec::length` field as public. Safe Rust code can set `length` to a value larger than the backing array capacity. Other safe methods, including `remove`, `pop`, and `truncate`, rely on `length` to check bounds before performing unsafe pointer operations (`ptr::read`, `ptr::copy`, `offset`/`add`).
+Affected versions of `stackvector` contained multiple soundness issues that could allow safe Rust code to trigger undefined behavior.
 
-If `length` is corrupted by safe code, these methods may perform out-of-bounds pointer arithmetic, reads, writes, or copies. This makes the safe API unsound, since callers could trigger undefined behavior without using `unsafe`.
+One issue was that `StackVec::length` was exposed as a public field. Safe Rust code could set `length` to a value larger than the backing array capacity. Other safe methods, including `remove`, `pop`, and `truncate`, relied on `length` before performing unsafe pointer operations (`ptr::read`, `ptr::copy`, `offset`/`add`). If `length` was corrupted by safe code, these methods could perform out-of-bounds pointer arithmetic, reads, writes, or copies.
 
-The issue was fixed in the upstream repository by making `length` private, but as of this advisory no patched version has been released to crates.io — the latest published version is `1.1.1`.
+The upstream maintainer also identified additional soundness issues, including the use of `mem::uninitialized` in `StackVec::from_vec_unchecked`, which was reachable through `from_vec`, and Miri violations related to `MaybeUninit` usage.
+
+Version `2.0.0` was released to fix the known soundness issues.

--- a/crates/stackvector/RUSTSEC-0000-0000.md
+++ b/crates/stackvector/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "stackvector"
+date = "2025-10-23"
+url = "https://github.com/Alexhuszagh/rust-stackvector/issues/3"
+references = [
+    "https://github.com/Alexhuszagh/rust-stackvector/pull/6",
+    "https://github.com/Alexhuszagh/rust-stackvector/commit/02b947afdeeb1be95ec0888354aa76afdd9d0357",
+]
+informational = "unsound"
+
+[versions]
+patched = []
+```
+
+# stackvector's public `length` field allows memory safety violations from safe code
+
+Affected versions of `stackvector` expose the `StackVec::length` field as public. Safe Rust code can set `length` to a value larger than the backing array capacity. Other safe methods, including `remove`, `pop`, and `truncate`, rely on `length` to check bounds before performing unsafe pointer operations (`ptr::read`, `ptr::copy`, `offset`/`add`).
+
+If `length` is corrupted by safe code, these methods may perform out-of-bounds pointer arithmetic, reads, writes, or copies. This makes the safe API unsound, since callers could trigger undefined behavior without using `unsafe`.
+
+The issue was fixed in the upstream repository by making `length` private, but as of this advisory no patched version has been released to crates.io — the latest published version is `1.1.1`.


### PR DESCRIPTION
## Affected crate(s)

- `stackvector` (16,059 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- Upstream issue: https://github.com/Alexhuszagh/rust-stackvector/issues/3
- Fix PR: https://github.com/Alexhuszagh/rust-stackvector/pull/6
- Fix commit: https://github.com/Alexhuszagh/rust-stackvector/commit/02b947afdeeb1be95ec0888354aa76afdd9d0357

## Severity

This advisory classifies the issue as informational `unsound`. In affected versions, `StackVec::length` is public, so safe Rust code can set it to a value larger than the backing array capacity. Safe methods such as `remove`, `pop`, and `truncate` then rely on this corrupted length before performing unsafe pointer operations, which can lead to out-of-bounds access and undefined behavior.

The fix has been merged upstream, but at the time of writing, a patched release does not appear to have been published to crates.io.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate
