### PR TITLE
Add advisory for `error-stack` aliased mutable references in `Report::frames_mut`

### DIFF
--- a/crates/error-stack/RUSTSEC-0000-0000.md
+++ b/crates/error-stack/RUSTSEC-0000-0000.md
@@ -1,0 +1,34 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "error-stack"
+date = "2026-07-03"
+url = "https://github.com/hashintel/hash/issues/8945"
+references = ["https://github.com/hashintel/hash/pull/8946"]
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["aliasing"]
+
+[versions]
+patched = [">= 0.8.0"]
+
+[affected]
+functions = { "error_stack::Report::frames_mut" = ["*"] }
+```
+
+# `Report::frames_mut` allows aliased mutable references
+
+Affected versions of this crate return an iterator from
+`Report::frames_mut` whose `&mut Frame` items have lifetimes independent
+of the iterator, so all yielded references can be held at the same time.
+A yielded frame's sources are also yielded by the iterator and reachable
+through the parent frame via `Frame::sources_mut`, allowing safe code to
+obtain two live mutable references to the same frame. This is undefined
+behavior and can be used to cause a segmentation fault (see reproducer in
+the linked issue). Versions 0.1.0 and 0.1.1 are affected through
+`Frame::source_mut` instead of `Frame::sources_mut`.
+
+The flaw is fixed in 0.8.0 by replacing the iterator with internal
+iteration: `Report::frames_mut` now takes a visitor closure, so mutable
+access to a frame is scoped and cannot overlap with access to its
+sources.


### PR DESCRIPTION
## Affected crate(s)

- [`error-stack`](https://crates.io/crates/error-stack) (~4M total downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- Report: https://github.com/hashintel/hash/issues/8945
- Fix: https://github.com/hashintel/hash/pull/8946 ([released as 0.8.0](https://github.com/hashintel/hash/releases/tag/error-stack%400.8.0))

## Severity

`Report::frames_mut` returned an iterator whose `&mut Frame` items could all be held simultaneously, while the same frames were also reachable through `Frame::sources_mut`. Safe code could therefore obtain two live mutable
references to the same frame -> undefined behavior, demonstrated as a segmentation fault in the linked issue. No known exploitation.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate (I am the maintainer)