### PR TITLE
Add advisory for infisearch

### DIFF
--- a/crates/infisearch/RUSTSEC-0000-0000.md
+++ b/crates/infisearch/RUSTSEC-0000-0000.md
@@ -1,0 +1,30 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "infisearch"
+date = "2024-10-13"
+url = "https://github.com/ang-zeyu/infisearch/issues/11"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["out-of-bounds", "heap-buffer-overflow", "soundness", "unsafe"]
+
+[versions]
+patched = []
+```
+
+# `DocInfo::get_num_val` can read out of bounds
+
+Affected versions of `infisearch` contain a safe method,
+`DocInfo::get_num_val`, which can perform an out-of-bounds read.
+
+The method calculates an index from `doc_id` and `num_id`, but the debug
+assertion checks the computed index against the wrong backing vector. The
+method then uses unchecked indexing on `doc_i64_vals`, which can read past the
+end of the allocation when the computed index is greater than or equal to
+`doc_i64_vals.len()`.
+
+Because the method is safe, callers do not need to use `unsafe` to trigger the
+invalid memory access. The issue was reported with AddressSanitizer as a
+heap-buffer-overflow.
+
+No patched release is currently known.


### PR DESCRIPTION
## Affected crate(s)

- infisearch (81 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/ang-zeyu/infisearch/issues/11

## Severity

This is submitted as an informational unsound advisory. The reported issue involves unchecked indexing in a safe method, which can lead to out-of-bounds access and undefined behavior.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate