### PR TITLE
Add advisories for nostr

### DIFF
--- a/crates/nostr/RUSTSEC-0000-0000.1.md
+++ b/crates/nostr/RUSTSEC-0000-0000.1.md
@@ -1,0 +1,34 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "nostr"
+date = "2026-08-01"
+references = [
+    "https://github.com/nostrdevkit/nostr/commit/2bc5fa2c270bb87b397d381909053f12ee734d44",
+    "https://github.com/nostrdevkit/nostr/commit/778af7e4930449dcdd7a070774da7b71b282d171",
+]
+categories = ["file-disclosure"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"
+keywords = ["nostr", "nip46", "nip60", "credentials"]
+
+[versions]
+patched = [">= 0.44.7"]
+```
+
+# Debug output exposes NIP-46 and NIP-60 credentials
+
+Several NIP-46 and NIP-60 types used derived `Debug` implementations even though
+their fields contained credentials or decrypted application data. Formatting these
+values exposed NIP-46 connection secrets and request parameters, as well as NIP-60
+private keys, Cashu bearer proofs, and quote capability identifiers.
+
+Applications commonly include `Debug` output in diagnostic logs, tracing spans, or
+error reports. Anyone able to read those outputs could recover the disclosed
+credentials and, depending on the value, impersonate a signer connection or spend
+wallet tokens. The issue does not expose data unless an affected value is formatted
+and the resulting output is made accessible.
+
+The affected types now use custom `Debug` implementations that preserve variant and
+non-sensitive structural information while replacing credentials, bearer values,
+and plaintext fields with redaction markers. Serialization and protocol behavior are
+unchanged.

--- a/crates/nostr/RUSTSEC-0000-0000.2.md
+++ b/crates/nostr/RUSTSEC-0000-0000.2.md
@@ -1,0 +1,32 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "nostr"
+date = "2026-08-01"
+references = ["https://github.com/nostrdevkit/nostr/commit/25e4e9ce66a533d9d7f5071f6c1dae992476cf83"]
+categories = ["denial-of-service"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:L"
+keywords = ["nostr", "nip04", "decryption"]
+
+[versions]
+patched = [">= 0.44.7"]
+```
+
+# NIP-04 parsing amplifies malformed ciphertext memory use
+
+The NIP-04 decryption parser split attacker-controlled content on every `?iv=`
+separator and collected all resulting segments before checking that the message had
+the expected two parts. It also Base64-decoded the complete IV text before checking
+that it represented the required 16-byte AES-CBC IV.
+
+A malicious sender could include a large number of separators or an oversized IV in
+an encrypted direct message. Applications that attempted to decrypt the message
+performed avoidable allocations proportional to the malformed input, with additional
+allocation amplification from the segment vector and Base64 output. This can consume
+memory and CPU in clients processing messages received through a relay. It does not
+weaken NIP-04 encryption or reveal plaintext or key material.
+
+The parser now uses a single bounded split, rejects additional separators, and
+validates the 24-byte encoded IV length before Base64 decoding. Malformed inputs are
+returned as errors without allocating for every separator or decoding an arbitrarily
+large IV.

--- a/crates/nostr/RUSTSEC-0000-0000.3.md
+++ b/crates/nostr/RUSTSEC-0000-0000.3.md
@@ -1,0 +1,34 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "nostr"
+date = "2026-08-01"
+references = ["https://github.com/nostrdevkit/nostr/commit/89dc1a77eaa774174588c5a38b6324c502948830"]
+categories = ["denial-of-service"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+keywords = ["nostr", "nip44", "decryption"]
+
+[versions]
+patched = [">= 0.44.7"]
+```
+
+# NIP-44 v2 decryption permits resource exhaustion
+
+The NIP-44 decryption entry point Base64-decoded the complete attacker-controlled
+payload before determining its version or enforcing any size limit. For v2 payloads,
+the decoded buffer was then authenticated with HMAC even when it was much larger than
+the maximum payload supported by the crate's current v2 codec.
+
+A malicious relay or event author could deliver an oversized value to an application
+that decrypts NIP-44 content. The value caused memory allocation and Base64 and HMAC
+work proportional to its size before authentication failed; knowledge of the
+conversation key was not required to consume those initial resources. Repeated
+payloads could exhaust memory or CPU and make the receiving application unavailable.
+The issue does not disclose plaintext or key material and does not bypass message
+authentication.
+
+Decryption now reads only the encoded version prefix first, derives the bound from
+the largest payload the current v2 encoder can emit, and rejects oversized encoded
+and decoded payloads before full allocation or HMAC processing. The limit remains in
+the v2 implementation so a future codec with a different length format can define its
+own bound.

--- a/crates/nostr/RUSTSEC-0000-0000.4.md
+++ b/crates/nostr/RUSTSEC-0000-0000.4.md
@@ -1,0 +1,29 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "nostr"
+date = "2026-08-01"
+references = ["https://github.com/nostrdevkit/nostr/commit/29182657bc54ac18564597e4414f08c3e4e9aa0a"]
+categories = ["denial-of-service"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+keywords = ["nostr", "nip50", "panic"]
+
+[versions]
+patched = [">= 0.44.7"]
+```
+
+# Empty NIP-50 search filters can panic
+
+The NIP-50 event-matching path searched event content with
+`slice::windows(search.len())`. An empty search string therefore called
+`slice::windows(0)`, which always panics instead of returning a match result.
+
+A remote client able to submit filters to an application using this matcher could
+trigger the panic with an empty NIP-50 search value. This includes clients querying an
+SDK local relay. Depending on the application's panic configuration and task
+isolation, the crafted filter could terminate request processing, a runtime worker, or
+the entire process, causing denial of service. No confidentiality or integrity impact
+is known.
+
+Empty searches are now handled before the substring search, so the matcher returns a
+defined result without constructing a zero-sized window or panicking.

--- a/crates/nostr/RUSTSEC-0000-0000.5.md
+++ b/crates/nostr/RUSTSEC-0000-0000.5.md
@@ -1,0 +1,30 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "nostr"
+date = "2026-08-01"
+references = ["https://github.com/nostrdevkit/nostr/commit/fd69825a3aa83c4a99f0d620fafba66c765db96b"]
+categories = ["denial-of-service"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+keywords = ["nostr", "nip98", "authorization"]
+
+[versions]
+patched = [">= 0.44.7"]
+```
+
+# NIP-98 authorization parsing permits resource exhaustion
+
+The NIP-98 HTTP authorization parser Base64-decoded the complete authorization value
+and parsed the resulting JSON event without applying an application-level size limit.
+Both operations occurred before the event's signature and authorization fields could
+be validated.
+
+An unauthenticated remote client could send an oversized `Authorization: Nostr`
+header to a server using this parser. Each request caused memory allocation and
+decoding and JSON parsing work proportional to the supplied value, allowing repeated
+requests to consume server memory and CPU. The impact depends on any lower HTTP header
+limit already enforced by the hosting server. The issue does not bypass NIP-98
+authentication or disclose protected data.
+
+The parser now rejects oversized encoded input before Base64 allocation and rejects
+decoded authorization events larger than 64 KiB before JSON parsing.

--- a/crates/nostr/RUSTSEC-0000-0000.6.md
+++ b/crates/nostr/RUSTSEC-0000-0000.6.md
@@ -1,0 +1,35 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "nostr"
+date = "2026-08-01"
+references = [
+    "https://github.com/nostrdevkit/nostr/commit/2b6d6227cd884c1acb200bffa66a3f402b02a176",
+    "https://github.com/nostrdevkit/nostr/commit/0b78464e39604b0f052862035f47fdabc2a536dd",
+]
+categories = ["crypto-failure"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+keywords = ["nostr", "nip47", "nip60", "wallet"]
+
+[versions]
+patched = [">= 0.44.7"]
+```
+
+# Wallet event parsers accept unauthenticated events
+
+The NIP-47 response and notification parsers and the NIP-60 wallet event parsers
+decrypted relay-provided events before verifying their kind, computed event ID,
+signature, and expected wallet public key. The decryption peer was derived from the
+untrusted event author, so successful decryption did not prove that the configured
+wallet created the event.
+
+An attacker can sign an event with their own key and derive the corresponding shared
+secret with the victim's public key. A malicious relay delivering that event could
+therefore cause attacker-chosen encrypted content to be parsed as a response,
+notification, token, spending record, or quote from the configured wallet. This can
+corrupt wallet state or cause an application to act on forged wallet data. The issue
+does not expose the victim's private key or decrypt events authored by the legitimate
+wallet.
+
+The affected parsers now verify the event kind, ID, signature, and exact configured
+wallet author before attempting decryption or parsing the plaintext.


### PR DESCRIPTION
## Affected crate(s)

- `nostr` (`658,858` recent downloads per crates.io)

## Severity

The advisories include credential disclosure, remote denial-of-service through excessive resource consumption or panics, and acceptance of forged wallet events. Potential effects include exposure of sensitive credentials, application unavailability, corruption of wallet state, or applications acting on attacker-controlled wallet data.

## Checklist

- [X] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [X] `date` field is set to the public disclosure date
- [X] Contains a concise and descriptive title after advisory metadata
- [X] Asked maintainer(s) if publishing an advisory is appropriate
