### PR TITLE
Add advisory for event-listener

### DIFF
--- a/crates/event-listener/RUSTSEC-0000-0000.md
+++ b/crates/event-listener/RUSTSEC-0000-0000.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "event-listener"
+date = "2026-07-13"
+url = "https://github.com/smol-rs/event-listener/pull/163"
+informational = "unsound"
+categories = ["memory-corruption", "thread-safety"]
+keywords = ["concurrency"]
+
+[versions]
+patched = [">= 5.4.2"]
+unaffected = ["< 5.1.0"]
+```
+
+# `event-listener` allows `!Send` tags to cross thread boundaries via `StackSlot`
+
+Affected versions of `event-listener` unconditionally implement `Send` and
+`Sync` for `StackSlot<'_, T>`, the stack-allocated listener type created
+by the `listener!` macro.
+
+This allows a `!Send` tag type set via `Event::with_tag` to be moved to
+another thread and accessed via `StackSlot::wait`, causing a data race in safe
+code.


### PR DESCRIPTION
## Affected crate(s)

- event-listener (recent downloads per crates.io: 92645331)

## Links to upstream issue(s) or PR(s)

https://github.com/smol-rs/event-listener/pull/163

## Severity

Unsound `Send`/`Sync` impl on `StackSlot<'_, T>` (stack-allocated listener
from the `listener!` macro) lets a `!Send` tag set via `Event::with_tag`
cross thread boundaries and get accessed via `StackSlot::wait`, causing a
data race in safe code.

## Checklist

- [X] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [X] `date` field is set to the public disclosure date
- [X] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate