### PR TITLE
fix web publishing when we have a cache hit

### DIFF
--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -20,8 +20,10 @@ jobs:
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: admin-cache
         with:
-          path: ~/.cargo/bin
-          key: rustsec-admin-04cc3a7e0e0a81370a08c6f4aea3192255b19275
+          path:
+            ~/.cargo/bin
+            ~/.cargo/git
+          key: rustsec-admin-04cc3a7e0e0a81370a08c6f4aea3192255b19275-v2
 
       - name: Install rustsec-admin
         if: steps.admin-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Since d9c89372 in rustsec/rustsec, we've been failing to build whenever the admin binary is cached.
