### PR TITLE
Add advisory for nostr (NIP-04)

### DIFF
--- a/crates/nostr/RUSTSEC-0000-0000.md
+++ b/crates/nostr/RUSTSEC-0000-0000.md
@@ -1,0 +1,44 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "nostr"
+date = "2026-07-26"
+url = "https://github.com/nostrdevkit/nostr/commit/b24619346f666d08ef7fefe27f033b8bc871697f"
+categories = ["denial-of-service"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+keywords = ["panic", "nip04", "nip47", "nwc"]
+
+[affected.functions]
+"nostr::nips::nip04::decrypt" = [">= 0.1.5"]
+"nostr::nips::nip04::decrypt_to_bytes" = [">= 0.26.0"]
+
+[versions]
+patched = [">= 0.44.6, < 0.45.0-alpha.1", ">= 0.45.0-alpha.6"]
+```
+
+# Remote Denial of Service via malformed NIP-04 IV
+
+The `nostr` crate did not validate the length of the initialization vector
+decoded from the `?iv=` portion of a NIP-04 encrypted message.
+
+The decoded IV was converted from a byte slice to the 16-byte AES-CBC IV type
+using a conversion that asserts the slice length. As a result, an IV whose
+decoded length was not exactly 16 bytes caused a panic before ciphertext
+decryption. For example, `?iv=AAAA` decodes to a three-byte IV and triggers the
+panic.
+
+Applications that decrypt untrusted NIP-04 content are affected. The issue is
+also reachable through NIP-47 (Nostr Wallet Connect), where response and
+notification events from a malicious or compromised wallet service are passed
+to NIP-04 decryption. If the panic is not isolated, a crafted event can terminate
+the application or disrupt message processing, causing a denial of service.
+
+The issue does not affect confidentiality or integrity.
+
+The flaw was corrected by converting the decoded IV to `[u8; 16]` using a
+checked conversion. Invalid IV lengths now return a `Malformed` error instead of
+panicking.
+
+## Credit
+
+Discovered and responsibly disclosed by **Muhammed Shekho** ([mhd-shekho.com](https://mhd-shekho.com)).


### PR DESCRIPTION
## Affected crate(s)

- nostr (`621,415` downloads per crates.io)

## Links to upstream issue(s) or PR(s)

https://github.com/nostrdevkit/nostr/commit/b24619346f666d08ef7fefe27f033b8bc871697f (This vulnerability was reported and fixed privately as part of a coordinated disclosure. No public issue or pull request exists.)

## Severity

A reachable panic in the NIP‑04 decryption function allows a remote attacker to cause denial‑of‑service (process crash) in the recipient's client.

## Checklist

- [X] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [X] `date` field is set to the public disclosure date
- [X] Contains a concise and descriptive title after advisory metadata
- [X] Asked maintainer(s) if publishing an advisory is appropriate
