### PR TITLE
Add advisories for issues fixed in rkyv v0.8.17

### DIFF
--- a/crates/rkyv/RUSTSEC-0000-0000.1.md
+++ b/crates/rkyv/RUSTSEC-0000-0000.1.md
@@ -1,0 +1,30 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rkyv"
+date = "2026-05-11"
+url = "https://github.com/rkyv/rkyv/issues/666"
+references = [
+    "https://github.com/rkyv/rkyv/commit/3c9d07fbff5949261bef38d00ab160b129bd9d3a",
+    "https://github.com/rkyv/rkyv/commit/107772907c4e839fa67900385f0d4814e7d15e42",
+]
+categories = ["memory-corruption"]
+keywords = ["use-after-free", "validation", "deserialization"]
+
+[versions]
+patched = [">= 0.8.17"]
+unaffected = ["< 0.8.0-rc.1"]
+```
+
+# Crafted archives can cause a use-after-free during deserialization
+
+Insufficient archive range validation could allow a crafted archive to reach
+`ArchivedString::deserialize` with an invalid pointer. A reported reproducer
+used `rkyv::from_bytes` to deserialize a struct containing strings, a vector,
+a box, and an optional hash map. AddressSanitizer detected a heap use-after-free
+during string deserialization.
+
+The flaw could be triggered through the safe checked deserialization API when
+processing malicious archive bytes. Version 0.8.17 rejects the malformed
+archive during validation. Users who process untrusted archives should upgrade
+to 0.8.17 or later.

--- a/crates/rkyv/RUSTSEC-0000-0000.2.md
+++ b/crates/rkyv/RUSTSEC-0000-0000.2.md
@@ -1,0 +1,34 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rkyv"
+date = "2026-05-13"
+url = "https://github.com/rkyv/rkyv/issues/670"
+references = [
+    "https://github.com/rkyv/rkyv/commit/3c9d07fbff5949261bef38d00ab160b129bd9d3a",
+]
+categories = ["memory-exposure"]
+keywords = ["out-of-bounds-read", "validation", "shared-pointer"]
+
+[versions]
+patched = [">= 0.8.17"]
+unaffected = ["< 0.7.0-pre.2"]
+```
+
+# Insufficient archive validation can cause out-of-bounds reads in archives containing Rc/Arc
+
+Shared pointer validation keyed already-validated pointees by their address and
+type, but did not include pointer metadata. For unsized pointees, an archive
+could therefore contain multiple `Rc`, `Arc`, or weak pointers that shared a
+data address but used different metadata, such as different slice lengths.
+
+Once the first pointer had been validated, later pointers to the same address
+skipped pointee validation. The safe checked `rkyv::access` API could
+consequently return a slice with a forged length, allowing safe indexing to
+read out of bounds. The same validation bypass was reachable through checked
+deserialization with `rkyv::from_bytes`.
+
+Version 0.8.17 includes pointer metadata in shared pointer validation and
+rejects conflicting metadata. The 0.7 series is also affected but is no
+longer supported by upstream. Users who process untrusted archives should upgrade
+to 0.8.17 or later.

--- a/crates/rkyv/RUSTSEC-0000-0000.md
+++ b/crates/rkyv/RUSTSEC-0000-0000.md
@@ -1,0 +1,36 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rkyv"
+date = "2026-05-11"
+url = "https://github.com/rkyv/rkyv/issues/663"
+references = [
+    "https://github.com/rkyv/rkyv/issues/664",
+    "https://github.com/rkyv/rkyv/issues/665",
+    "https://github.com/rkyv/rkyv/issues/669",
+    "https://github.com/rkyv/rkyv/commit/3c9d07fbff5949261bef38d00ab160b129bd9d3a",
+    "https://github.com/rkyv/rkyv/commit/57086e1c7f417d0360c7045905db3b3d8e30f866",
+]
+categories = ["memory-exposure", "denial-of-service"]
+keywords = ["out-of-bounds-read", "validation", "hashmap"]
+
+[versions]
+patched = [">= 0.8.17"]
+unaffected = ["< 0.8.0-rc.1"]
+```
+
+# Insufficient archive validation can cause out-of-bounds reads in archives containing hash tables
+
+The archive validator could accept certain malformed relative pointers and
+invalid `ArchivedHashTable` states. In particular, the hash table verifier did
+not ensure that the number of occupied buckets matched the table's declared
+length.
+
+A crafted archive could pass the checks performed by the safe `rkyv::access`
+and `rkyv::from_bytes` APIs and then cause an out-of-bounds read in later
+validation, lookup, or deserialization. Depending on the input, this could
+perform scalar or SIMD reads outside the archive buffer or crash the process.
+
+Version 0.8.17 strengthens archive range validation and rejects hash tables
+whose number of occupied buckets does not match their declared length. Users
+who process untrusted archives should upgrade to 0.8.17 or later.


### PR DESCRIPTION
## Affected crate(s)

- rkvy (recent downloads per crates.io: 32 million)

## Links to upstream issue(s) or PR(s)

https://github.com/rkyv/rkyv/issues/663
https://github.com/rkyv/rkyv/issues/664
https://github.com/rkyv/rkyv/issues/665
https://github.com/rkyv/rkyv/issues/666
https://github.com/rkyv/rkyv/issues/669
https://github.com/rkyv/rkyv/issues/670

## Severity

High. UAF and out-of-bounds reads in deserializing untrusted archives.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate

