### PR TITLE
Add advisory for quick-xml: unbounded namespace-declaration allocation (memory DoS)

### DIFF
--- a/crates/quick-xml/RUSTSEC-0000-0000.md
+++ b/crates/quick-xml/RUSTSEC-0000-0000.md
@@ -1,0 +1,61 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "quick-xml"
+date = "2026-06-29"
+url = "https://github.com/tafia/quick-xml/issues/970"
+references = [
+    "https://github.com/tafia/quick-xml/commit/7ca25266e94987210daa864889ab15c9332c8a2a",
+]
+categories = ["denial-of-service"]
+keywords = ["xml", "parser", "dos", "memory", "namespace"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+
+[versions]
+patched = [">= 0.41.0"]
+```
+
+# Unbounded namespace-declaration allocation in `NsReader` enables memory-exhaustion denial of service
+
+`NsReader` resolves namespaces by calling `NamespaceResolver::push` for every
+`Start`/`Empty` event *before* the event is returned to the caller. `push`
+iterated all `xmlns` / `xmlns:*` attributes on the start tag and, for each one,
+appended the prefix bytes to an internal buffer and pushed a `NamespaceBinding`
+(32 bytes on 64-bit) to an internal `Vec`, with no upper bound on the number of
+declarations.
+
+## Impact
+
+A start tag with `N` namespace declarations drove roughly `3×` the tag's byte
+size in `NamespaceResolver` heap, allocated *inside* `quick-xml` before the
+`NsReader` consumer ever received the event and could inspect or reject it. A
+consumer that bounds its *input* size therefore still cannot bound this
+allocation: an `M`-byte start tag yields on the order of `3 × M` bytes of
+resolver heap the caller never sees.
+
+On untrusted XML this lets a remote, unauthenticated attacker force large heap
+allocations with a single start tag. With several `NsReader`s running
+concurrently on independent inputs (a common server pattern), the allocations
+stack and can exhaust process memory, causing the operating system to kill the
+process (OOM). This was confirmed against a real-world RPKI relying party (NLnet
+Labs Routinator), where concurrent RRDP validation workers parsing a crafted
+`snapshot.xml` exceeded the memory limit and the process was OOM-killed.
+
+## Affected code paths
+
+Consumers using `NsReader` (which always calls `NamespaceResolver::push` before
+yielding `Start`/`Empty`), or calling `NamespaceResolver::push` directly. A plain
+`Reader` that does not perform namespace resolution is not affected.
+
+## Remediation
+
+Upgrade to `quick-xml >= 0.41.0`. `NamespaceResolver::push` now rejects a start
+tag that declares more than `DEFAULT_MAX_DECLARATIONS_PER_ELEMENT` (256)
+namespace bindings, returning the new `NamespaceError::TooManyDeclarations`
+instead of allocating without limit. The limit is configurable via
+`NamespaceResolver::set_max_declarations_per_element` (use `usize::MAX` to
+restore the previous unbounded behavior), and `NsReader::resolver_mut()` is
+provided to reach it.
+
+There is no clean workaround for `NsReader` consumers before 0.41.0, as the
+allocation happens inside the reader with no configuration knob to cap it.


### PR DESCRIPTION
This adds a RustSec advisory for [quick-xml#970](https://github.com/tafia/quick-xml/issues/970).

- **Crate:** `quick-xml`
- **Affected:** `< 0.41.0`
- **Patched:** `0.41.0` (released 2026-06-29)
- **Category:** denial-of-service (uncontrolled memory allocation)

`NsReader` calls `NamespaceResolver::push` for every `Start`/`Empty` event *before* returning it to the caller. `push` allocated one `NamespaceBinding` (plus prefix/value bytes) per `xmlns` / `xmlns:*` attribute with no upper bound, so a start tag with `N` namespace declarations drove ~3× the tag's byte size in resolver heap *inside* quick-xml — allocation a consumer cannot observe or bound even if it caps its input size. On untrusted XML, and especially with several `NsReader`s running concurrently, this can exhaust process memory (OOM). Only `NsReader` consumers are affected; a plain `Reader` without namespace resolution is not. Fixed in 0.41.0 (commit [`7ca2526`](https://github.com/tafia/quick-xml/commit/7ca25266e94987210daa864889ab15c9332c8a2a)), which adds a configurable per-element declaration cap (default 256) and `NamespaceError::TooManyDeclarations`.

Reported by me; the `quick-xml` maintainer asked that I file the RustSec advisory. The ID is left as the `RUSTSEC-0000-0000` placeholder for assignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
