### PR TITLE
Add advisories for Bodil's crates

### DIFF
--- a/crates/bitmaps/RUSTSEC-0000-0000.0.md
+++ b/crates/bitmaps/RUSTSEC-0000-0000.0.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "bitmaps"
+date = "2026-05-03"
+informational = "unmaintained"
+url = "https://github.com/bodil/bitmaps"
+
+[versions]
+patched = []
+```
+
+# bitmaps is unmaintained
+
+The bitmaps crate is unmaintained; all versions are affected. The GitHub
+repository was archived by the owner on 2026-05-03.
+
+Recommended alternatives:
+
+* [fixedbitset](https://crates.io/crates/fixedbitset)
+* [bitvec](https://crates.io/crates/bitvec)

--- a/crates/bitmaps/RUSTSEC-0000-0000.1.md
+++ b/crates/bitmaps/RUSTSEC-0000-0000.1.md
@@ -1,0 +1,27 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "bitmaps"
+date = "2025-12-25"
+informational = "unsound"
+url = "https://github.com/bodil/bitmaps/issues/35"
+categories = ["memory-corruption"]
+
+[versions]
+patched = []
+unaffected = ["< 3.2.0"]
+```
+
+# `Bitmap::try_from(&[u8])` can create invalid values
+
+The `TryFrom<&[u8]>` implementation for `Bitmap<SIZE>` copies the input bytes
+into an uninitialized backing store and calls `assume_init()` without
+validating that the bytes form a valid value of the backing store type. For
+`SIZE = 1` the backing store is a `bool`, so any input byte other than `0x00`
+or `0x01` produces an invalid value, which is immediate undefined behavior.
+
+The `AsMut<[u8]>` implementation has the same problem, as it allows safe code
+to write invalid bit patterns into the backing store through the returned slice.
+
+No fixed version is available, as the crate is unmaintained; its GitHub
+repository was archived by the owner on 2026-05-03.

--- a/crates/im-rc/RUSTSEC-0000-0000.md
+++ b/crates/im-rc/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "im-rc"
+date = "2026-05-03"
+informational = "unmaintained"
+url = "https://github.com/bodil/im-rs"
+
+[versions]
+patched = []
+```
+
+# im-rc is unmaintained
+
+The im-rc crate is unmaintained; all versions are affected. The GitHub
+repository was archived by the owner on 2026-05-03.
+
+[imbl](https://crates.io/crates/imbl) is a maintained fork of the im crate,
+but we're not aware of maintained alternative to im-rc at this time.

--- a/crates/im/RUSTSEC-0000-0000.0.md
+++ b/crates/im/RUSTSEC-0000-0000.0.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "im"
+date = "2026-05-03"
+informational = "unmaintained"
+url = "https://github.com/bodil/im-rs"
+
+[versions]
+patched = []
+```
+
+# im is unmaintained
+
+The im crate is unmaintained; all versions are affected. The GitHub
+repository was archived by the owner on 2026-05-03.
+
+Recommended alternative:
+
+* [imbl](https://crates.io/crates/imbl) is a maintained fork of this crate

--- a/crates/im/RUSTSEC-0000-0000.1.md
+++ b/crates/im/RUSTSEC-0000-0000.1.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "im"
+date = "2023-02-04"
+informational = "unsound"
+url = "https://github.com/bodil/im-rs/issues/207"
+categories = ["memory-corruption"]
+
+[versions]
+patched = []
+```
+
+# Aliasing violation in `OrdSet` insertion
+
+Inserting into an `im::OrdSet` (for example by collecting an iterator into one) can violate
+Rust's aliasing rules: Miri reports a stacked borrows violation in
+`sized_chunks::Chunk::force_copy()`, which is called during insertion, where a shared borrow
+is invalidated by a unique borrow before the read through it completes.
+This is undefined behavior, reachable from safe code.
+
+No fixed version is available, as the crate is unmaintained; its GitHub
+repository was archived by the owner on 2026-05-03.

--- a/crates/sized-chunks/RUSTSEC-0000-0000.0.md
+++ b/crates/sized-chunks/RUSTSEC-0000-0000.0.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "sized-chunks"
+date = "2026-05-03"
+informational = "unmaintained"
+url = "https://github.com/bodil/sized-chunks"
+
+[versions]
+patched = []
+```
+
+# sized-chunks is unmaintained
+
+The sized-chunks crate is unmaintained; all versions are affected. The
+GitHub repository was archived by the owner on 2026-05-03.
+
+Recommended alternative:
+
+* [imbl-sized-chunks](https://crates.io/crates/imbl-sized-chunks), a popular fork of this crate

--- a/crates/smartstring/RUSTSEC-0000-0000.md
+++ b/crates/smartstring/RUSTSEC-0000-0000.md
@@ -1,0 +1,21 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "smartstring"
+date = "2026-05-03"
+informational = "unmaintained"
+url = "https://github.com/bodil/smartstring"
+
+[versions]
+patched = []
+```
+
+# smartstring is unmaintained
+
+The smartstring crate is unmaintained; all versions are affected. The
+GitHub repository was archived by the owner on 2026-05-03.
+
+Recommended alternatives:
+
+* [compact_str](https://crates.io/crates/compact_str)
+* [smol_str](https://crates.io/crates/smol_str)


### PR DESCRIPTION
Fixes #3058.

- bitmaps: unsound and unmaintained
- im-rc: unmaintained
- im: unsound and unmaintained
- sized-chunks: unmaintained (the unsound issue seems fairly hard to reach by accident)
- smartstring: unmaintained