### PR TITLE
Add unmaintained advisory for ttf-parser

### DIFF
--- a/crates/ttf-parser/RUSTSEC-0000-0000.md
+++ b/crates/ttf-parser/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "ttf-parser"
+date = "2026-06-28"
+url = "https://github.com/harfbuzz/ttf-parser/issues/217"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `ttf-parser` is unmaintained
+
+The author of `ttf-parser` has stated that the crate is unmaintained and will not receive further fixes (see the referenced issue).
+
+## Alternative(s)
+
+- [`skrifa`](https://crates.io/crates/skrifa), an actively maintained TrueType and OpenType font parsing crate, part of the Google Fonts "oxidize" (`fontations`) project.


### PR DESCRIPTION
## Affected crate(s)

- `ttf-parser` (22,578,747 recent downloads (90 days))

## Links to upstream issue(s) or PR(s)

- https://github.com/harfbuzz/ttf-parser/issues/217 (the maintainer states the crate is unmaintained/abandoned).

## Severity

Informational. The crate's author has stated on the referenced issue that `ttf-parser` is unmaintained and will not be fixed. Recommended alternative: `skrifa`, an actively maintained TrueType and OpenType font parsing crate, part of the Google Fonts "oxidize" (`fontations`) project.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate