### PR TITLE
Add advisory for ruint (shift overflow-flag false negatives, shift-amount truncation)

### DIFF
--- a/crates/ruint/RUSTSEC-0000-0000.md
+++ b/crates/ruint/RUSTSEC-0000-0000.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "ruint"
-date = "2026-07-30"
+date = "2026-07-08"
 url = "https://github.com/alloy-rs/ruint/pull/603"
 categories = ["denial-of-service"]
 keywords = ["shift", "overflow", "arithmetic", "infinite-loop"]

--- a/crates/ruint/RUSTSEC-0000-0000.md
+++ b/crates/ruint/RUSTSEC-0000-0000.md
@@ -1,0 +1,45 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "ruint"
+date = "2026-07-30"
+url = "https://github.com/alloy-rs/ruint/pull/603"
+categories = ["denial-of-service"]
+keywords = ["shift", "overflow", "arithmetic", "infinite-loop"]
+
+[affected.functions]
+"ruint::Uint::overflowing_shl" = ["< 1.20.0"]
+"ruint::Uint::overflowing_shr" = ["< 1.20.0"]
+"ruint::Uint::checked_shl" = ["< 1.20.0"]
+"ruint::Uint::checked_shr" = ["< 1.20.0"]
+"ruint::Uint::saturating_shl" = ["< 1.20.0"]
+"ruint::Uint::saturating_shr" = ["< 1.20.0"]
+"ruint::Uint::wrapping_shl" = ["< 1.20.0"]
+"ruint::Uint::wrapping_shr" = ["< 1.20.0"]
+
+[versions]
+patched = [">= 1.20.0"]
+```
+
+# Uint shift operations: incorrect overflow flags and truncated shift amounts
+
+`Uint::overflowing_shl`/`overflowing_shr` returned false-negative overflow
+flags. `overflowing_shl` missed bits shifted above `BITS` but within the top
+limb (non-limb-aligned widths such as `U160`), and limbs wholly discarded by
+shifts >= 64; `overflowing_shr` missed wholly discarded low limbs. Shifted
+values were correct; only the flag was wrong.
+
+The wrong flag propagates: `checked_shl`/`checked_shr` return `Some` instead
+of `None`, `strict_*` fail to panic, and `saturating_*` return a wrapped
+value instead of saturating. The incorrect `checked_shl` result causes
+`to_base_be` (and string formatting) to loop forever on no-alloc builds for
+non-limb-aligned widths — a denial of service if formatting is reachable
+from untrusted input.
+
+Separately, `wrapping_shl`/`wrapping_shr` on 64/128/256-bit types truncated
+the shift amount modulo 2^32, so shifts >= 2^32 returned an incorrectly
+wrapped value instead of zero; on 32-bit targets the generic path also
+truncated 64-bit shift amounts.
+
+Callers using checked or saturating shift semantics on untrusted shift
+amounts may compute incorrect results.


### PR DESCRIPTION
## Affected crate(s)

- ruint (~6,500,000 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- Fix: https://github.com/alloy-rs/ruint/pull/603 (released in 1.20.0)

## Severity

Low/moderate. `overflowing_shl`/`overflowing_shr` returned false-negative
overflow flags, so `checked_*`/`strict_*`/`saturating_*` shifts silently
mis-handled oversized shift amounts, and `to_base_be` loops forever on
no-alloc builds for non-limb-aligned widths (denial of service if
formatting is reachable from untrusted input).

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate — I maintain ruint and agreed to file this in alloy-rs/ruint#603
