### PR TITLE
Add advisory for exception safety violation in scc Array::insert

### DIFF
--- a/crates/scc/RUSTSEC-0000-0000.md
+++ b/crates/scc/RUSTSEC-0000-0000.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "scc"
+date = "2026-07-06"
+url = "https://codeberg.org/wvwwvwwv/scalable-concurrent-containers/issues/232"
+informational = "unsound"
+keywords = ["exception", "unwind"]
+[affected]
+#arch = ["x86", "x86_64"]
+#os = ["windows"]
+
+[versions]
+patched = [">= 3.8.4"]
+```
+
+# `Array::insert` violates exception safety if compare function panics, leading to potential Double-Free
+
+In affected versions of this crate, `Array::insert` is not exception safe. In the `UPSERT` path, `key` and `value`'s snapshot is written to `self.data_block`, and after the insertion is completed, `key` and `value` are `mem::forget` in order to prevent double free. However, during the insertion, `K::compare` is invoked, which is a user-provided method. If user deliberately call panic in this function, during unwinding, the destructors of `key`, `value`, and `self` will all be called (since the `mem::forget` has not been called yet), leading to Double Free. Similar issues happens in the `!UPSERT` path.
+
+The soundness issue was fixed in version `3.8.4` by using `ManuallyDrop` instead of `mem::forget`, and separating fallible code from infallible code during a node split - insert = insert_try -> insert_unchecked.


### PR DESCRIPTION
## Affected crate(s)

- scc (17,743,722 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

<!-- In principle, we do not publish advisories for issues that have
     not been reported upstream. -->

<https://codeberg.org/wvwwvwwv/scalable-concurrent-containers/issues/232>

## Severity

<!-- Briefly describe the risk and potential effect of the vulnerability.
     For example: allows remote denial-of-service via stack exhaustion,
     or: use-after-free that can lead to arbitrary code execution. -->

Double free due to exception safety violation, leading to potential memory corruption.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
