### PR TITLE
Add advisory for pilka

### DIFF
--- a/crates/pilka/RUSTSEC-0000-0000.md
+++ b/crates/pilka/RUSTSEC-0000-0000.md
@@ -1,0 +1,29 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "pilka"
+date = "2024-10-13"
+url = "https://github.com/pannapudi/pilka/issues/58"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["null-pointer-dereference", "segfault", "ffi", "soundness"]
+
+[affected.functions]
+"pilka::instance::vulkan_debug_callback" = ["<= 0.8.2"]
+
+[versions]
+patched = []
+```
+
+# `vulkan_debug_callback` dereferences a possibly null pointer
+
+Affected versions of `pilka` dereference the `p_callback_data` raw pointer in
+`vulkan_debug_callback` without first checking whether the pointer is null.
+
+If the callback is invoked with a null `p_callback_data` pointer, the function
+can perform invalid memory access before returning to the caller. The issue was
+reported with AddressSanitizer as a null pointer dereference in the Vulkan debug
+callback implementation.
+
+The upstream repository contains a null check for this pointer, but no patched
+crates.io release is currently known.


### PR DESCRIPTION
## Affected crate(s)

- pilka (143 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/pannapudi/pilka/issues/58

## Severity

This is submitted as an informational unsound advisory. The reported issue involves a null pointer dereference in the Vulkan debug callback implementation. The upstream repository contains a null check, but no patched crates.io release is currently known.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate