### PR TITLE
Add unmaintained advisories for nostr-keyring, nostr-relay-builder, and nostr-relay-pool

### DIFF
--- a/crates/nostr-keyring/RUSTSEC-0000-0000.md
+++ b/crates/nostr-keyring/RUSTSEC-0000-0000.md
@@ -1,0 +1,15 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "nostr-keyring"
+date = "2026-08-03"
+references = ["https://github.com/nostrdevkit/nostr/pull/1414", "https://github.com/nostrdevkit/nostr/issues/1415"]
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `nostr-keyring` is unmaintained   
+
+The `nostr-keyring` crate is no longer actively maintained.

--- a/crates/nostr-relay-builder/RUSTSEC-0000-0000.md
+++ b/crates/nostr-relay-builder/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "nostr-relay-builder"
+date = "2026-08-03"
+references = ["https://github.com/nostrdevkit/nostr/issues/1415"]
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `nostr-relay-builder` is unmaintained
+
+The `nostr-relay-builder` crate is no longer actively maintained as a standalone crate.
+
+Its functionality has been incorporated into [`nostr-sdk`](https://crates.io/crates/nostr-sdk) starting with version `0.45.0`.
+
+Users should migrate to [`nostr-sdk`](https://crates.io/crates/nostr-sdk).

--- a/crates/nostr-relay-pool/RUSTSEC-0000-0000.md
+++ b/crates/nostr-relay-pool/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "nostr-relay-pool"
+date = "2026-08-03"
+references = ["https://github.com/nostrdevkit/nostr/issues/1415"]
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `nostr-relay-pool` is unmaintained
+
+The `nostr-relay-pool` crate is no longer actively maintained as a standalone crate.
+
+Its functionality has been incorporated into [`nostr-sdk`](https://crates.io/crates/nostr-sdk) starting with version `0.45.0`.
+
+Users should migrate to [`nostr-sdk`](https://crates.io/crates/nostr-sdk).


### PR DESCRIPTION
## Affected crate(s)

- `nostr-keyring` (`259` recent downloads per crates.io)
- `nostr-relay-builder` (`19,150` recent downloads per crates.io)
- `nostr-relay-pool` (`526,140` recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

https://github.com/nostrdevkit/nostr/issues/1415

## Checklist

- [X] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [X] `date` field is set to the public disclosure date
- [X] Contains a concise and descriptive title after advisory metadata
- [X] Asked maintainer(s) if publishing an advisory is appropriate
