### PR TITLE
Add advisory for nostr-relay-pool (NIP-42, event verification)

### DIFF
--- a/crates/nostr-relay-pool/RUSTSEC-0000-0000.1.md
+++ b/crates/nostr-relay-pool/RUSTSEC-0000-0000.1.md
@@ -1,0 +1,31 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "nostr-relay-pool"
+date = "2026-08-01"
+references = ["https://github.com/nostrdevkit/nostr/commit/6eb8766caa25f03803f178861be054f3bca718d7"]
+categories = ["denial-of-service"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+keywords = ["nostr", "authentication", "relay"]
+
+[versions]
+patched = [">= 0.44.3"]
+```
+
+# Relay authentication challenges can exhaust memory
+
+The SDK forwarded every NIP-42 `AUTH` challenge received from a relay through an
+unbounded command queue. Challenge handling can wait for an asynchronous signer or
+user interaction, so receiving challenges was substantially faster than completing
+the corresponding authentication work.
+
+A malicious relay could continuously send new challenges without authenticating or
+delivering valid events. Every value remained queued, causing memory use and pending
+signer operations to grow without a fixed limit until the client became unavailable.
+The issue does not allow the relay to forge a signature or learn the client's private
+key.
+
+The SDK now coalesces pending challenges through a latest-value channel. NIP-42 makes
+an earlier challenge invalid when the relay sends a new one, so replacing pending
+work preserves the only challenge that can still be answered while keeping memory
+use bounded.

--- a/crates/nostr-relay-pool/RUSTSEC-0000-0000.2.md
+++ b/crates/nostr-relay-pool/RUSTSEC-0000-0000.2.md
@@ -1,0 +1,33 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "nostr-relay-pool"
+date = "2026-08-01"
+references = ["https://github.com/nostrdevkit/nostr/commit/4b67f9b45909d2e35f34c30c084c0ab66e599a9f"]
+categories = ["crypto-failure"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+keywords = ["nostr", "event", "signature"]
+
+[versions]
+patched = [">= 0.44.3"]
+```
+
+# Processing of unverified relay events
+
+The processed events received from a relay through admission-policy and database
+paths before verifying that the serialized fields matched the claimed event ID and
+signature. In particular, a database result for the claimed ID could cause
+verification to be skipped. The verification cache also keyed successful checks by a
+64-bit hash instead of the complete event ID.
+
+A malicious relay could send an event whose claimed ID referred to a known database
+entry while its content, tags, author, or signature differed from that ID. The forged
+event could then reach policy callbacks or other SDK processing as if it were
+authentic. A cache-key collision provided a second path for an unverified event to be
+treated as previously verified. This undermines event integrity but does not reveal
+private keys or enable the attacker to produce a valid signature for the altered
+event.
+
+The SDK now verifies each event before policy evaluation, database lookup, or
+propagation decisions, and the verification cache stores the complete `EventId` so a
+truncated hash collision cannot stand in for successful verification.


### PR DESCRIPTION
## Affected crate(s)

- `nostr-relay-pool` (` 503,566` recent downloads per crates.io)

## Severity

The advisories cover remote denial-of-service through unbounded processing of relay authentication challenges and acceptance of unverified relay events. Potential effects include client memory exhaustion and application unavailability, or forged events reaching policy callbacks and other SDK processing as if they were authentic.

## Checklist

- [X] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [X] `date` field is set to the public disclosure date
- [X] Contains a concise and descriptive title after advisory metadata
- [X] Asked maintainer(s) if publishing an advisory is appropriate
