### PR TITLE
Add advisory for fulgur: blank-page denial of service via non-painting replaced elements

### DIFF
--- a/crates/fulgur/RUSTSEC-0000-0000.md
+++ b/crates/fulgur/RUSTSEC-0000-0000.md
@@ -1,0 +1,53 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "fulgur"
+date = "2026-07-05"
+url = "https://github.com/fulgur-rs/fulgur/security/advisories/GHSA-4rf6-qx84-q9fv"
+categories = ["denial-of-service"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+keywords = ["dos", "pagination", "pdf"]
+aliases = ["GHSA-4rf6-qx84-q9fv"]
+
+[versions]
+patched = [">= 0.26.0"]
+```
+
+# Non-painting replaced elements amplify to thousands of blank PDF pages (denial of service)
+
+`fulgur` converts untrusted HTML/CSS into PDF, commonly on a server that
+processes input supplied by many tenants. In versions prior to 0.26.0, a
+childless box that resolves to a pathologically tall height was amplified into
+thousands of blank PDF pages, even when it produces no visible output.
+
+The childless-collapse defense that would normally collapse such a box was gated
+by a tag-only "replaced content" check, so any non-painting replaced element
+bypassed it, including an unresolved `src` (the common offline-first case), a
+`visibility:hidden` image, an undecodable image format, and an empty `<svg>`. A
+trailing-sibling variant of the same gap was also open.
+
+A few bytes of HTML therefore amplified into roughly `MAX_PAGES` (10,000) blank
+pages; the renderer allocates and runs a per-page loop over them, producing CPU
+and memory exhaustion. An attacker able to submit HTML to a fulgur-based
+conversion service can trigger this with a trivially small payload, denying
+service to the host and any co-tenants.
+
+Fixed in 0.26.0: the tag-only gate was removed so that any pathologically tall
+childless box collapses regardless of whether it is a replaced element, closing
+the missing-`src`, `visibility:hidden`, undecodable-format, and empty-`<svg>`
+vectors along with the trailing-sibling variant.
+
+Versions prior to 0.19.0 additionally lacked any page-count cap, allowing an
+unbounded (rather than 10,000-page) variant of this amplification; that earlier
+variant is tracked separately as GHSA-j5cx-ph8g-95v3.
+
+## Attack Vector rationale
+
+`fulgur` performs no network I/O of its own; it renders HTML/CSS handed to it by
+the embedding application. This advisory scores the crate independent of any
+specific adopting program, so per the CVSS v3.1 User Guide §3.7 the Attack
+Vector is assessed as Network for the reasonable worst-case deployment — a
+network-facing service that renders untrusted HTML without user interaction. A
+concrete system that receives the HTML in one component and passes it to fulgur
+in a separate component may assess a lower environmental Attack Vector (Local,
+per §3.10).


### PR DESCRIPTION
Adds a denial-of-service advisory for the `fulgur` crate (an HTML/CSS to PDF converter). This is a maintainer-published advisory — the corresponding GitHub Security Advisory GHSA-4rf6-qx84-q9fv has already been published by the fulgur project.

## Affected crate(s)

- `fulgur` (1,797 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- GitHub Security Advisory (maintainer-published): https://github.com/fulgur-rs/fulgur/security/advisories/GHSA-4rf6-qx84-q9fv
- Upstream fix: https://github.com/fulgur-rs/fulgur/pull/575 (merged; released in 0.26.0)

## Severity

Denial of service via uncontrolled resource consumption (CWE-400). In `fulgur` < 0.26.0, a non-painting replaced element — an unresolved `src` (the common offline-first case), a `visibility:hidden` image, an undecodable image format, or an empty `<svg>` — bypassed the childless-collapse defense and amplified a few bytes of HTML into roughly 10,000 (`MAX_PAGES`) blank PDF pages, exhausting CPU and memory via the per-page allocation and render loop. A trailing-sibling variant of the same gap was also open. Fixed in 0.26.0 by removing the tag-only "replaced content" gate so any pathologically tall childless box collapses.

The amplification is bounded (no infinite loop), so it is scored CWE-400 only. CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H (7.5); `fulgur` performs no network I/O of its own, so the Attack Vector is assessed as Network per the CVSS v3.1 User Guide §3.7, as explained in the advisory body. The unbounded pre-0.19.0 variant is tracked separately as GHSA-j5cx-ph8g-95v3.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate (maintainer-published; GHSA-4rf6-qx84-q9fv was filed by the fulgur project itself)
