### PR TITLE
Update alternative recommendation for RUSTSEC-2023-0085

### DIFF
--- a/crates/hpack/RUSTSEC-2023-0085.md
+++ b/crates/hpack/RUSTSEC-2023-0085.md
@@ -32,5 +32,10 @@ pub fn main() {
 hpack is unmaintained. A crate with the panics fixed has been published as
 [hpack-patched](https://crates.io/crates/hpack-patched).
 
-Also consider using [fluke-hpack](https://crates.io/crates/fluke-hpack) or
+Also consider using
+[loona-hpack](https://crates.io/crates/loona-hpack) or
 [httlib-huffman](https://crates.io/crates/httlib-huffman) as an alternative.
+
+Version 0.3.1 of
+[fluke-hpack](https://crates.io/crates/fluke-hpack) still reproduces the panic
+described in this advisory.


### PR DESCRIPTION
## Summary

Update the recommended alternatives in `RUSTSEC-2023-0085`.

`fluke-hpack` 0.3.1 still reproduces the panic described in the advisory,
whereas `loona-hpack` 0.4.3 returns an error instead.
