### PR TITLE
Add advisory for gettext-rs (unsound setlocale)

### DIFF
--- a/crates/gettext-rs/RUSTSEC-0000-0000.md
+++ b/crates/gettext-rs/RUSTSEC-0000-0000.md
@@ -1,0 +1,23 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "gettext-sys"
+date = "2026-08-06"
+url = "https://github.com/gettext-rs/gettext-rs/issues/64"
+informational = "unsound"
+categories = ["memory-corruption", "thread-safety"]
+
+[affected]
+[affected.functions]
+"gettextrs::setlocale" = ["< 0.8.0"]
+"gettextrs::TextDomain::init" = ["< 0.8.0"]
+
+[versions]
+patched = [">= 0.8.0"]
+```
+
+# `setlocale` and `TextDomain::init` are unsound as they access environment with no synchronization
+
+`setlocale` and `TextDomain::init` are unsound and may allow safe code to exhibit undefined behavior when called in a multi-threaded program.
+
+The flaw is fixed in 0.8.0 by marking these functions `unsafe` and documenting the conditions under which they can be called safely.


### PR DESCRIPTION
## Affected crate(s)

- gettext-rs (about 5000 downloads per day)

## Links to upstream issue(s) or PR(s)

- https://github.com/gettext-rs/gettext-rs/issues/64

## Severity

Unsoundness can lead to memory corruption and crashes. (I could not reproduce the crash, but the linked issue claims that the binary segfaults and I believe it to be a likely outcome.)

<!-- Briefly describe the risk and potential effect of the vulnerability.
     For example: allows remote denial-of-service via stack exhaustion,
     or: use-after-free that can lead to arbitrary code execution. -->

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date -- I used today's date, although the fixes were released yesterday and the issue was filed 5 years ago
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate -- I am the maintainer

Fixes #3073.