### PR TITLE
Add advisory for tract-nnef (NNEF parser integer overflow → OOB read)

### DIFF
--- a/crates/tract-nnef/RUSTSEC-0000-0000.md
+++ b/crates/tract-nnef/RUSTSEC-0000-0000.md
@@ -1,0 +1,54 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tract-nnef"
+date = "2026-06-18"
+url = "https://github.com/sonos/tract/security/advisories/GHSA-x5mv-8wgw-29hg"
+references = [
+    "https://github.com/sonos/tract/commit/34c7df2c9bd2a36583e09b52f3e6319bf23102e8",
+]
+categories = ["memory-exposure", "denial-of-service"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:L/I:N/A:H"
+keywords = ["parsing", "nnef", "integer-overflow", "out-of-bounds-read"]
+aliases = ["CVE-2026-55093", "GHSA-x5mv-8wgw-29hg"]
+
+[affected.functions]
+"tract_nnef::tensors::read_tensor" = ["< 0.21.16", ">= 0.22.0, < 0.22.2", ">= 0.23.0, < 0.23.1"]
+
+[versions]
+patched = [">= 0.21.16, < 0.22.0", ">= 0.22.2, < 0.23.0", ">= 0.23.1"]
+```
+
+# Integer overflow in tract-nnef NNEF tensor parser leads to out-of-bounds read on model load
+
+`tract_nnef::tensors::read_tensor` builds a tensor shape from attacker-controlled
+32-bit dimensions and computes both the element count `product(shape)` and the
+byte allocation `product(shape) * size_of(dt)` with **unchecked `usize`
+arithmetic**. In release builds (no `overflow-checks`) both products wrap modulo
+2^64.
+
+A crafted NNEF `.dat` tensor can choose dimensions whose wrapped products
+collapse to a small value that satisfies the header size-consistency check, while
+the true element count stays astronomically large. `read_tensor` then returns a
+`Tensor` whose reported `len` (e.g. `2^61 + 7`) far exceeds its backing heap
+allocation (e.g. 56 bytes). The unchecked accessor `as_slice_unchecked`
+(`slice::from_raw_parts(ptr, self.len())`) subsequently yields a slice spanning
+~18 EiB over the small buffer.
+
+The out-of-bounds read fires automatically during model build (no inference
+required), reachable through the default `DatLoader` resource loader via the
+public `tract_nnef::nnef().model_for_path` / `model_for_read` API when the
+const-folding `as_uniform` fast-path materializes the over-long constant. The
+always-on primitive is a bounded adjacent-heap over-read (information
+disclosure); access further past the mapped region SIGSEGVs (denial of service).
+No out-of-bounds write or code execution was demonstrated.
+
+Affected: every release line prior to the backported fixes — `< 0.21.16`,
+`0.22.0`–`0.22.1`, and `0.23.0`. The block-quant path had already received an
+analogous blob-size guard; the dense `DatLoader` path was missed.
+
+## Mitigation
+
+Upgrade to `0.21.16`, `0.22.2`, or `0.23.1`. The fix computes the shape product
+and byte size with `checked_mul` and rejects the tensor on overflow
+(commit [`34c7df2`](https://github.com/sonos/tract/commit/34c7df2c9bd2a36583e09b52f3e6319bf23102e8)).


### PR DESCRIPTION
This re-files #2955, which was closed because it didn't follow the pull request
template. This one does. Same crate, same bug, same fix commit.

## Affected crate(s)

- `tract-nnef` (~882k recent downloads)

## Links to upstream issue(s) or PR(s)

- Fix commit: https://github.com/sonos/tract/commit/34c7df2c9bd2a36583e09b52f3e6319bf23102e8 ("fix(nnef): reject overflowing tensor dims")
- Reported privately to the maintainer and confirmed via GitHub Security Advisory GHSA-x5mv-8wgw-29hg (sonos/tract), published 2026-06-18. CVE-2026-55093 was assigned through that advisory.
- The maintainer (kali) reviewed the finding, shipped the fix, and confirmed he was fine with a RustSec advisory being filed.

## Severity

`read_tensor` in `tract-nnef` computes a tensor's element count and byte size from attacker-controlled 32-bit dimensions using unchecked `usize` arithmetic. On a crafted NNEF `.dat` the products wrap mod 2^64 past the size-consistency check, leaving a `Tensor` whose reported `len` is far larger than its heap allocation. Loading the model is enough to trigger an out-of-bounds read (adjacent-heap disclosure; SIGSEGV on any access further past the buffer) through the public `model_for_path` / `model_for_read` API. No write primitive or RCE was demonstrated. Medium.

Patched in 0.21.16, 0.22.2 and 0.23.1 by computing the products with `checked_mul` and rejecting on overflow. The block-quant path already had this guard (commit eacd13cc); the dense `DatLoader` path was missed.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
