### PR TITLE
Add advisory for kalker

### DIFF
--- a/crates/kalker/RUSTSEC-0000-0000.md
+++ b/crates/kalker/RUSTSEC-0000-0000.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "kalker"
+date = "2024-10-17"
+url = "https://github.com/PaddiM8/kalker/issues/163"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["stack-use-after-scope", "segfault", "asan", "debug-build"]
+
+[versions]
+patched = [">= 2.2.1"]
+unaffected = ["< 1.1.0"]
+```
+
+# Stack-use-after-scope in `kalker` 1.1.0 debug builds
+
+Version 1.1.0 of `kalker` was reported to trigger a stack-use-after-scope in
+debug builds when parsing identifiers. The report shows AddressSanitizer
+detecting a stack-use-after-scope during parser execution.
+
+The upstream maintainer recommended using version 2.2.1 or later for the latest
+stability fixes. Earlier versions before 1.1.0 are not currently known to be
+affected.


### PR DESCRIPTION
## Affected crate(s)

- kalker (222 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/PaddiM8/kalker/issues/163

## Severity

This is submitted as an informational unsound advisory. The report describes a stack-use-after-scope detected by AddressSanitizer in kalker 1.1.0 debug builds. The upstream maintainer recommended using version 2.2.1 or later for stability fixes.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate