### PR TITLE
add advisory for `zip` GHSA-94vh-gphv-8pm8

### DIFF
--- a/crates/zip/RUSTSEC-0000-0000.md
+++ b/crates/zip/RUSTSEC-0000-0000.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "zip"
-date = "2026-08-01"
+date = "2025-03-16"
 url = "https://github.com/zip-rs/zip2/security/advisories/GHSA-94vh-gphv-8pm8"
 cvss = "CVSS:4.0/AV:N/AC:H/AT:N/PR:L/UI:N/VC:L/VI:H/VA:N/SC:H/SI:H/SA:H"
 keywords = ["file-overwrite", "symlink", "path-traversal"]

--- a/crates/zip/RUSTSEC-0000-0000.md
+++ b/crates/zip/RUSTSEC-0000-0000.md
@@ -1,0 +1,25 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "zip"
+date = "2026-08-01"
+url = "https://github.com/zip-rs/zip2/security/advisories/GHSA-94vh-gphv-8pm8"
+cvss = "CVSS:4.0/AV:N/AC:H/AT:N/PR:L/UI:N/VC:L/VI:H/VA:N/SC:H/SI:H/SA:H"
+keywords = ["file-overwrite", "symlink", "path-traversal"]
+aliases = ["CVE-2025-29787", "GHSA-94vh-gphv-8pm8"]
+license = "CC-BY-4.0"
+
+[affected.functions]
+"zip::unstable::stream::ZipStreamReader::extract" = ["< 2.3.0, >= 1.3.0"]
+"zip::read::ZipArchive::extract" = ["< 2.3.0, >= 1.3.0"]
+
+[versions]
+patched = [">= 2.3.0"]
+unaffected = ["< 1.3.0"]
+```
+
+# Incorrect path canonicalization during Archive Extraction Leading to Arbitrary File Write
+
+In the archive extraction routine of affected versions of the zip crate, symbolic links earlier in the archive are allowed to be used for later files in the archive without validation of the final canonicalized path, allowing maliciously crafted archives to overwrite arbitrary files in the file system when extracted.
+
+For more details, see the GitHub-hosted security advisory: <https://github.com/zip-rs/zip2/security/advisories/GHSA-94vh-gphv-8pm8>


### PR DESCRIPTION
This adds a year-old advisory on old versions of the `zip` crate.

I used today's date, instead of the GHSA publish data, since I wasn't sure if backdated entries are OK. Please advise if that's wrong!

Also, I copied only the first paragraph of the GHSA advisory. Please advise if you'd rather see the full text copied, or something less (e.g. only the link).

Since this was already published as a GHSA, is asking the zip maintainer still a required step?

Closes: #3098

## Affected crate(s)

- zip (56,908,394 recent downloads, though most of those are fixed versions)

## Links to upstream issue(s) or PR(s)

https://github.com/zip-rs/zip2/security/advisories/GHSA-94vh-gphv-8pm8

## Severity

From the upstream advisory:
> In the archive extraction routine of affected versions of the zip crate, symbolic links earlier in the archive are allowed to be used for later files in the archive without validation of the final canonicalized path, allowing maliciously crafted archives to overwrite arbitrary files in the file system when extracted.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date (See question above)
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
