### PR TITLE
Add four dcrypt security advisories fixed in v2.0.0

### DIFF
--- a/crates/dcrypt-algorithms/RUSTSEC-0000-0000.md
+++ b/crates/dcrypt-algorithms/RUSTSEC-0000-0000.md
@@ -1,0 +1,32 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "dcrypt-algorithms"
+date = "2026-08-09"
+url = "https://github.com/ioi-foundation/dcrypt/security/advisories/GHSA-h9f2-fgp8-vc4h"
+references = [
+    "https://github.com/ioi-foundation/dcrypt/commit/c99cc86f0ee353010cd202cbcd2c310371b0bbb8",
+    "https://github.com/ioi-foundation/dcrypt/releases/tag/v2.0.0",
+]
+categories = ["crypto-failure"]
+keywords = ["aes-gcm", "nonce-reuse"]
+aliases = ["GHSA-h9f2-fgp8-vc4h"]
+
+[versions]
+patched = [">= 2.0.0"]
+```
+
+# Low-level GCM ignores the operation nonce
+
+In all published versions of `dcrypt-algorithms` before 2.0.0, the low-level
+`Gcm` builder required an operation nonce but derived `J0` from the nonce
+captured by the original `Gcm` constructor. Multiple operations could therefore
+silently reuse a nonce even when callers supplied distinct values, compromising
+confidentiality and authenticity under an affected key.
+
+Version 2.0.0 makes `Gcm` key-only and passes the operation nonce through IV
+derivation, encryption, and decryption. It also corrects non-96-bit IV
+processing, rejects tags shorter than 96 bits, and enforces counter limits.
+Applications must upgrade, identify affected keys, rotate them, and re-encrypt
+affected data; updating the implementation cannot restore security after nonce
+reuse.

--- a/crates/dcrypt-api/RUSTSEC-0000-0000.md
+++ b/crates/dcrypt-api/RUSTSEC-0000-0000.md
@@ -1,0 +1,36 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "dcrypt-api"
+date = "2026-08-09"
+url = "https://github.com/ioi-foundation/dcrypt/security/advisories/GHSA-7hc7-h3f2-r4j6"
+references = [
+    "https://github.com/ioi-foundation/dcrypt/commit/c99cc86f0ee353010cd202cbcd2c310371b0bbb8",
+    "https://github.com/ioi-foundation/dcrypt/releases/tag/v2.0.0",
+]
+categories = ["memory-corruption", "thread-safety"]
+keywords = ["safe-code", "type-confusion", "use-after-free"]
+aliases = ["GHSA-7hc7-h3f2-r4j6"]
+
+[versions]
+patched = [">= 2.0.0"]
+```
+
+# Safe ErrorRegistry APIs can cause undefined behavior
+
+All published versions of `dcrypt-api` before 2.0.0 exposed safe
+`ErrorRegistry` operations that could trigger undefined behavior when the
+default `std` feature was enabled.
+
+Stored `Box<E>` values were erased to raw pointers and later deallocated as
+`Box<()>`. The `get_error<E>` operation also performed an unchecked cast to a
+caller-selected type. Finally, concurrent replacement or clearing could free a
+value while another thread cloned it. Ordinary safe Rust could therefore cause
+mismatched deallocation, type confusion, and use-after-free. Crates that
+re-exported this API are affected transitively.
+
+Version 2.0.0 replaces the raw pointers with owned `Box<dyn Any + Send>` values
+behind a mutex, performs checked downcasts, and uses a mutation generation so
+concurrent stores and clears win safely. There is no reliable workaround while
+calling the affected registry API. Upgrade to 2.0.0 or later and avoid
+process-global error state where possible.

--- a/crates/dcrypt-sign/RUSTSEC-0000-0000.md
+++ b/crates/dcrypt-sign/RUSTSEC-0000-0000.md
@@ -1,0 +1,33 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "dcrypt-sign"
+date = "2026-08-09"
+url = "https://github.com/ioi-foundation/dcrypt/security/advisories/GHSA-7j32-2mpw-c784"
+references = [
+    "https://github.com/ioi-foundation/dcrypt/commit/c99cc86f0ee353010cd202cbcd2c310371b0bbb8",
+    "https://github.com/ioi-foundation/dcrypt/releases/tag/v2.0.0",
+]
+categories = ["crypto-failure"]
+keywords = ["ed25519", "identity-key", "signature-forgery"]
+aliases = ["GHSA-7j32-2mpw-c784"]
+
+[versions]
+patched = [">= 2.0.0"]
+```
+
+# Ed25519 identity public keys permit universal signature forgery
+
+All published versions of `dcrypt-sign` before 2.0.0 accepted the Edwards
+identity as an Ed25519 public key. A signature with `R = B` and `S = 1` then
+verified for every message because the challenge term multiplied the identity.
+The implementation also admitted other noncanonical or small-order inputs.
+Consumers that accepted externally supplied dcrypt Ed25519 keys may therefore
+have accepted forged authorizations.
+
+Version 2.0.0 replaces the custom arithmetic with `ed25519-dalek`, uses strict
+verification, and rejects noncanonical, small-order, and non-torsion-free public
+keys and `R` values, as well as noncanonical `S >= L`. No wrapper around the
+affected verifier is recommended as a complete workaround. Upgrade to 2.0.0 or
+later, audit registered keys and trust stores, and review historical actions
+authorized with externally supplied keys.

--- a/crates/dcrypt-symmetric/RUSTSEC-0000-0000.md
+++ b/crates/dcrypt-symmetric/RUSTSEC-0000-0000.md
@@ -1,0 +1,34 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "dcrypt-symmetric"
+date = "2026-08-09"
+url = "https://github.com/ioi-foundation/dcrypt/security/advisories/GHSA-8cwp-4826-jg9f"
+references = [
+    "https://github.com/ioi-foundation/dcrypt/commit/c99cc86f0ee353010cd202cbcd2c310371b0bbb8",
+    "https://github.com/ioi-foundation/dcrypt/releases/tag/v2.0.0",
+]
+categories = ["crypto-failure", "denial-of-service"]
+keywords = ["aead", "reordering", "replay", "streaming", "truncation"]
+aliases = ["GHSA-8cwp-4826-jg9f"]
+
+[versions]
+patched = [">= 2.0.0"]
+```
+
+# Streaming AEAD does not authenticate stream structure
+
+In all published versions of `dcrypt-symmetric` before 2.0.0, version-1 GCM and
+ChaCha20-Poly1305 streams used unauthenticated terminator, counter, and length
+fields. Decryptors trusted transmitted counters, allocated from unbounded
+lengths, and discarded plaintext that did not fit a caller's single read
+buffer. An attacker could obtain successful truncated EOF, omit, replay, or
+reorder frames within a stream, or request an allocation approaching 4 GiB.
+
+Version 2.0.0 introduces the `DCRSTRM2` format, which authenticates its version,
+algorithm, random stream identifier, base nonce, strict sequence, bounded
+lengths, final flag, and caller AAD. It enforces authenticated finality and
+physical EOF, bounds frames to 16 KiB before allocation, retains partial-read
+plaintext, and rejects legacy version-1 input. Existing version-1 ciphertext
+cannot retrospectively prove completeness or ordering and must be migrated only
+through an application-specific, explicitly trusted process.


### PR DESCRIPTION
## Affected crate(s)

- `dcrypt-api` (4,924 recent downloads on crates.io)
- `dcrypt-sign` (4,675 recent downloads on crates.io)
- `dcrypt-algorithms` (4,829 recent downloads on crates.io)
- `dcrypt-symmetric` (4,631 recent downloads on crates.io)

## Links to upstream disclosures and fix

- [ErrorRegistry memory unsafety (GHSA-7hc7-h3f2-r4j6)](https://github.com/ioi-foundation/dcrypt/security/advisories/GHSA-7hc7-h3f2-r4j6)
- [Ed25519 identity-key forgery (GHSA-7j32-2mpw-c784)](https://github.com/ioi-foundation/dcrypt/security/advisories/GHSA-7j32-2mpw-c784)
- [GCM operation nonce ignored (GHSA-h9f2-fgp8-vc4h)](https://github.com/ioi-foundation/dcrypt/security/advisories/GHSA-h9f2-fgp8-vc4h)
- [Unauthenticated streaming framing (GHSA-8cwp-4826-jg9f)](https://github.com/ioi-foundation/dcrypt/security/advisories/GHSA-8cwp-4826-jg9f)
- [Remediation commit](https://github.com/ioi-foundation/dcrypt/commit/c99cc86f0ee353010cd202cbcd2c310371b0bbb8)
- [dcrypt v2.0.0 security-remediation release](https://github.com/ioi-foundation/dcrypt/releases/tag/v2.0.0)

## Severity

- `dcrypt-api`: critical memory unsafety reachable through safe Rust, including mismatched deallocation, type confusion, and concurrent use-after-free.
- `dcrypt-sign`: critical Ed25519 authentication bypass that permits universal signature forgery with the identity public key.
- `dcrypt-algorithms`: high-severity GCM nonce reuse that can compromise confidentiality and authenticity.
- `dcrypt-symmetric`: high-severity stream-integrity failure, plus denial of service through an attacker-controlled allocation size.

GitHub CVE requests are pending for all four published GHSAs. CVSS vectors are intentionally omitted rather than inferred without deployment context.

## Version-range verification

The upstream maintainer reviewed the Git history and every published artifact for each affected package. All 24 versions from `0.9.0-beta.1` through `1.2.3` contain the corresponding vulnerable implementation, and `2.0.0` is the first fixed version. There are no earlier published versions of these crate names.

## Checklist

- [x] Advisory filenames start with `RUSTSEC-0000-0000` as the ID
- [x] `date` fields are set to the public disclosure date
- [x] Each advisory contains a concise and descriptive title after its metadata
- [x] Publishing was approved by the upstream maintainer
