### PR TITLE
`downcast_mut` unsoundness advisory for `eyre`

### DIFF
--- a/crates/eyre/RUSTSEC-0000-0000.md
+++ b/crates/eyre/RUSTSEC-0000-0000.md
@@ -1,0 +1,67 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "eyre"
+date = "2026-06-26"
+url = "https://github.com/eyre-rs/eyre/issues/285"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["unsound", "downcast_mut"]
+
+[affected.functions]
+"eyre::Report::downcast_mut" = ["<= 0.6.12"]
+
+[versions]
+patched = ["> 0.6.12"]
+```
+
+# Unsoundness in `Report::downcast_mut()`
+
+Affected versions of this crate violate borrow rules, resulting in undefined behavior, when the user adds context to a report via `Report::wrap_err` and then later calls `Report::downcast_mut` on the returned `Report`.
+
+The flaw was corrected in commit `95da6c5` by revising how the mutable reference is constructed, avoiding inclusion of a shared reference in the resulting borrow chain.
+
+## Example
+
+```rust
+use eyre::Report;
+use std::fmt;
+
+#[derive(Debug)]
+struct ErrorContext(&'static str);
+
+impl fmt::Display for ErrorContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+fn main() {
+    let mut error = Report::msg("inner error").wrap_err(ErrorContext("old context"));
+    let context: &mut ErrorContext = error.downcast_mut().unwrap();
+    context.0 = "new context";
+    println!("{:?}", error);
+}
+```
+
+## Miri output
+
+```
+error: Undefined Behavior: trying to retag from <1130> for Unique permission at alloc540[0x18], but that tag only grants SharedReadOnly permission for this location
+   --> /home/dfranke/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/non_null.rs:478:18
+    |
+478 |         unsafe { &mut *self.as_ptr() }
+    |                  ^^^^^^^^^^^^^^^^^^^ this error occurs as part of retag at alloc540[0x18..0x28]
+    |
+    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
+    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
+help: <1130> was created by a SharedReadOnly retag at offsets [0x18..0x28]
+   --> eyre/src/error.rs:746:19
+    = note: stack backtrace:
+            0: std::ptr::NonNull::<ErrorContext>::as_mut::<'_>
+                at /home/dfranke/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ptr/non_null.rs:478:18: 478:37
+            1: eyre::error::<impl eyre::Report>::downcast_mut::<ErrorContext>
+                at eyre/src/error.rs:447:18: 447:43
+            2: main
+                at eyre/examples/downcast_mut.rs:15:38: 15:58
+```


### PR DESCRIPTION
The same unsoundness bug occurs in three popular error-handling crates. The unsound code originally appeared in `anyhow`. `eyre` copied it, and then `miette` copied it from `eyre`. This PR covers `eyre`. See also #3000 for the `anyhow` advisory and general tracking information.

## Affected crate(s)

- eyre (16,375,087)

## Links to upstream issue(s) or PR(s)

* `eyre`: [Issue](https://github.com/eyre-rs/eyre/issues/285), [PR](https://github.com/eyre-rs/eyre/pull/286)

## Severity

Informational advisory for soundness issues in safe public APIs. Advisories include example code that crashes in MIRI, but in my limited testing I was unable to find any evidence that rustc currently exploits the UB or compiles the code according to other than its author-intended semantics.

## Checklist

- [X] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [X] `date` field is set to the public disclosure date
- [X] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate - conversation in progress
