### PR TITLE
Add advisory for fulgur: unbounded page slicing denial of service

### DIFF
--- a/crates/fulgur/RUSTSEC-0000-0000.md
+++ b/crates/fulgur/RUSTSEC-0000-0000.md
@@ -1,0 +1,48 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "fulgur"
+date = "2026-07-05"
+url = "https://github.com/fulgur-rs/fulgur/security/advisories/GHSA-j5cx-ph8g-95v3"
+categories = ["denial-of-service"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+keywords = ["dos", "pagination", "pdf"]
+aliases = ["GHSA-j5cx-ph8g-95v3"]
+
+[versions]
+patched = [">= 0.19.0"]
+```
+
+# Unbounded page slicing from attacker-controlled CSS height causes denial of service
+
+`fulgur` converts untrusted HTML/CSS into PDF, commonly on a server that
+processes input supplied by many tenants. In versions prior to 0.19.0, a
+body-direct child whose CSS-resolved height greatly exceeds the page height was
+sliced into one fragment per page with no upper bound.
+
+The height is taken directly from attacker-controlled HTML/CSS (`height`, `vh`
+units), so a few bytes such as `<div style="height:99999999px"></div>` forced on
+the order of 125,000 page fragments. The pagination code then allocates
+`vec![Vec::new(); page_count]` and runs a per-page render loop, resulting in CPU
+and memory exhaustion. A non-finite height (one that resolves to `+inf`)
+additionally made the slicing loop's `remaining -= last_slice_h` decrement never
+terminate, causing an infinite loop.
+
+An attacker able to submit HTML/CSS to a fulgur-based conversion service can
+trigger this with a trivially small payload, denying service to the host and any
+co-tenants.
+
+Fixed in 0.19.0: a `MAX_PAGES` cap bounds the slice loop — halting it even for a
+`+inf` height — and non-finite layout heights are sanitized so they can no
+longer drive the loop.
+
+## Attack Vector rationale
+
+`fulgur` performs no network I/O of its own; it renders HTML/CSS handed to it by
+the embedding application. This advisory scores the crate independent of any
+specific adopting program, so per the CVSS v3.1 User Guide §3.7 the Attack
+Vector is assessed as Network for the reasonable worst-case deployment — a
+network-facing service that renders untrusted HTML without user interaction. A
+concrete system that receives the HTML in one component and passes it to fulgur
+in a separate component may assess a lower environmental Attack Vector (Local,
+per §3.10).


### PR DESCRIPTION
Adds a denial-of-service advisory for the `fulgur` crate (an HTML/CSS to PDF converter). This is a maintainer-published advisory — the corresponding GitHub Security Advisory GHSA-j5cx-ph8g-95v3 has already been published by the fulgur project.

## Affected crate(s)

- `fulgur` (1,797 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- GitHub Security Advisory (maintainer-published): https://github.com/fulgur-rs/fulgur/security/advisories/GHSA-j5cx-ph8g-95v3
- Upstream fix: https://github.com/fulgur-rs/fulgur/pull/501 (merged; released in 0.19.0)

## Severity

Denial of service via uncontrolled resource consumption (CWE-400, CWE-835). In `fulgur` < 0.19.0, a body-direct element whose CSS height is attacker-controlled (`height` / `vh`) was sliced into one PDF page per page-strip with no upper bound: a few bytes such as `<div style="height:99999999px">` force on the order of 125,000 page fragments and a per-page render loop, exhausting CPU and memory. A non-finite height (`+inf`) causes a non-terminating loop. Fixed in 0.19.0 by a `MAX_PAGES` cap and non-finite-height sanitization.

CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H (7.5). `fulgur` is a library that performs no network I/O of its own; the Attack Vector is assessed as Network per the CVSS v3.1 User Guide §3.7 for the reasonable worst-case deployment (a network-facing service rendering untrusted HTML), as explained in the advisory body.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate (maintainer-published; GHSA-j5cx-ph8g-95v3 was filed by the fulgur project itself)
