### PR TITLE
Add advisory for aarty

### DIFF
--- a/crates/aarty/RUSTSEC-0000-0000.md
+++ b/crates/aarty/RUSTSEC-0000-0000.md
@@ -1,0 +1,30 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "aarty"
+date = "2024-10-13"
+url = "https://github.com/0x61nas/aarty/issues/78"
+informational = "unsound"
+categories = ["memory-corruption"]
+keywords = ["out-of-bounds", "heap-buffer-overflow", "unsafe", "unchecked-indexing"]
+
+[affected.functions]
+"aarty::text_image::TextImage::get_unchecked" = ["<= 0.8.2"]
+
+[versions]
+patched = []
+```
+
+# `TextImage::get_unchecked` can access memory out of bounds if misused
+
+Affected versions of `aarty` expose `TextImage::get_unchecked` as a public
+unsafe API. The function indexes into the internal `fragments` buffer without
+performing bounds checks.
+
+Calling this function with an index outside the bounds of the image can cause
+out-of-bounds memory access and undefined behavior. The issue was reported with
+AddressSanitizer as an illegal instruction after unchecked indexing.
+
+The upstream maintainer has stated that `get_unchecked` is intentionally marked
+unsafe and is expected to be used only when the caller can uphold the required
+bounds invariant. No patched release is currently known.


### PR DESCRIPTION
## Affected crate(s)

- aarty (109 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/0x61nas/aarty/issues/78

## Severity

This is submitted as an informational unsound advisory. The report describes out-of-bounds access through a public unsafe API. The upstream maintainer stated that the function is intentionally unsafe and callers are expected to uphold the bounds invariant.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate