### PR TITLE
add advisory for nostr

### DIFF
--- a/crates/nostr/RUSTSEC-0000-0000.md
+++ b/crates/nostr/RUSTSEC-0000-0000.md
@@ -1,0 +1,41 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "nostr"
+date = "2026-07-25"
+references = [
+    "https://github.com/nostrdevkit/nostr/commit/73bdd677b872641d57a2ebcc5afc23ee0e5f0d2d",
+]
+categories = ["denial-of-service"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+keywords = ["nostr", "nip-44", "panic"]
+
+[affected.functions]
+"nostr::nips::nip44::decrypt" = [">= 0.26.0, < 0.44.5", ">= 0.45.0-alpha.1, < 0.45.0-alpha.5"]
+"nostr::nips::nip44::decrypt_to_bytes" = [">= 0.26.0, < 0.44.5", ">= 0.45.0-alpha.1, < 0.45.0-alpha.5"]
+"nostr::nips::nip44::v2::decrypt_to_bytes" = [">= 0.26.0, < 0.44.5", ">= 0.45.0-alpha.1, < 0.45.0-alpha.5"]
+
+[versions]
+patched = [">= 0.44.5, < 0.45.0-alpha.1", ">= 0.45.0-alpha.5"]
+```
+
+# Remote Denial of Service via malformed NIP‑44 v2 payload
+
+The NIP-44 v2 decryption path in the `nostr` crate contains a reachable panic
+when processing a short or empty ciphertext. After the HMAC check passes and the
+ciphertext is decrypted via ChaCha20, the code reads a 2‑byte unpadded‑length
+prefix via `buffer[0..2]` without first verifying that the decrypted buffer
+contains at least 2 bytes. A malicious sender who holds the symmetric
+conversation key (e.g., a direct‑message sender) can craft a payload that
+produces a 0 or 1‑byte decrypted buffer, causing an index‑out‑of‑bounds panic.
+This can be triggered remotely through any relay that delivers the crafted
+event to the victim's client, resulting in a denial of service. No key material,
+plaintext, or memory corruption occurs.
+
+The vulnerability is present in all versions from `0.26.0` up to `0.44.4`
+(inclusive) and in the alpha releases `0.45.0‑alpha.1` through `0.45.0‑alpha.4`.
+Versions `0.44.5` and `0.45.0‑alpha.5` contain the fix.
+
+## Credit
+
+Discovered and responsibly disclosed by **Muhammed Shekho** (info@mhd-shekho.com, [mhd-shekho.com](https://mhd-shekho.com)).


### PR DESCRIPTION
## Affected crate(s)

- `nostr` (`596,316` recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/nostrdevkit/nostr/commit/73bdd677b872641d57a2ebcc5afc23ee0e5f0d2d (This vulnerability was reported and fixed privately as part of a coordinated disclosure. No public issue or pull request exists.)

## Severity

A reachable panic in the NIP‑44 v2 decryption function allows a remote attacker to cause denial‑of‑service (process crash) in the recipient's client.

## Checklist

- [X] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [X] `date` field is set to the public disclosure date
- [X] Contains a concise and descriptive title after advisory metadata
- [X] Asked maintainer(s) if publishing an advisory is appropriate
