### PR TITLE
Extract repeated rustsec-admin install/cache into a reusable action

### DIFF
--- a/.github/actions/install-rustsec-admin/action.yml
+++ b/.github/actions/install-rustsec-admin/action.yml
@@ -1,0 +1,23 @@
+name: Install rustsec-admin
+description: Install the rustsec-admin tool, with caching
+
+inputs:
+  rev:
+    description: Git revision of rustsec/rustsec to build rustsec-admin from
+    required: false
+    default: 9296b796c38ff8e64c4278d3ae9fd18e42cab1ad
+
+runs:
+  using: composite
+  steps:
+    - name: Cache cargo bin
+      id: admin-cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cargo/bin
+        key: rustsec-admin-${{ inputs.rev }}
+
+    - name: Install rustsec-admin
+      if: steps.admin-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: cargo install --git https://github.com/rustsec/rustsec rustsec-admin --rev ${{ inputs.rev }}

--- a/.github/workflows/assign-ids.yml
+++ b/.github/workflows/assign-ids.yml
@@ -18,16 +18,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Cache cargo bin
-        id: admin-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cargo/bin
-          key: rustsec-admin-9296b796c38ff8e64c4278d3ae9fd18e42cab1ad
-
       - name: Install rustsec-admin
-        if: steps.admin-cache.outputs.cache-hit != 'true'
-        run: cargo install --git https://github.com/rustsec/rustsec rustsec-admin --rev 9296b796c38ff8e64c4278d3ae9fd18e42cab1ad
+        uses: ./.github/actions/install-rustsec-admin
 
       - name: Assign IDs
         id: assign

--- a/.github/workflows/export-osv.yml
+++ b/.github/workflows/export-osv.yml
@@ -12,20 +12,19 @@ jobs:
     permissions:
       contents: write # needed for pushing back to the repo
     steps:
+      # Checkout main first so the local install-rustsec-admin action is
+      # available; the osv checkout below replaces the workspace.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install rustsec-admin
+        uses: ./.github/actions/install-rustsec-admin
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: osv
           persist-credentials: true # persists the token for git push below
-
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: admin-cache
-        with:
-          path: ~/.cargo/bin
-          key: rustsec-admin-9296b796c38ff8e64c4278d3ae9fd18e42cab1ad
-
-      - name: Install rustsec-admin
-        if: steps.admin-cache.outputs.cache-hit != 'true'
-        run: cargo install --git https://github.com/rustsec/rustsec rustsec-admin --rev 9296b796c38ff8e64c4278d3ae9fd18e42cab1ad
 
       - run: |
           mkdir -p crates

--- a/.github/workflows/publish-web.yml
+++ b/.github/workflows/publish-web.yml
@@ -12,20 +12,19 @@ jobs:
     permissions:
       contents: write # needed for pushing back to the repo
     steps:
+      # Checkout main first so the local install-rustsec-admin action is
+      # available; the gh-pages checkout below replaces the workspace.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install rustsec-admin
+        uses: ./.github/actions/install-rustsec-admin
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: gh-pages
           persist-credentials: true # persists the token for git push below
-
-      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: admin-cache
-        with:
-          path: ~/.cargo/bin
-          key: rustsec-admin-9296b796c38ff8e64c4278d3ae9fd18e42cab1ad
-
-      - name: Install rustsec-admin
-        if: steps.admin-cache.outputs.cache-hit != 'true'
-        run: cargo install --git https://github.com/rustsec/rustsec rustsec-admin --rev 9296b796c38ff8e64c4278d3ae9fd18e42cab1ad
 
       - run: |
           rustsec-admin web .

--- a/.github/workflows/sync-ids.yml
+++ b/.github/workflows/sync-ids.yml
@@ -20,16 +20,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Cache cargo bin
-        id: admin-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cargo/bin
-          key: rustsec-admin-9296b796c38ff8e64c4278d3ae9fd18e42cab1ad
-
       - name: Install rustsec-admin
-        if: steps.admin-cache.outputs.cache-hit != 'true'
-        run: cargo install --git https://github.com/rustsec/rustsec rustsec-admin --rev 9296b796c38ff8e64c4278d3ae9fd18e42cab1ad
+        uses: ./.github/actions/install-rustsec-admin
 
       - name: Synchronize IDs
         id: sync_ids

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,16 +16,8 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Cache cargo bin
-        id: admin-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.cargo/bin
-          key: rustsec-admin-9296b796c38ff8e64c4278d3ae9fd18e42cab1ad
-
       - name: Install rustsec-admin
-        if: steps.admin-cache.outputs.cache-hit != 'true'
-        run: cargo install --git https://github.com/rustsec/rustsec rustsec-admin --rev 9296b796c38ff8e64c4278d3ae9fd18e42cab1ad
+        uses: ./.github/actions/install-rustsec-admin
 
       - name: Lint advisories
         run: rustsec-admin lint


### PR DESCRIPTION
All five workflows duplicated the same `actions/cache` + `cargo install` steps for `rustsec-admin`, each hardcoding the pinned revision twice. This moves them into a composite action at `.github/actions/install-rustsec-admin`, with the revision as a single-source-of-truth default input — future version bumps become a one-line change (the cache key derives from it automatically).

`publish-web` and `export-osv` check out the `gh-pages`/`osv` branches, where the new action file doesn't exist (local `uses: ./...` resolves from the workspace). Those two now check out `main` first, run the install action, then check out the deploy branch as before. The second checkout fully replaces the workspace — with the default `clean: true`, actions/checkout runs `git clean -ffdx` + `git reset --hard` and then `git checkout --force <ref>` (falling back to deleting the directory contents and re-cloning if cleaning fails), so the publish steps run against exactly the same content as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)