### PR TITLE
Ammonia 4.1.4, 4.0.3, 3.3.3

### DIFF
--- a/crates/ammonia/RUSTSEC-0000-0000.md
+++ b/crates/ammonia/RUSTSEC-0000-0000.md
@@ -1,0 +1,36 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "ammonia"
+date = "2026-07-21"
+categories = ["format-injection"]
+keywords = ["html", "xss"]
+aliases = ["GHSA-m6mh-2hw2-555x"]
+
+[versions]
+patched = [">= 4.1.4", ">= 4.0.3, < 4.1.0", ">= 3.3.3, < 4.0.0"]
+```
+
+# XSS in ammonia via SVG `animate` and `set` animation tags
+
+The following SVG will produce a link with a javascript scheme.
+If the user clicks this link, they will run it.
+
+```xml
+<svg xmlns="http://www.w3.org/2000/svg">
+  <a>
+    <set attributeName="href" to="javascript:alert('SET_XSS')"></set>
+    <text y="30">Click set</text>
+  </a>
+</svg>
+```
+
+Ammonia did not apply attribute filters based on `attributeName`,
+so the contents of the `to`, `from`, and `values` tags were not sanitized as URLs.
+
+Applications that do not explicitly allow either of these tags should not be affected,
+since neither are allowed by default.
+
+---
+
+**Discovered by:** [Younghun Ko (@koyokr)](https://github.com/koyokr)


### PR DESCRIPTION
## Affected crate(s)

- ammonia (2,338,015)

## Links to upstream issue(s) or PR(s)

- https://github.com/rust-ammonia/ammonia/pull/250
- https://github.com/rust-ammonia/ammonia/pull/251
- https://github.com/rust-ammonia/ammonia/pull/252

## Severity

Low: Produces stored XSS, but only if SVG is enabled, and most sites don't.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
