### PR TITLE
Add advisory for bump-scope: wrong documentation potentially leading to use-after-free

### DIFF
--- a/crates/bump-scope/RUSTSEC-0000-0000.md
+++ b/crates/bump-scope/RUSTSEC-0000-0000.md
@@ -1,0 +1,31 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "bump-scope"
+date = "2026-07-07"
+url = "https://github.com/bluurryy/bump-scope/security/advisories/GHSA-xhx6-q96x-pf9c"
+informational = "unsound"
+categories = ["memory-corruption", "memory-exposure"]
+keywords = ["use-after-free", "unsound"]
+aliases = ["GHSA-xhx6-q96x-pf9c"]
+
+[versions]
+patched = [">= 2.3.2"]
+```
+
+# Misdocumented guarantees on `BumpAllocatorCore` for deallocate and reallocate methods can cause use-after-free
+
+In affected versions of this crate, the [documentation of `BumpAllocatorCore`](https://docs.rs/bump-scope/2.3.1/bump_scope/traits/trait.BumpAllocatorCore.html), subtrait of `Allocator`, says:
+> You can call `grow*`, `shrink` and `deallocate` with pointers that came from a different `BumpAllocatorCore`. In this case:
+>  - `grow*` will always allocate a new memory block.
+>  - `deallocate` will do nothing
+>  - `shrink` will either do nothing or allocate iff the alignment increases
+
+None of the invariants in the bullet points hold. When calling methods with an allocation from an ancestor scope, `deallocate` and `shrink`[^1] may free memory and `shrink` and `grow*` may happen in-place just like if the allocator was the ancestor scope itself.
+
+A user may assume that "do nothing" means that an allocation is still valid after a call to `deallocate` or `shrink` when in fact it isn't. This can lead to use-after-free bugs as future allocations yield memory blocks overlapping with the one that was deallocated/shrunk.
+
+The flaw was corrected in commit [db9da19](https://github.com/bluurryy/bump-scope/commit/db9da1967d5d8a22b93eb05ec65f6078a61289f7) by removing the offending documentation, leaving just 
+> You can call `grow*`, `shrink` and `deallocate` with pointers that came from a different `BumpAllocatorCore`.
+
+[^1]: By association also `BumpAllocatorTyped::shrink_slice`


### PR DESCRIPTION
I'm the maintainer of the affected crate.

## Affected crate(s)

- bump-scope (88,910 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- [GHSA-xhx6-q96x-pf9c](https://github.com/bluurryy/bump-scope/security/advisories/GHSA-xhx6-q96x-pf9c)
- https://github.com/bluurryy/bump-scope/commit/db9da1967d5d8a22b93eb05ec65f6078a61289f7

## Severity

Soundness issue in safety invariants of `BumpAllocatorCore` trait potentially leading to use-after-free bugs.

This does not affect safe code of the library. It only affects niche, unlikely to be useful or used, safety invariants.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
