### PR TITLE
smallstr and gumdrop are unmaintained

### DIFF
--- a/crates/gumdrop/RUSTSEC-0000-0000.md
+++ b/crates/gumdrop/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "gumdrop"
+date = "2026-07-22"
+informational = "unmaintained"
+url = "https://github.com/murarth/gumdrop/issues/63"
+
+[versions]
+patched = []
+```
+
+# gumdrop is unmaintained
+
+The gumdrop crate is unmaintained, and all versions are affected.
+
+Recommended alternatives:
+
+- [clap](https://crates.io/crates/clap) is the most popular by far
+- [bpaf](https://crates.io/crates/bpaf) is a more lightweight alternative

--- a/crates/smallstr/RUSTSEC-0000-0000.md
+++ b/crates/smallstr/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "smallstr"
+date = "2026-07-22"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# smallstr is unmaintained
+
+The smallstr crate is unmaintained, and all versions are affected.
+
+Recommended alternatives:
+
+- [compact_str](https://crates.io/crates/compact_str) is the most popular by far
+- [smol_str](https://crates.io/crates/smol_str) focuses on immutable strings


### PR DESCRIPTION
## Affected crate(s)

- smallstr (2.2M recent downloads)
- gumdrop (720k recent downloads)

I contacted the author privately to inquire about the status of gumdrop. This is their response:

> Unfortunately, I don't have time to maintain my open source software projects anymore. So, yes, it would be fair to list gumdrop and any other crates I've uploaded as unmaintained. Thanks for reaching out.

See [their crates](https://crates.io/users/murarth?sort=recent-downloads).

The most popular crate by far is assert_matches. Given that this was just stabilized in std in 1.97, I think now would not be a good time to notify people that is is unmaintained? gumdrop and smallstr are both pretty popular and have popular alternatives available. Beyond that, the remainder of the crates is much less popular.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
