### PR TITLE
add advisory for `nostr-relay-pool`

### DIFF
--- a/crates/nostr-relay-pool/RUSTSEC-0000-0000.md
+++ b/crates/nostr-relay-pool/RUSTSEC-0000-0000.md
@@ -1,0 +1,41 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "nostr-relay-pool"
+date = "2026-08-01"
+url = "https://github.com/nostrdevkit/nostr/commit/02a88bd5688de058bfba8aa9fb4612441a384eff"
+aliases = ["GHSA-f96q-5f6p-v7cj"]
+categories = ["crypto-failure"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+keywords = ["cache-poisoning", "signature-verification"]
+
+[versions]
+patched = [">= 0.44.2"]
+```
+
+# Verification cache poisoning allows forged Nostr events to bypass signature validation
+
+The `nostr-relay-pool` crate cached the result of event signature verification
+before the check was actually performed. Because the entry was inserted
+unconditionally, a first delivery whose signature failed was still recorded
+in the cache. A subsequent delivery of the same event (identical ID,
+but with a forged signature) would then hit the cache, causing signature
+verification to be skipped entirely. The forged event was passed on to
+`NostrDatabase::save_event()` as if it had been validated.
+
+Applications that connect to untrusted or compromised Nostr relays and persist
+received events are vulnerable. An attacker can inject arbitrary events
+without a valid signature into the application's trusted database, enabling
+impersonation of any public key or corruption of application state derived from
+stored events.
+
+The issue does not compromise confidentiality or availability. It solely
+undermines the integrity of stored event data.
+
+The fix, released in version 0.44.2, moves the cache insertion to occur only
+after a successful signature verification, so that failed attempts never create
+a cache entry.
+
+## Credit
+
+Discovered and reported by [Ali Al-Sorehi](https://github.com/aykoooo)


### PR DESCRIPTION
## Affected crate(s)

- nostr-relay-pool (Recent Downloads: 502,264)

## Links to upstream issue(s) or PR(s)

- https://github.com/nostrdevkit/nostr/commit/02a88bd5688de058bfba8aa9fb4612441a384eff
- https://github.com/nostrdevkit/nostr/security/advisories/GHSA-f96q-5f6p-v7cj

## Severity

The caching flaw allows an attacker to inject forged Nostr events that completely bypass signature validation, leading to impersonation of any public key and corruption of the application’s stored event data.

## Checklist

- [X] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [X] `date` field is set to the public disclosure date
- [X] Contains a concise and descriptive title after advisory metadata
- [X] Asked maintainer(s) if publishing an advisory is appropriate

## Note
I'm a maintainer in NostrDevKit project, check https://github.com/rustsec/advisory-db/pull/3070#issuecomment-5079053167 and https://nostrdevkit.org/maintainers/
