### PR TITLE
Add unmaintained advisory for rustybuzz

### DIFF
--- a/crates/rustybuzz/RUSTSEC-0000-0000.md
+++ b/crates/rustybuzz/RUSTSEC-0000-0000.md
@@ -5,7 +5,6 @@ package = "rustybuzz"
 date = "2026-07-11"
 url = "https://github.com/harfbuzz/rustybuzz/issues/166"
 informational = "unmaintained"
-license = "CC-1.0"
 
 [versions]
 patched = []

--- a/crates/rustybuzz/RUSTSEC-0000-0000.md
+++ b/crates/rustybuzz/RUSTSEC-0000-0000.md
@@ -3,7 +3,7 @@
 id = "RUSTSEC-0000-0000"
 package = "rustybuzz"
 date = "2026-07-11"
-url = "[https://github.com/mystuff/mycrate/issues/123](https://github.com/harfbuzz/rustybuzz/issues/166)"
+url = "https://github.com/harfbuzz/rustybuzz/issues/166"
 informational = "unmaintained"
 license = "CC-1.0"
 

--- a/crates/rustybuzz/RUSTSEC-0000-0000.md
+++ b/crates/rustybuzz/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rustybuzz"
+date = "2026-07-11"
+url = "[https://github.com/mystuff/mycrate/issues/123](https://github.com/harfbuzz/rustybuzz/issues/166)"
+informational = "unmaintained"
+license = "CC-1.0"
+
+[versions]
+patched = []
+```
+
+# `rustybuzz` is unmaintained
+
+The current maintainer of `rustybuzz` has stated that the crate is unmaintained and will not receive further fixes or updates (see the referenced issue).
+
+## Alternative(s)
+
+- [`harfrust`](https://github.com/harfbuzz/harfrust), an actively maintained and updated alternative which is part of the Harfbuzz project.


### PR DESCRIPTION
## Affected crate(s)

- `rustybuzz` (8,103,992 recent downloads (90 days))

## Links to upstream issue(s) or PR(s)
- https://github.com/harfbuzz/rustybuzz/issues/166 (the maintainer states the crate is unmaintained/abandoned).

## Severity

Informational. The crate's author has stated on the referenced issue that `rustybuzz` is unmaintained and will not be updated. Recommended alternative: `harfrust`, an actively maintained Harfbuzz port owned and maintained by the Harfbuzz owners.

## Checklist

- [X] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [X] `date` field is set to the public disclosure date
- [X] Contains a concise and descriptive title after advisory metadata
- [X] Asked maintainer(s) if publishing an advisory is appropriate
