### PR TITLE
Ammonia 4.1.3, 4.0.2, 3.3.2

### DIFF
--- a/crates/ammonia/RUSTSEC-0000-0000.md
+++ b/crates/ammonia/RUSTSEC-0000-0000.md
@@ -1,0 +1,48 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "ammonia"
+date = "2026-06-30"
+categories = ["format-injection"]
+keywords = ["html", "xss"]
+
+[versions]
+patched = [">= 4.1.3", ">= 4.0.2, < 4.1.0", ">= 3.3.2, < 4.0.0"]
+```
+
+# mXSS in ammonia via MathML `annotation-xml` encoding strip
+
+This tag has slightly different behavior than the other "integration point"
+tags in MathML and SVG, but ammonia didn't handle it, so it didn't correctly
+strip the namespace-incompatible tags.
+
+This vulnerability only has an effect when the `math` and `annotation-xml` tags
+are both enabled, but the `encoding` attribute is disabled, because it relies
+on the following sequence of steps:
+
+1. User writes code like `<math><annotation-xml encoding="text/html"><gadget></annotation-xml></math>`.
+2. Namespace filtering checks the DOM, and it passes. `<gadget>` is parsed as HTML.
+3. Attribute filter strips it down to `<math><annotation-xml><gadget></annotation-xml></math>`. Because the encoding attribute is gone, `<gadget>` is now parsed as MathML.
+4. The gadget is written in such a way that it exploits the parsing differences between HTML and MathML.
+
+Additionally, the gadget can only be written using a tag that is parsed as raw text in HTML.
+These [elements] are:
+
+* title
+* textarea
+* xmp
+* iframe
+* noembed
+* noframes
+* plaintext
+* noscript
+* style
+* script
+
+Applications that do not explicitly allow any of these tags should not be affected, since none are allowed by default.
+
+[elements]: https://github.com/servo/html5ever/blob/045a0378f2b0f8d4a350793899cf722a2a9b3d11/html5ever/src/tree_builder/rules.rs
+
+---
+
+**Discovered by:** ivan0912 (YesWeHack) · **Date:** 2026-06-29 · Found via local differential analysis and source review of ammonia's sanitisation pipeline; no third-party systems were tested.

--- a/crates/ammonia/RUSTSEC-0000-0000.md
+++ b/crates/ammonia/RUSTSEC-0000-0000.md
@@ -12,7 +12,9 @@ patched = [">= 4.1.3", ">= 4.0.2, < 4.1.0", ">= 3.3.2, < 4.0.0"]
 
 # mXSS in ammonia via MathML `annotation-xml` encoding strip
 
-This tag has slightly different behavior than the other "integration point"
+If a certain set of MathML tags are enabled, an attacker can inject arbitrary JavaScript code into the user's browser.
+
+The `annotation-xml` tag has slightly different behavior than the other "integration point"
 tags in MathML and SVG, but ammonia didn't handle it, so it didn't correctly
 strip the namespace-incompatible tags.
 


### PR DESCRIPTION
## Affected crate(s)

- ammonia (2,090,733)

## Links to upstream issue(s) or PR(s)

- https://github.com/rust-ammonia/ammonia/pull/245
- https://github.com/rust-ammonia/ammonia/pull/244
- https://github.com/rust-ammonia/ammonia/pull/243

## Severity

Low: Requires MathML to be enabled, and most sites don't.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
