### PR TITLE
Add advisory for fontdue: invalid char constructed from untrusted font data

### DIFF
--- a/crates/fontdue/RUSTSEC-0000-0000.md
+++ b/crates/fontdue/RUSTSEC-0000-0000.md
@@ -1,0 +1,99 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "fontdue"
+date = "2026-07-06"
+url = "https://github.com/mooman219/fontdue/issues/172"
+references = [
+    "https://docs.rs/fontdue/0.9.3/src/fontdue/font.rs.html#269",
+]
+informational = "unsound"
+categories = ["memory-corruption"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:L/A:L"
+keywords = ["font", "cmap", "transmute", "undefined-behavior"]
+
+[affected.functions]
+"fontdue::Font::from_bytes" = [">= 0.6.4"]
+
+[versions]
+patched = []
+unaffected = ["< 0.6.4"]
+```
+
+# `fontdue::Font::from_bytes` constructs an invalid `char` from untrusted font data
+
+`Font::from_bytes` builds the codepoint-to-glyph map by transmuting each raw `u32`
+codepoint read from the font's `cmap` table directly into a `char`, with no
+validity check (`src/font.rs:269` in 0.9.3):
+
+```rust
+subtable.codepoints(|codepoint| {
+    if let Some(mapping) = subtable.glyph_index(codepoint) {
+        if let Some(mapping) = NonZeroU16::new(mapping.0) {
+            indices_to_load.insert(mapping.get());
+            char_to_glyph.insert(unsafe { mem::transmute::<u32, char>(codepoint) }, mapping);
+        }
+    }
+})
+```
+
+A `char` must be a Unicode scalar value — `0..=0xD7FF` or `0xE000..=0x10FFFF`.
+Producing one from any other `u32` is immediate undefined behavior.
+
+The codepoints originate in `ttf-parser`'s cmap iterators, which pass through
+whatever the file contains:
+
+- format 4 (`Subtable4::codepoints`) yields `u32::from(code_point)` for every
+  `code_point in start..=end`, where `start` and `end` are read straight from the
+  table; the surrogate range `0xD800..=0xDFFF` is not excluded. With
+  `idRangeOffset == 0`, `glyph_index` returns
+  `Some(GlyphId(code_point.wrapping_add(id_delta)))`, so a surrogate reaches the
+  transmute with a non-zero glyph id.
+- format 12 (`Subtable12::codepoints`) iterates `start_char_code..=end_char_code`
+  as raw `u32`, so values above `0x10FFFF` reach the same sink.
+
+`Font::from_bytes` is the crate's only font constructor and is safe. An
+application that parses an untrusted or user-supplied font therefore executes the
+undefined behavior during parsing, before any rasterization. The invalid `char`
+is retained as a live `HashMap<char, NonZeroU16>` key and returned to safe
+callers by the public `chars()` accessor.
+
+Reproduced under Miri against the published `fontdue 0.9.3`, with a 240-byte font
+carrying one format-4 segment `startCode = endCode = 0xD800`,
+`idRangeOffset = 0`, `idDelta = 1`:
+
+```
+error: Undefined Behavior: constructing invalid value of type char:
+       encountered 0x0000d800, but expected a valid unicode scalar value
+       (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
+   --> fontdue-0.9.3/src/font.rs:269:59
+```
+
+The same input reproduces on 0.6.4, the first release in which `char_to_glyph` is
+keyed by `char` and the transmute was introduced. Releases up to 0.6.3 key that
+map by `u32` and are unaffected. No memory corruption or code execution was
+demonstrated; consequences beyond the undefined behavior itself depend on code
+generation and on what consumers do with the invalid `char`.
+
+## Mitigation
+
+No fixed release exists. The issue was reported upstream on 2026-07-06 and
+remains open; the crate is marked `maintenance = "experimental"` and has had no
+release since February 2025.
+
+Validating the codepoint with `char::from_u32` and skipping values that are not
+scalar values removes the undefined behavior and is behaviour-preserving, since a
+`HashMap<char, _>` cannot key on a non-scalar value regardless:
+
+```rust
+if let Some(character) = char::from_u32(codepoint) {
+    if let Some(mapping) = subtable.glyph_index(codepoint) {
+        if let Some(mapping) = NonZeroU16::new(mapping.0) {
+            indices_to_load.insert(mapping.get());
+            char_to_glyph.insert(character, mapping);
+        }
+    }
+}
+```
+
+Until that lands, do not pass untrusted font data to `Font::from_bytes`.


### PR DESCRIPTION
## Affected crate(s)

- `fontdue` (3,236,119 recent downloads, 7,970,747 all-time per crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/mooman219/fontdue/issues/172 (filed 2026-07-06, open, no maintainer response)

## Severity

Soundness issue — undefined behavior reachable from a safe public API with only
attacker-controlled input.

`Font::from_bytes`, the crate's only font constructor, transmutes each raw `u32`
codepoint from the font's `cmap` table into a `char` without checking that it is
a Unicode scalar value:

```rust
char_to_glyph.insert(unsafe { mem::transmute::<u32, char>(codepoint) }, mapping);
```

`ttf-parser`'s cmap iterators do not filter invalid codepoints: format-4
subtables yield surrogates (`0xD800..=0xDFFF`) and format-12 subtables yield
values above `0x10FFFF`. A crafted font therefore makes `from_bytes` construct an
invalid `char`, which is immediate undefined behavior. The invalid value is kept
as a live `HashMap<char, NonZeroU16>` key and handed back to safe callers by the
public `chars()` accessor.

Confirmed with Miri against the published crates.io releases, using a 240-byte
font with one format-4 segment `startCode = endCode = 0xD800`,
`idRangeOffset = 0`, `idDelta = 1`:

```
error: Undefined Behavior: constructing invalid value of type char:
       encountered 0x0000d800, but expected a valid unicode scalar value
       (in `0..=0x10FFFF` but not in `0xD800..=0xDFFF`)
   --> fontdue-0.9.3/src/font.rs:269:59
```

The UB fires during parsing, before any rasterization, so any application that
loads untrusted or user-supplied fonts is exposed. No memory corruption or code
execution was demonstrated.

Affected from 0.6.4 onward: that is the release in which `char_to_glyph` changed
from `HashMap<u32, NonZeroU16>` to `HashMap<char, NonZeroU16>` and the transmute
was introduced. Reproduced under Miri on both 0.6.4 (with `ttf-parser` 0.12.3)
and 0.9.3 (with `ttf-parser` 0.21.1). Releases up to 0.6.3 key the map by `u32`
and are unaffected. 0.9.3 is the latest release (2025-02-12) and is still
affected, as is current `master`; the crate is marked
`maintenance = "experimental"`, so `patched` is empty.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate

On the last point: the crate has no security policy and private vulnerability
reporting is disabled, so the report was made on the public issue tracker on
2026-07-06. It has had no maintainer response in over three weeks. This is filed
under the CONTRIBUTING provision for advisories that receive no response
following public disclosure on the repository issue tracker. Happy to hold the
advisory if you would rather wait longer.

Reported by s1ko (s1ko@riseup.net, https://github.com/s1ko).
