### PR TITLE
RUSTSEC-2026-0188: add alias to assigned CVE

### DIFF
--- a/crates/wasmtime-wasi/RUSTSEC-2026-0188.md
+++ b/crates/wasmtime-wasi/RUSTSEC-2026-0188.md
@@ -6,7 +6,7 @@ date = "2026-06-24"
 url = "https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-4ch3-9j33-3pmj"
 categories = []
 keywords = []
-aliases = ["GHSA-4ch3-9j33-3pmj"]
+aliases = ["GHSA-4ch3-9j33-3pmj", "CVE-2026-58494"]
 license = "CC0-1.0"
 cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:N/I:H/A:N"
 


### PR DESCRIPTION
GitHub assigned CVE-2026-58494 to this security advisory after it was published.

https://github.com/bytecodealliance/wasmtime/security/advisories/GHSA-4ch3-9j33-3pmj
