### PR TITLE
Add advisory for grubbnet NetworkBuffer drain unsoundness

### DIFF
--- a/crates/grubbnet/RUSTSEC-0000-0000.md
+++ b/crates/grubbnet/RUSTSEC-0000-0000.md
@@ -1,0 +1,26 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "grubbnet"
+date = "2025-05-21"
+url = "https://github.com/Dooskington/grubbnet/issues/4"
+references = [
+    "https://github.com/Dooskington/grubbnet/commit/32562b9dca028357b27a9d317d62316be22035bd"
+]
+informational = "unsound"
+
+[affected.functions]
+"grubbnet::buffer::NetworkBuffer::drain" = ["< 0.2.0"]
+
+[versions]
+patched = [">= 0.2.0"]
+```
+
+
+# `NetworkBuffer::drain` can cause undefined behavior from safe code
+
+Affected versions of `grubbnet` exposed a safe public method `NetworkBuffer::drain` that accepted a caller-provided `count` and used it in unsafe pointer operations without validating that `count` was no larger than the number of bytes currently stored in the buffer (`self.offset`).
+
+If `count > self.offset`, the expression `self.offset - count` underflows and produces a very large length for `ptr::copy`, while the source pointer is also computed from the unchecked `count`. A safe caller can therefore trigger out-of-bounds pointer arithmetic and out-of-bounds memory copying without writing any `unsafe` code.
+
+The issue was fixed in `0.2.0` by checking `count > self.offset` and panicking before the copy.


### PR DESCRIPTION
## Affected crate(s)

- `grubbnet` (143 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- Upstream issue: https://github.com/Dooskington/grubbnet/issues/4
- Fix commit: https://github.com/Dooskington/grubbnet/commit/32562b9dca028357b27a9d317d62316be22035bd

## Severity

This advisory is proposed as informational `unsound`. Affected versions exposed the safe public method `NetworkBuffer::drain`, which used a caller-controlled `count` in unsafe pointer arithmetic and `ptr::copy` without checking. If `count` was too large, safe callers could trigger integer underflow and out-of-bounds memory copying, causing undefined behavior.

The issue was fixed in `0.2.0` by validating `count` before performing the copy.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate
