### PR TITLE
Save rustsec-admin cache eagerly instead of in a post step

### DIFF
--- a/.github/actions/install-rustsec-admin/action.yml
+++ b/.github/actions/install-rustsec-admin/action.yml
@@ -10,9 +10,13 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Cache cargo bin
+    # restore/save are used instead of the combined cache action because the
+    # latter saves in a post step, which re-resolves this action.yml from the
+    # workspace at job end — and fails in jobs that later check out a branch
+    # (gh-pages, osv) where this file doesn't exist.
+    - name: Restore cached cargo bin
       id: admin-cache
-      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
       with:
         path: ~/.cargo/bin
         key: rustsec-admin-${{ inputs.rev }}
@@ -21,3 +25,10 @@ runs:
       if: steps.admin-cache.outputs.cache-hit != 'true'
       shell: bash
       run: cargo install --git https://github.com/rustsec/rustsec rustsec-admin --rev ${{ inputs.rev }}
+
+    - name: Save cached cargo bin
+      if: steps.admin-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cargo/bin
+        key: rustsec-admin-${{ inputs.rev }}


### PR DESCRIPTION
Fixes the post-step failure in `publish-web` and `export-osv` after #3078 (e.g. [this run](https://github.com/rustsec/advisory-db/actions/runs/30282638207/job/90032592413)).

The combined `actions/cache` action saves the cache in a **post step**, and the runner re-resolves a local composite action's `action.yml` from the workspace when running its post steps. In `publish-web`/`export-osv` the workspace holds the `gh-pages`/`osv` branch by job end, so the file is gone and the post step errors out:

```
Post Install rustsec-admin  ##[error]Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '.../.github/actions/install-rustsec-admin'.
```

This switches the action to `actions/cache/restore` + an explicit `actions/cache/save` immediately after `cargo install` (both pinned to the same sha; neither defines a `post` hook, so the composite registers no post step). Saving eagerly is also strictly better here: `~/.cargo/bin` is final right after the install, and the old post-step save was silently never running in these two jobs, so their cache was only ever populated by the other workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)