### PR TITLE
Add advisory for invalid pointer dereference in fmt::Pointer impl for crossbeam_epoch::{Atomic,Shared}

### DIFF
--- a/crates/crossbeam-epoch/RUSTSEC-0000-0000.md
+++ b/crates/crossbeam-epoch/RUSTSEC-0000-0000.md
@@ -1,0 +1,17 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "crossbeam-epoch"
+date = "2026-07-06"
+url = "https://github.com/crossbeam-rs/crossbeam/pull/1276"
+keywords = ["NULL-pointer-dereference"]
+aliases = []
+
+[versions]
+patched = [">= 0.9.20"]
+unaffected = ["< 0.9.0"]
+```
+
+# Invalid pointer dereference in `fmt::Pointer` impl for `Atomic` and `Shared` when the underlying pointer is invalid
+
+Affected versions of `fmt::Display` dereference the underlying pointer. This causes a invalid pointer dereference e.g., when a pointer created with `Atomic::null` or `Shared::null`. `fmt::Debug` impls and pre-0.9 `fmt::Display` impls, which do not dereference pointers, are not affected by this issue.


### PR DESCRIPTION
## Affected crate(s)

- crossbeam-epoch (recent downloads per crates.io: 112.9M)

## Links to upstream issue(s) or PR(s)

<!-- In principle, we do not publish advisories for issues that have
     not been reported upstream. -->
- https://github.com/crossbeam-rs/crossbeam/pull/1273 (incomplete fix in 0.9.19)
- https://github.com/crossbeam-rs/crossbeam/pull/1276 (full fix in 0.9.20)

## Severity

<!-- Briefly describe the risk and potential effect of the vulnerability.
     For example: allows remote denial-of-service via stack exhaustion,
     or: use-after-free that can lead to arbitrary code execution. -->

- I confirmed that null pointer dereference can be triggered without unsafe code when the opt-level is low or when the pointer is to a DST.
  - 0.9.19's fix addressed this.
- I guess use-after-free is also possible when combined with other unsafe code.
  - 0.9.20's fix addressed this.
    - Another case addressed in 0.9.20 is an unsoundness that can likely be triggered in Miri or sanitizer but is not considered to occur on real hardware. (See the PR 1276 mentioned above for details.)

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate