### PR TITLE
Add advisory for sized-chunks: panic-safety UAF/double-free in clear/drop_left/drop_right

### DIFF
--- a/crates/sized-chunks/RUSTSEC-0000-0000.md
+++ b/crates/sized-chunks/RUSTSEC-0000-0000.md
@@ -2,41 +2,34 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "sized-chunks"
-date = "2026-08-04"
+date = "2026-08-11"
 categories = ["memory-corruption"]
 keywords = ["panic-safety", "memory-safety", "use-after-free", "double-free"]
 informational = "unsound"
 
+[affected]
+[affected.functions]
+"sized_chunks::InlineArray::clear" = ["<= 0.7.0"]
+"sized_chunks::Chunk::clear" = ["<= 0.7.0"]
+"sized_chunks::Chunk::drop_left" = ["<= 0.7.0"]
+"sized_chunks::Chunk::drop_right" = ["<= 0.7.0"]
+"sized_chunks::RingBuffer::clear" = ["<= 0.7.0"]
+"sized_chunks::RingBuffer::drop_left" = ["<= 0.7.0"]
+"sized_chunks::RingBuffer::drop_right" = ["<= 0.7.0"]
+
 [versions]
 patched = []
-unaffected = []
 ```
 
 # Panic-safety unsoundness in `Chunk`, `RingBuffer`, and `InlineArray` (use-after-free / double-free)
 
-Several methods in `sized-chunks` drop elements before updating the container's
-length/boundary metadata. If an element's `Drop` panics during the drop, the metadata
-update is skipped, so the container still treats the already-dropped elements as live.
-When the container is later dropped, its own `Drop` re-visits those slots and drops the
-freed elements again — a use-after-free / double-free reachable from safe Rust.
+Several methods in `sized-chunks` drop elements before updating the length/boundary metadata. If an element's `Drop` panics during the drop, the metadata update is skipped, so the container still treats the already-dropped elements as live. When the container's own `Drop` runs, those elements are visited again — a use-after-free / double-free reachable from safe Rust.
 
-## Affected methods
-
-- `InlineArray::clear`
-- `Chunk::clear`, `Chunk::drop_left`, `Chunk::drop_right`
-- `RingBuffer::clear`, `RingBuffer::drop_left`, `RingBuffer::drop_right`
-  (require the `ringbuffer` feature)
+The `RingBuffer` methods require the `ringbuffer` feature. This is distinct from RUSTSEC-2020-0041 (`Chunk::clone` / `insert_from`, fixed in 0.6.3); the methods here are still affected in 0.7.0. The repository is archived with issues/PRs disabled and no fix available.
 
 ## Impact
 
-- **CWE-415 (Double Free):** the same allocation is freed twice (e.g. an element holding `Box<T>`).
-- **CWE-416 (Use-After-Free):** an element reads its own freed allocation during `Drop` (e.g. `String`) — confirmed under AddressSanitizer.
+- **CWE-415 (Double Free):** the same allocation is freed twice.
+- **CWE-416 (Use-After-Free):** a freed allocation is accessed during a repeated `Drop`.
 
-All seven are reachable entirely from safe Rust via `catch_unwind` with element types
-whose `Drop` can panic.
-
-## Status
-
-The repository is archived and unmaintained (no release in several years), so no upstream
-fix is expected. Affected users should avoid these methods with element types whose `Drop`
-can panic, or migrate away from the crate.
+Reachable entirely from safe Rust via `catch_unwind` with element types whose `Drop` can panic.

--- a/crates/sized-chunks/RUSTSEC-0000-0000.md
+++ b/crates/sized-chunks/RUSTSEC-0000-0000.md
@@ -1,0 +1,56 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "sized-chunks"
+date = "2026-08-04"
+url = "https://github.com/bodil/sized-chunks"
+categories = ["memory-corruption", "denial-of-service"]
+keywords = ["panic-safety", "memory-safety", "use-after-free", "double-free"]
+informational = "unsound"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# Panic safety bugs in `Chunk`, `RingBuffer`, and `InlineArray` methods enable use-after-free / double-free
+
+Several methods in `sized-chunks` are not panic-safe. They drop elements via
+`ptr::drop_in_place` (or `force_drop`) and update the container's length/boundary
+metadata only *after* the drop. If an element's `Drop` implementation panics during
+the drop, the metadata update is skipped, so the container still describes the
+already-dropped elements as live.
+
+When the container is later dropped, its own `Drop` implementation re-visits those
+slots using the stale metadata and drops the already-freed elements a second time.
+
+## Affected methods
+
+- `InlineArray::clear`
+- `Chunk::clear`, `Chunk::drop_left`, `Chunk::drop_right`
+- `RingBuffer::clear`, `RingBuffer::drop_left`, `RingBuffer::drop_right`
+  (the `RingBuffer` methods require the `ringbuffer` feature)
+
+In each case the pattern is:
+
+```rust
+unsafe { ptr::drop_in_place(slice) }; // may panic
+self.metadata = new_value;            // skipped on panic -> stale metadata
+```
+
+## Impact
+
+- **CWE-415 (Double Free):** heap corruption when the element type holds `Box<T>` --
+  the same allocation is freed twice.
+- **CWE-416 (Use-After-Free):** memory corruption when the element reads from its
+  own heap allocation during `Drop` (e.g. `String`) -- confirmed under
+  AddressSanitizer (`heap-use-after-free`).
+
+All seven are triggerable entirely from safe Rust via `std::panic::catch_unwind`
+with element types that have potentially-panicking `Drop` implementations.
+
+## Status
+
+The repository is archived and unmaintained (no release in several years), so no
+upstream fix is expected. Affected users should avoid these methods with element
+types whose `Drop` can panic, or migrate away from the crate.

--- a/crates/sized-chunks/RUSTSEC-0000-0000.md
+++ b/crates/sized-chunks/RUSTSEC-0000-0000.md
@@ -3,8 +3,7 @@
 id = "RUSTSEC-0000-0000"
 package = "sized-chunks"
 date = "2026-08-04"
-url = "https://github.com/bodil/sized-chunks"
-categories = ["memory-corruption", "denial-of-service"]
+categories = ["memory-corruption"]
 keywords = ["panic-safety", "memory-safety", "use-after-free", "double-free"]
 informational = "unsound"
 
@@ -13,44 +12,31 @@ patched = []
 unaffected = []
 ```
 
-# Panic safety bugs in `Chunk`, `RingBuffer`, and `InlineArray` methods enable use-after-free / double-free
+# Panic-safety unsoundness in `Chunk`, `RingBuffer`, and `InlineArray` (use-after-free / double-free)
 
-Several methods in `sized-chunks` are not panic-safe. They drop elements via
-`ptr::drop_in_place` (or `force_drop`) and update the container's length/boundary
-metadata only *after* the drop. If an element's `Drop` implementation panics during
-the drop, the metadata update is skipped, so the container still describes the
-already-dropped elements as live.
-
-When the container is later dropped, its own `Drop` implementation re-visits those
-slots using the stale metadata and drops the already-freed elements a second time.
+Several methods in `sized-chunks` drop elements before updating the container's
+length/boundary metadata. If an element's `Drop` panics during the drop, the metadata
+update is skipped, so the container still treats the already-dropped elements as live.
+When the container is later dropped, its own `Drop` re-visits those slots and drops the
+freed elements again — a use-after-free / double-free reachable from safe Rust.
 
 ## Affected methods
 
 - `InlineArray::clear`
 - `Chunk::clear`, `Chunk::drop_left`, `Chunk::drop_right`
 - `RingBuffer::clear`, `RingBuffer::drop_left`, `RingBuffer::drop_right`
-  (the `RingBuffer` methods require the `ringbuffer` feature)
-
-In each case the pattern is:
-
-```rust
-unsafe { ptr::drop_in_place(slice) }; // may panic
-self.metadata = new_value;            // skipped on panic -> stale metadata
-```
+  (require the `ringbuffer` feature)
 
 ## Impact
 
-- **CWE-415 (Double Free):** heap corruption when the element type holds `Box<T>` --
-  the same allocation is freed twice.
-- **CWE-416 (Use-After-Free):** memory corruption when the element reads from its
-  own heap allocation during `Drop` (e.g. `String`) -- confirmed under
-  AddressSanitizer (`heap-use-after-free`).
+- **CWE-415 (Double Free):** the same allocation is freed twice (e.g. an element holding `Box<T>`).
+- **CWE-416 (Use-After-Free):** an element reads its own freed allocation during `Drop` (e.g. `String`) — confirmed under AddressSanitizer.
 
-All seven are triggerable entirely from safe Rust via `std::panic::catch_unwind`
-with element types that have potentially-panicking `Drop` implementations.
+All seven are reachable entirely from safe Rust via `catch_unwind` with element types
+whose `Drop` can panic.
 
 ## Status
 
-The repository is archived and unmaintained (no release in several years), so no
-upstream fix is expected. Affected users should avoid these methods with element
-types whose `Drop` can panic, or migrate away from the crate.
+The repository is archived and unmaintained (no release in several years), so no upstream
+fix is expected. Affected users should avoid these methods with element types whose `Drop`
+can panic, or migrate away from the crate.


### PR DESCRIPTION
## Affected crate(s)

- `sized-chunks` 0.7.0 (6,946,615 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

The repo is archived with issues/PRs disabled. I emailed the maintainer on 2026-04-22 with no response. Unmaintained status is tracked in #3058 / #3093.

## Severity

Panic-safety unsoundness in `Chunk`, `RingBuffer`, and `InlineArray` (`clear`, `drop_left`, `drop_right`, `InlineArray::clear`). Elements are dropped before the length/boundary metadata is updated, so a panicking element `Drop` leaves stale metadata and the container's own `Drop` re-drops already-freed elements — use-after-free / double-free reachable from safe Rust, confirmed under AddressSanitizer. Distinct from RUSTSEC-2020-0041 (`Chunk::clone` / `insert_from`, fixed in 0.6.3); still affected in 0.7.0.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate (repo archived, issues disabled, emailed maintainer 2026-04-22 with no response — unreachable-author exception)