### PR TITLE
Add advisory for infisearch_common

### DIFF
--- a/crates/infisearch_common/RUSTSEC-0000-0000.md
+++ b/crates/infisearch_common/RUSTSEC-0000-0000.md
@@ -1,0 +1,31 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "infisearch_common"
+date = "2024-10-13"
+url = "https://github.com/ang-zeyu/infisearch/issues/11"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["out-of-bounds", "global-buffer-overflow", "soundness", "unsafe"]
+
+[affected.functions]
+"infisearch_common::packed_var_int::PackedVarIntReader::read_type" = ["<= 0.10.1"]
+
+[versions]
+patched = []
+```
+
+# `PackedVarIntReader::read_type` can access memory out of bounds
+
+Affected versions of `infisearch_common` contain a safe method,
+`PackedVarIntReader::read_type`, which can perform out-of-bounds accesses.
+
+The method accepts a type index `t` and uses it to access several internal
+arrays through unchecked indexing. If `t` is outside the expected range, the
+method can read or write out of bounds.
+
+Because the method is safe, callers do not need to use `unsafe` to trigger the
+invalid memory access. The issue was reported with AddressSanitizer as a
+global-buffer-overflow.
+
+No patched release is currently known.


### PR DESCRIPTION
## Affected crate(s)

- infisearch_common (259 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/ang-zeyu/infisearch/issues/11

## Severity

This is submitted as an informational unsound advisory. The reported issue involves unchecked indexing in a safe method, which can lead to out-of-bounds access and undefined behavior.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate