### PR TITLE
Add advisory for ithmb-core < 1.9.5 (progressive-JPEG OOM + PhotoDB infinite loop)

### DIFF
--- a/crates/ithmb-core/RUSTSEC-0000-0000.md
+++ b/crates/ithmb-core/RUSTSEC-0000-0000.md
@@ -1,0 +1,46 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "ithmb-core"
+date = "2026-08-06"
+url = "https://github.com/B67687/Ithmb-Codec"
+categories = ["denial-of-service", "memory-exposure"]
+keywords = ["jpeg", "photodb", "denial-of-service", "memory-exhaustion", "infinite-loop"]
+
+[versions]
+patched = [">= 1.9.5"]
+```
+
+# Two denial-of-service vulnerabilities in untrusted input handling
+
+Two independent denial-of-service vulnerabilities exist in `ithmb-core`
+versions prior to 1.9.5, both reachable from untrusted `.ithmb` input.
+
+## 1. Unbounded allocation on crafted progressive JPEG (CWE-400)
+
+A crafted `.ithmb` container embedding a progressive JPEG whose SOF2 header
+declares dimensions up to 65535×65535 causes an ~8 GiB coefficient-buffer
+allocation before any size validation runs. `jpeg_decoder` 0.3.2 performs this
+allocation during the first SOS marker, before the buffer-limit check that only
+runs at EOI, so `set_max_decoding_buffer_size` alone does not mitigate it.
+
+- Trigger: 166-byte fixture → `memory allocation of 8589934592 bytes failed` → SIGABRT.
+- Impact: deterministic crash (native CLI/library); bounded wasm trap on the web target.
+- Fix: `Decoder::read_info()` pre-check rejects frames whose `w×h×11` budget
+  (RGB out + BGRA conversion + EXIF-rotation copy) exceeds 256 MiB before decoding.
+
+## 2. Infinite loop in PhotoDB container parser (CWE-835)
+
+A crafted PhotoDB container with an `mhii` chunk declaring `total_len == 0`
+makes the chunk walker never advance (`child_end == pos`), so `open_ithmb`
+spins at 100% CPU forever.
+
+- Trigger: 24-byte file (`mhfd(hdr_size=24) + mhii(hdr_size=12, total_len=0)`).
+- Impact: hang (denial of service), reachable via CLI `--open` and the python bindings.
+- Fix: the walker bails out when `child_end <= pos`.
+
+## Note on deleted versions
+
+All crates.io versions prior to 1.9.5 were permanently deleted (see the 1.9.5
+changelog). Any lockfile or vendored copy referencing an earlier `ithmb-core`
+is affected by one or both issues and must move to `>= 1.9.5`.


### PR DESCRIPTION
## Advisory

New advisory for `ithmb-core` (published by `B67687/Ithmb-Codec`): two denial-of-service vulnerabilities reachable from untrusted input, fixed in 1.9.5.

1. **CWE-400**: crafted progressive JPEG (SOF2 65535x65535) triggers ~8 GiB coefficient allocation before any size check → deterministic SIGABRT. Root cause is in `jpeg_decoder` 0.3.2 (allocates during first SOS, before its buffer-limit check at EOI); fix is a `read_info()` pre-flight rejection using a `w*h*11` byte budget.
2. **CWE-835**: crafted PhotoDB container with `mhii total_len==0` makes the chunk walker spin at 100% CPU forever; fix is a `child_end <= pos` bail-out.

Both were found via security research with working PoCs (166-byte and 24-byte fixtures). Filed by the crate author.

## Note

All crates.io versions prior to 1.9.5 were permanently deleted from the registry, so the practical exposure is limited to existing lockfiles and vendored copies — but `cargo audit` should still flag them.