### PR TITLE
object: unbounded allocation in Zstd-compressed section decompression

### DIFF
--- a/crates/object/RUSTSEC-0000-0000.md
+++ b/crates/object/RUSTSEC-0000-0000.md
@@ -1,0 +1,40 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "object"
+date = "2026-07-18"
+url = "https://github.com/gimli-rs/object/issues/950"
+references = ["https://github.com/gimli-rs/object/pull/961"]
+categories = ["denial-of-service"]
+keywords = ["zstd", "decompression", "allocation", "oom", "elf"]
+
+[versions]
+patched = [">= 0.40.0"]
+unaffected = ["< 0.31.0"]
+
+[affected]
+functions = { "object::read::CompressedData::decompress" = [">= 0.31.0, < 0.40.0"] }
+```
+
+# Unbounded allocation when decompressing a crafted Zstandard-compressed ELF section
+
+`CompressedData::decompress` in the `object` crate handles Zlib- and Zstandard-compressed
+ELF sections differently. The Zlib branch decompresses only into the pre-reserved capacity
+(bounded by the declared `ch_size`), but the Zstandard branch calls `read_to_end`, which
+grows the output buffer to the actual decoded length, ignoring the reservation.
+
+A crafted ELF file with an `SHF_COMPRESSED` section that declares a small `ch_size` but
+carries a Zstandard stream expanding to gigabytes causes an unbounded allocation via the
+default `Section::uncompressed_data()` path when the `compression` feature is enabled
+(enabled by default).
+
+The size sanity check (`if size != decompressed.len()`) runs only after the allocation
+has already completed.
+
+Fixed in 0.40.0 by switching to `ruzstd::FrameDecoder::decode_all_to_vec`, which bounds
+the decompression output.
+
+Only crates using the `compression` feature (default) to read untrusted ELF files with
+Zstandard-compressed sections are affected.
+
+Found with [rust-in-peace](https://github.com/scadastrangelove/rust-in-peace).

--- a/crates/object/RUSTSEC-0000-0000.md
+++ b/crates/object/RUSTSEC-0000-0000.md
@@ -6,35 +6,32 @@ date = "2026-07-18"
 url = "https://github.com/gimli-rs/object/issues/950"
 references = ["https://github.com/gimli-rs/object/pull/961"]
 categories = ["denial-of-service"]
-keywords = ["zstd", "decompression", "allocation", "oom", "elf"]
+keywords = ["zstd", "decompression", "allocation", "elf"]
+
+[affected]
+
+[affected.functions]
+"object::read::CompressedData::decompress" = [">= 0.31.0, < 0.40.0"]
 
 [versions]
 patched = [">= 0.40.0"]
 unaffected = ["< 0.31.0"]
-
-[affected]
-functions = { "object::read::CompressedData::decompress" = [">= 0.31.0, < 0.40.0"] }
 ```
 
 # Unbounded allocation when decompressing a crafted Zstandard-compressed ELF section
 
-`CompressedData::decompress` in the `object` crate handles Zlib- and Zstandard-compressed
-ELF sections differently. The Zlib branch decompresses only into the pre-reserved capacity
-(bounded by the declared `ch_size`), but the Zstandard branch calls `read_to_end`, which
-grows the output buffer to the actual decoded length, ignoring the reservation.
+Affected versions of `object` decompress Zstandard-compressed ELF sections without
+limiting output to the section's declared uncompressed size.
 
-A crafted ELF file with an `SHF_COMPRESSED` section that declares a small `ch_size` but
-carries a Zstandard stream expanding to gigabytes causes an unbounded allocation via the
-default `Section::uncompressed_data()` path when the `compression` feature is enabled
-(enabled by default).
+`object::read::CompressedData::decompress` first reserves the declared `ch_size`, but
+the Zstandard branch then grows the output buffer to the actual decoded length. The
+size check runs only after decompression has completed.
 
-The size sanity check (`if size != decompressed.len()`) runs only after the allocation
-has already completed.
+This can cause excessive memory allocation when a crafted ELF file contains an
+`SHF_COMPRESSED` section with a small declared `ch_size` and a Zstandard stream
+that expands to a much larger output. The issue is reachable through
+`Section::uncompressed_data()` when the `compression` feature is enabled.
 
-Fixed in 0.40.0 by switching to `ruzstd::FrameDecoder::decode_all_to_vec`, which bounds
-the decompression output.
-
-Only crates using the `compression` feature (default) to read untrusted ELF files with
-Zstandard-compressed sections are affected.
-
-Found with [rust-in-peace](https://github.com/scadastrangelove/rust-in-peace).
+The flaw was corrected in `0.40.0` by using
+`ruzstd::FrameDecoder::decode_all_to_vec`, which bounds Zstandard decompression
+to the declared uncompressed size.


### PR DESCRIPTION
## Affected crate(s)

- `object`

## Links to upstream issue(s) or PR(s)

- Upstream issue: https://github.com/gimli-rs/object/issues/950
- Fix PR: https://github.com/gimli-rs/object/pull/961
- Patched release: `object` 0.40.0, released 2026-08-01

## Severity

Denial of service / resource exhaustion. A crafted ELF file with a small
compressed-section size but a Zstandard stream that expands much larger can
cause excessive allocation through `Section::uncompressed_data()` when the
`compression` feature is enabled.

Affected versions: `>= 0.31.0, < 0.40.0`. Zstandard support was added in
`0.31.0`; the issue was fixed in `0.40.0`.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate
