### PR TITLE
Add advisory for enum-map

### DIFF
--- a/crates/enum-map/RUSTSEC-0000-0000.md
+++ b/crates/enum-map/RUSTSEC-0000-0000.md
@@ -1,0 +1,40 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "enum-map"
+date = "2026-07-21"
+url = "https://codeberg.org/sugar700/enum-map/src/branch/master/CHANGELOG.md#version-310"
+references = ["https://github.com/rustsec/advisory-db/issues/3060"]
+informational = "unsound"
+categories = ["memory-corruption"]
+
+[versions]
+patched = [">= 3.1.0"]
+unaffected = ["< 3.0.0-0.gat.0"]
+```
+
+# `Enum` trait allows type confusion when manually implemented
+
+Affected versions of this crate did not require the element type of the `Array` associated type in the `Enum` trait to match the array's generic parameter `V`.
+
+This can result in type confusion, and consequently memory corruption, when a manual `Enum` implementation declares an `Array<V>` whose elements are not actually of type `V`:
+
+```rust
+struct IntentionallyWrong;
+
+impl Enum for IntentionallyWrong {
+    type Array<V> = [String; 4];
+
+    fn from_usize(_: usize) -> Self {
+        IntentionallyWrong
+    }
+
+    fn into_usize(self) -> usize {
+        0
+    }
+}
+
+enum_map! { IntentionallyWrong => 42 };
+```
+
+The flaw was corrected in commit [7a8b815432](https://codeberg.org/sugar700/enum-map/commit/7a8b8154323d426415a10accf104cd05c394cda9) by adding a `Value = V` bound to the `Array` type in the `Enum` trait.


### PR DESCRIPTION
## Affected crate(s)

- enum-map  (RecentDownloads: 9,422,323)

## Links to upstream issue(s) or PR(s)

Reported by the developer @sugar700  at https://github.com/rustsec/advisory-db/issues/3060

## Severity

Unsoundness leading to memory corruption.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [ ] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
