### PR TITLE
Add tree-sitter-perl-next unmaintained advisory

### DIFF
--- a/crates/tree-sitter-perl-next/RUSTSEC-0000-0000.md
+++ b/crates/tree-sitter-perl-next/RUSTSEC-0000-0000.md
@@ -1,6 +1,6 @@
 ```toml
 [advisory]
-id = "RUSTSEC-2026-0203"
+id = "RUSTSEC-0000-0000"
 package = "tree-sitter-perl-next"
 date = "2026-07-06"
 url = "https://github.com/PRRPCHT/tree-sitter-perl-next"
@@ -12,7 +12,7 @@ patched = []
 
 # `tree-sitter-perl-next` is unmaintained
 
-The author of `tree-sitter-perl-next` has stated that the crate is unmaintained and will not receive further fixes (see the referenced issue).
+The author of `tree-sitter-perl-next` has stated that the crate is unmaintained and will not receive further fixes (see the repo's readme).
 
 ## Alternative(s)
 

--- a/crates/tree-sitter-perl-next/RUSTSEC-0000-0000.md
+++ b/crates/tree-sitter-perl-next/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-2026-0203"
+package = "tree-sitter-perl-next"
+date = "2026-07-06"
+url = "https://github.com/PRRPCHT/tree-sitter-perl-next"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `tree-sitter-perl-next` is unmaintained
+
+The author of `tree-sitter-perl-next` has stated that the crate is unmaintained and will not receive further fixes (see the referenced issue).
+
+## Alternative(s)
+
+- [`ts-parser-perl `](https://crates.io/crates/ts-parser-perl), an actively maintained tree-sitter Perl grammar that tree-sitter-perl-next initially forked.


### PR DESCRIPTION
## Affected crate(s)

- tree-sitter-perl-next (32280 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

Declared unmaintained by the author (me): https://github.com/PRRPCHT/tree-sitter-perl-next

## Severity

No more updates in case of bugs/security issues.

## Checklist

- [X] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [X] `date` field is set to the public disclosure date
- [X] Contains a concise and descriptive title after advisory metadata
- [X] Asked maintainer(s) if publishing an advisory is appropriate
