### PR TITLE
Add advisory for unbounded memory allocation in geozero WKB decoding

### DIFF
--- a/crates/geozero/RUSTSEC-0000-0000.md
+++ b/crates/geozero/RUSTSEC-0000-0000.md
@@ -46,7 +46,7 @@ fn main() {
 
 ## Patches
 
-No fixed release is available yet. A fix that bounds the reservation against the bytes remaining in the input (or grows fallibly with `Vec::try_reserve`) is proposed in [georust/geozero#297](https://github.com/georust/geozero/pull/297).
+No fixed release is available yet. A fix that bounds the reservation against the bytes remaining in the input (or grows fallibly with `Vec::try_reserve`) was proposed upstream in [georust/geozero#297](https://github.com/georust/geozero/pull/297) on 2026-06-17, and remains open at the time of this advisory.
 
 ## Workarounds
 

--- a/crates/geozero/RUSTSEC-0000-0000.md
+++ b/crates/geozero/RUSTSEC-0000-0000.md
@@ -1,0 +1,59 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "geozero"
+date = "2026-07-04"
+url = "https://github.com/georust/geozero/pull/297"
+categories = ["denial-of-service"]
+keywords = ["wkb", "ewkb", "parsing", "memory", "oom"]
+
+[versions]
+patched = []
+```
+
+# Unbounded memory allocation when decoding untrusted WKB/EWKB
+
+## Impact
+
+Decoding an untrusted WKB or EWKB geometry through `geozero`'s `to_geo` (and any other path that drives the `geo-types` `GeomProcessor`) can trigger an out-of-memory process abort.
+
+The WKB reader reads a 32-bit element count (point count, ring count, sub-geometry count) directly from the input and hands it to the geometry processor, which reserves a `Vec` of that capacity before reading the corresponding coordinate bytes. Because the reservation happens before the payload is validated against the remaining input, a crafted geometry of a few dozen bytes can declare a count close to `u32::MAX` and force a multi-gigabyte allocation. When `Vec::with_capacity` cannot satisfy the request, the default Rust allocator aborts the process, killing all threads.
+
+This is a security concern for any application that decodes attacker-controlled WKB/EWKB, for example a spatial database extension, a tile server, or any service that accepts geometry BLOBs from clients.
+
+## Details
+
+The count is read in `src/wkb/wkb_reader.rs` (`process_wkb_geom_n`, for example `n_pts` and `ring_count`) and reserved without bound in `src/geo_types/geo_types_writer.rs`, where the coordinate, ring, polygon, and collection begin callbacks call `Vec::with_capacity(size)` with `size` taken directly from the reader. No check relates the declared count to the number of bytes actually remaining in the input.
+
+## Proof of concept
+
+This 38-byte big-endian `GeometryCollection` (its SRID flag and nested headers desync count parsing so that one declared count lands near 2.1 billion) makes `to_geo` attempt an allocation of roughly 47 GB and abort:
+
+```rust
+use geozero::wkb::Ewkb;
+use geozero::ToGeo;
+
+fn main() {
+    let blob: &[u8] = &[
+        0x00, 0x20, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x1b, 0x00, 0x00, 0x00, 0x01,
+        0x00, 0x20, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0xb0, 0x24, 0xa5, 0x94,
+        0x6e, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x65, 0xff, 0x00,
+    ];
+    let _: geo::Geometry<f64> = Ewkb(blob).to_geo().unwrap();
+    // memory allocation of 47283067200 bytes failed -> process abort (SIGABRT)
+}
+```
+
+## Patches
+
+No fixed release is available yet. A fix that bounds the reservation against the bytes remaining in the input (or grows fallibly with `Vec::try_reserve`) is proposed in [georust/geozero#297](https://github.com/georust/geozero/pull/297).
+
+## Workarounds
+
+- Validate the WKB structure before decoding, rejecting any element count that exceeds the bytes available in the buffer.
+- Decode WKB only from trusted sources.
+- Run the decode in a memory-limited subprocess, or with an allocator that returns errors instead of aborting.
+
+## Credits
+
+Reported by [Luca Cappelletti](https://github.com/LucaCappelletti94), found with `cargo-fuzz` while hardening the `sqlitegis` SQLite extension.


### PR DESCRIPTION
This adds a denial-of-service advisory for `geozero`. Decoding untrusted WKB or EWKB through `to_geo` reserves a `Vec` sized from a 32-bit element count read directly from the input, before the coordinate bytes are read, so a 38-byte blob can declare a count near `u32::MAX` and drive an allocation of roughly 47 GB that aborts the process. The reproduction in the advisory is verified against `geozero` 0.15.1 with no other crates involved. A fix that bounds the reservation is proposed upstream in georust/geozero#297 (open since 2026-06-17). No fixed release exists yet, so `patched` is empty.
