### PR TITLE
Add advisory for cxx let_cxx_string unsoundness

### DIFF
--- a/crates/cxx/RUSTSEC-0000-0000.md
+++ b/crates/cxx/RUSTSEC-0000-0000.md
@@ -4,6 +4,7 @@ id = "RUSTSEC-0000-0000"
 package = "cxx"
 date = "2026-07-05"
 url = "https://github.com/dtolnay/cxx/issues/1729"
+informational = "unsound"
 categories = ["memory-exposure"]
 keywords = ["exception", "unwind"]
 

--- a/crates/cxx/RUSTSEC-0000-0000.md
+++ b/crates/cxx/RUSTSEC-0000-0000.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "cxx"
+date = "2026-07-05"
+url = "https://github.com/dtolnay/cxx/issues/1729"
+categories = ["memory-exposure"]
+keywords = ["exception", "unwind"]
+
+[affected]
+#arch = ["x86", "x86_64"]
+#os = ["windows"]
+
+[affected.functions]
+"cxx::let_cxx_string" = ["< 1.0.195"]
+
+[versions]
+patched = [">= 1.0.195"]
+```
+
+# `let_cxx_string!` uses uninitialized value due to exception safety violations
+
+In affected versions of this crate, `let_cxx_string!` is not exception safe. After creating the `StackString`, if `match $value` panics, the content of `StackString` is not yet initialized, while the drop implementation of `StackString` unconditionally deinitializes the content, leading to use of uninitialized value.
+
+The soundness issue was fixed in version `1.0.195` by moving drop logics to separate drop guard after initializing the `StackString`.


### PR DESCRIPTION
## Affected crate(s)

- `cxx` (9,699,963 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

<!-- In principle, we do not publish advisories for issues that have
     not been reported upstream. -->

https://github.com/dtolnay/cxx/issues/1729

## Severity

<!-- Briefly describe the risk and potential effect of the vulnerability.
     For example: allows remote denial-of-service via stack exhaustion,
     or: use-after-free that can lead to arbitrary code execution. -->

Use of uninitialized memory due to exception safety, with potential memory exposure risk.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
