### PR TITLE
Libcrux advisories 2026w29

### DIFF
--- a/crates/libcrux-aesgcm/RUSTSEC-0000-0000.0.md
+++ b/crates/libcrux-aesgcm/RUSTSEC-0000-0000.0.md
@@ -1,0 +1,84 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libcrux-aesgcm"
+date = "2026-06-09"
+url = "https://github.com/celabshq/libcrux/pull/1474"
+
+categories = ["crypto-failure"]
+
+cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N"
+
+[affected.functions]
+"libcrux_aesgcm::AesGcm128Key::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::AesGcm256Key::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::AesGcm128Key::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::AesGcm256Key::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::AesGcm128::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::portable::PortableAesGcm128::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::x64::X64AesGcm128::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::neon::NeonAesGcm128::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::AesGcm256::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::portable::PortableAesGcm256::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::x64::X64AesGcm256::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::neon::NeonAesGcm256::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::AesGcm128::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::portable::PortableAesGcm128::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::x64::X64AesGcm128::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::neon::NeonAesGcm128::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::AesGcm256::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::portable::PortableAesGcm256::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::x64::X64AesGcm256::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::neon::NeonAesGcm256::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::Key::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::portable::Key::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::x64::Key::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::neon::Key::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::Key::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::portable::Key::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::x64::Key::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::neon::Key::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::Key::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::portable::Key::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::x64::Key::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::neon::Key::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::Key::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::portable::Key::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::x64::Key::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::neon::Key::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::KeyRef::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::portable::KeyRef::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::x64::KeyRef::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::neon::KeyRef::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::KeyRef::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::portable::KeyRef::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::x64::KeyRef::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::neon::KeyRef::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::KeyRef::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::portable::KeyRef::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::x64::KeyRef::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::neon::KeyRef::encrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::KeyRef::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::portable::KeyRef::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::x64::KeyRef::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::neon::KeyRef::decrypt" = ["<= 0.0.8"]
+
+[versions]
+patched = []
+```
+
+# AES-GCM did not enforce limits on AAD length
+
+NIST Special Publication 800-38D specifies that the bit length of the
+AAD shall not exceed `2^64 - 1` bits. The implementation of AES-GCM in
+`libcrux-aesgcm` neither enforced this limit for encryption nor for
+decryption.
+
+## Impact
+Use of AES-GCM with AAD of length exceeding the prescribed maximum
+length degrades the authentication security of the GCM tag.
+
+## Mitigation
+Starting from version `0.0.9` (published as `libcrux-aes@v0.0.9`),
+limits on the length of the AAD input are enforced, so overlong AAD
+inputs result in an error on encryption and decryption.

--- a/crates/libcrux-aesgcm/RUSTSEC-0000-0000.1.md
+++ b/crates/libcrux-aesgcm/RUSTSEC-0000-0000.1.md
@@ -1,0 +1,67 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libcrux-aesgcm"
+date = "2026-07-14"
+url = "https://github.com/celabshq/libcrux/pull/1528"
+
+categories = ["crypto-failure"]
+
+cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N"
+
+[affected.functions]
+"libcrux_aesgcm::AesGcm128Key::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::AesGcm256Key::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::AesGcm128::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::portable::PortableAesGcm128::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::x64::X64AesGcm128::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::neon::NeonAesGcm128::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::AesGcm256::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::portable::PortableAesGcm256::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::x64::X64AesGcm256::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::neon::NeonAesGcm256::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::Key::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::portable::Key::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::x64::Key::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::neon::Key::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::Key::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::portable::Key::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::x64::Key::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::neon::Key::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::KeyRef::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::portable::KeyRef::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::x64::KeyRef::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_128::neon::KeyRef::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::KeyRef::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::portable::KeyRef::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::x64::KeyRef::decrypt" = ["<= 0.0.8"]
+"libcrux_aesgcm::aes_gcm_256::neon::KeyRef::decrypt" = ["<= 0.0.8"]
+
+[versions]
+patched = []
+```
+
+# Non-constant time Authentication Tag Check in AES-GCM Decryption
+
+AES-GCM decryption used an implementation for checking the provided
+authentication tag against the recomputed authentication tag that was
+intended to be constant-time, but resulted in non-constant-time code
+generation in certain circumstances.
+Note that `libcrux-aesgcm` does not give guarantees on constant-time
+code generation and possible mitigations must be considered
+on a best-effort basis.
+
+## Impact
+Users of `libcrux-aesgcm` that expose a decryption oracle to an
+attacker, which allows repeatedly querying for the same ciphertext
+were at risk from timing side-channel attacks, depending on their
+compilation environment. In the worst case, this could lead to
+recovery of the recomputed authentication tag by the attacker, which
+enables ciphertext forgery.
+
+## Mitigation
+Starting from version `0.0.9` (published as `libcrux-aes@v0.0.9`),
+AES-GCM decryption uses a different, best-effort constant-time
+implementation of the tag check, which has been checked to reliably
+lead to constant time code generation, at the moment.
+

--- a/crates/libcrux-aesgcm/RUSTSEC-0000-0000.2.md
+++ b/crates/libcrux-aesgcm/RUSTSEC-0000-0000.2.md
@@ -1,0 +1,16 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libcrux-aesgcm"
+date = "2026-07-15"
+
+url = "https://github.com/celabshq/libcrux/releases/tag/libcrux-aes-v0.0.9"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `libcrux-aesgcm` Renamed to `libcrux-aes`
+
+Crate `libcrux-aesgcm` was renamed to `libcrux-aes` and will no longer receive new versions under the name `libcrux-aesgcm`, with the final released version under that name being version `0.0.8`. The original functionality is now provided in crate `libcrux-aes`, where development continues at version `0.0.9`.

--- a/crates/libcrux-secrets/RUSTSEC-0000-0000.md
+++ b/crates/libcrux-secrets/RUSTSEC-0000-0000.md
@@ -1,0 +1,37 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libcrux-secrets"
+date = "2026-05-26"
+url = "https://github.com/celabshq/libcrux/pull/1461"
+
+cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
+
+[affected.functions]
+"libcrux_secrets::Select::select" = [ "<= 0.0.5" ]
+"libcrux_secrets::Swap::swap" = [ "<= 0.0.5" ]
+
+[versions]
+patched = [">= 0.0.6 "]
+```
+
+# Potentially Incorrect Output of Constant-Time Swap/Select on Aarch64
+
+The implementation of constant-time swap and select on aarch64
+platforms used a `cmp` instruction in inline assembly to check whether
+an 8-bit wide selector was 0. The `cmp` instruction works on 32-bit
+registers, which included the unspecified high 24 bits of the `cmp` operand.
+Depending on the execution environment the `cmp`
+could thus potentially return an incorrect result because its
+operand's high bits in the inline assembly were set when Rust expected them to be unset.
+This could lead to incorrect results for the constant-time swap and select
+operations built from this comparison.
+
+## Impact
+In certain circumstances the swap and select instructions on aarch64
+platforms returned incorrect results.
+
+## Mitigation
+Starting from version `0.0.6`, the selector is compared using a `tst`
+instruction with a mask, which only compares the first 8 bits of the
+selector.

--- a/crates/libcrux-sha3/RUSTSEC-0000-0000.0.md
+++ b/crates/libcrux-sha3/RUSTSEC-0000-0000.0.md
@@ -1,0 +1,38 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libcrux-sha3"
+date = "2026-04-22"
+url = "https://github.com/celabshq/libcrux/pull/1389"
+
+cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
+
+[affected.functions]
+"libcrux_sha3::portable::incremental::Shake128Xof::squeeze" = [ "<= 0.0.9" ]
+"libcrux_sha3::portable::incremental::Shake256Xof::squeeze" = [ "<= 0.0.9" ]
+
+[versions]
+patched = [">= 0.0.10 "]
+```
+
+# Incorrect Output of Incremental Portable SHAKE API on Multiple Squeeze Calls
+
+The incremental squeeze functions in the portable SHAKE XOF API, when
+attempting to squeeze an output using multiple calls to `squeeze`,
+rather than squeezing the full output at once, could output incorrect
+values. Internally, output blocks that were not completely squeezed
+were not buffered for the next call to `squeeze`, which would
+consequently drop bytes of the correct squeeze output if the preceding
+call requested an output of length in bytes not cleanly divisible by
+`RATE` (168 for SHAKE128, 136 for SHAKE256).
+
+## Impact
+This bug impacts users that rely on this XOF API to squeeze output in
+multiple calls where any of the calls request an output length that is
+not divisible by `RATE`. It does not impact the use of libcrux-sha3 in
+libcrux-ml-kem or libcrux-ml-dsa.
+
+## Mitigation
+Starting from version `0.0.10` the squeeze functions correctly output
+all squeezed bytes independent of the number of `squeeze` calls and
+the output lengths requested in each call.

--- a/crates/libcrux-sha3/RUSTSEC-0000-0000.1.md
+++ b/crates/libcrux-sha3/RUSTSEC-0000-0000.1.md
@@ -1,0 +1,34 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "libcrux-sha3"
+date = "2026-05-21"
+url = "https://github.com/celabshq/libcrux/pull/1456"
+
+cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:N/VA:H/SC:N/SI:N/SA:N"
+
+[affected.functions]
+"libcrux_sha3::avx2::x4::shake256" = [ "<= 0.0.9" ]
+
+[versions]
+patched = [">= 0.0.10 "]
+```
+
+# Potential Panic in AVX2 SHAKE-256
+
+The AVX2-optimized implementation of SHAKE-256 intended for use in
+ML-KEM and ML-DSA would panic if the length of the output buffers was
+greater than 32 and not a multiple of 8, due to an out-of-bounds
+indexing operation.
+
+## Impact
+This bug impacts users on AVX2 platforms that use the
+`libcrux_sha3::avx2::x4::shake256` API outside of ML-KEM or ML-DSA
+with output buffers of length `> 32` and not divisible by `8`. It does
+not impact the use in ML-KEM or ML-DSA because there output buffer
+lengths are always divisible by `8`.
+
+## Mitigation
+Starting from version `0.0.10`, the AVX2-optimized SHAKE-256 will no
+longer panic on output buffer lengths `> 32` that are not divisible by
+`8`.


### PR DESCRIPTION
These are advisories for the most recent round of releases for `libcrux` crates.
I'm not entirely sure I've handled everything correctly, in particular the `affected.functions` sections for trait impls and the deprecation advisory for `libcrux-aesgcm`, which has been renamed to `libcrux-aes`.

## Affected crate(s)

- libcrux-sha3 (945k recent downloads)
- libcrux-secrets (917k recent downloads)
- libcrux-aesgcm (426k recent downloads)

## Links to upstream issue(s) or PR(s)
- https://github.com/celabshq/libcrux/pull/1389
- https://github.com/celabshq/libcrux/pull/1456
- https://github.com/celabshq/libcrux/pull/1461
- https://github.com/celabshq/libcrux/pull/1474
- https://github.com/celabshq/libcrux/pull/1528
- https://github.com/celabshq/libcrux/releases/tag/libcrux-aes-v0.0.9 (for the deprecation of `libcrux-aesgcm`

## Severity

- libcrux-sha3
  - Incorrect output of incremental portable SHAKE API on multiple calls to `squeeze`: Wrong output could lead to interoperability issues.
  - Potential Panic in AVX2 implementation of SHAKE-256: An API that was specialized for use in ML-KEM on AVX2 platforms could panic if called with inputs that invalidate the assumptions made when used in ML-KEM.
- libcrux-secrets
  - Incorrect outputs of constant-time swap/select routines on Aarch64: Wrong output on Aarch64 platforms under certain conditions could lead to interoperability issues.
- libcrux-aesgcm
  - AES-GCM did not enforce length limits on AAD: Using very long AAD could eventually degrade authentication strength of the GCM tag.
  - Non-Constant time Authentication Tag Check in AES-GCM Decryption: If a suitable decryption oracle existed and non-constant time code was generated, there was a risk of ciphertext forgery. Note that `libcrux` does not give guarantees on timing side-channel resistance of compiled binaries, but we include this fix as part of a best-effort attempt at side-channel resistance.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
