### PR TITLE
Document withdrawal of dcrypt 2.0.0

### DIFF
--- a/crates/dcrypt-algorithms/RUSTSEC-0000-0000.md
+++ b/crates/dcrypt-algorithms/RUSTSEC-0000-0000.md
@@ -6,7 +6,7 @@ date = "2026-08-09"
 url = "https://github.com/ioi-foundation/dcrypt/security/advisories/GHSA-h9f2-fgp8-vc4h"
 references = [
     "https://github.com/ioi-foundation/dcrypt/commit/c99cc86f0ee353010cd202cbcd2c310371b0bbb8",
-    "https://github.com/ioi-foundation/dcrypt/releases/tag/v2.0.0",
+    "https://github.com/ioi-foundation/dcrypt/blob/master/docs/security/V2.0.0-WITHDRAWAL.md",
 ]
 categories = ["crypto-failure"]
 keywords = ["aes-gcm", "nonce-reuse"]
@@ -18,6 +18,12 @@ patched = [">= 2.0.0"]
 
 # Low-level GCM ignores the operation nonce
 
+**Release withdrawal (2026-08-09):** Version 2.0.0 remediates this specific
+issue, but is withdrawn and yanked for a separate implementation-policy
+violation. It is not a supported upgrade target. Version 1.2.3 is not a safe
+fallback, and no maintainer-supported patched release is currently available.
+The immutable `v2.0.0` tag is retained only as historical provenance.
+
 In all published versions of `dcrypt-algorithms` before 2.0.0, the low-level
 `Gcm` builder required an operation nonce but derived `J0` from the nonce
 captured by the original `Gcm` constructor. Multiple operations could therefore
@@ -27,6 +33,7 @@ confidentiality and authenticity under an affected key.
 Version 2.0.0 makes `Gcm` key-only and passes the operation nonce through IV
 derivation, encryption, and decryption. It also corrects non-96-bit IV
 processing, rejects tags shorter than 96 bits, and enforces counter limits.
-Applications must upgrade, identify affected keys, rotate them, and re-encrypt
-affected data; updating the implementation cannot restore security after nonce
-reuse.
+Do not deploy 2.0.0. Stop relying on the affected implementation where feasible
+and await a supported replacement release. Applications must identify affected
+keys, rotate them, and re-encrypt affected data; updating the implementation
+cannot restore security after nonce reuse.

--- a/crates/dcrypt-api/RUSTSEC-0000-0000.md
+++ b/crates/dcrypt-api/RUSTSEC-0000-0000.md
@@ -6,7 +6,7 @@ date = "2026-08-09"
 url = "https://github.com/ioi-foundation/dcrypt/security/advisories/GHSA-7hc7-h3f2-r4j6"
 references = [
     "https://github.com/ioi-foundation/dcrypt/commit/c99cc86f0ee353010cd202cbcd2c310371b0bbb8",
-    "https://github.com/ioi-foundation/dcrypt/releases/tag/v2.0.0",
+    "https://github.com/ioi-foundation/dcrypt/blob/master/docs/security/V2.0.0-WITHDRAWAL.md",
 ]
 categories = ["memory-corruption", "thread-safety"]
 keywords = ["safe-code", "type-confusion", "use-after-free"]
@@ -17,6 +17,12 @@ patched = [">= 2.0.0"]
 ```
 
 # Safe ErrorRegistry APIs can cause undefined behavior
+
+**Release withdrawal (2026-08-09):** Version 2.0.0 remediates this specific
+issue, but is withdrawn and yanked for a separate implementation-policy
+violation. It is not a supported upgrade target. Version 1.2.3 is not a safe
+fallback, and no maintainer-supported patched release is currently available.
+The immutable `v2.0.0` tag is retained only as historical provenance.
 
 All published versions of `dcrypt-api` before 2.0.0 exposed safe
 `ErrorRegistry` operations that could trigger undefined behavior when the
@@ -32,5 +38,6 @@ re-exported this API are affected transitively.
 Version 2.0.0 replaces the raw pointers with owned `Box<dyn Any + Send>` values
 behind a mutex, performs checked downcasts, and uses a mutation generation so
 concurrent stores and clears win safely. There is no reliable workaround while
-calling the affected registry API. Upgrade to 2.0.0 or later and avoid
-process-global error state where possible.
+calling the affected registry API. Do not deploy 2.0.0. Stop relying on the
+affected functionality where feasible, await a supported replacement release,
+and avoid process-global error state where possible.

--- a/crates/dcrypt-sign/RUSTSEC-0000-0000.md
+++ b/crates/dcrypt-sign/RUSTSEC-0000-0000.md
@@ -6,7 +6,7 @@ date = "2026-08-09"
 url = "https://github.com/ioi-foundation/dcrypt/security/advisories/GHSA-7j32-2mpw-c784"
 references = [
     "https://github.com/ioi-foundation/dcrypt/commit/c99cc86f0ee353010cd202cbcd2c310371b0bbb8",
-    "https://github.com/ioi-foundation/dcrypt/releases/tag/v2.0.0",
+    "https://github.com/ioi-foundation/dcrypt/blob/master/docs/security/V2.0.0-WITHDRAWAL.md",
 ]
 categories = ["crypto-failure"]
 keywords = ["ed25519", "identity-key", "signature-forgery"]
@@ -18,6 +18,12 @@ patched = [">= 2.0.0"]
 
 # Ed25519 identity public keys permit universal signature forgery
 
+**Release withdrawal (2026-08-09):** Version 2.0.0 remediates this specific
+issue, but is withdrawn and yanked for a separate implementation-policy
+violation. It is not a supported upgrade target. Version 1.2.3 is not a safe
+fallback, and no maintainer-supported patched release is currently available.
+The immutable `v2.0.0` tag is retained only as historical provenance.
+
 All published versions of `dcrypt-sign` before 2.0.0 accepted the Edwards
 identity as an Ed25519 public key. A signature with `R = B` and `S = 1` then
 verified for every message because the challenge term multiplied the identity.
@@ -28,6 +34,7 @@ have accepted forged authorizations.
 Version 2.0.0 replaces the custom arithmetic with `ed25519-dalek`, uses strict
 verification, and rejects noncanonical, small-order, and non-torsion-free public
 keys and `R` values, as well as noncanonical `S >= L`. No wrapper around the
-affected verifier is recommended as a complete workaround. Upgrade to 2.0.0 or
-later, audit registered keys and trust stores, and review historical actions
-authorized with externally supplied keys.
+affected verifier is recommended as a complete workaround. Do not deploy
+2.0.0. Stop relying on the affected verifier where feasible and await a
+supported replacement release. Audit registered keys and trust stores, and
+review historical actions authorized with externally supplied keys.

--- a/crates/dcrypt-symmetric/RUSTSEC-0000-0000.md
+++ b/crates/dcrypt-symmetric/RUSTSEC-0000-0000.md
@@ -6,7 +6,7 @@ date = "2026-08-09"
 url = "https://github.com/ioi-foundation/dcrypt/security/advisories/GHSA-8cwp-4826-jg9f"
 references = [
     "https://github.com/ioi-foundation/dcrypt/commit/c99cc86f0ee353010cd202cbcd2c310371b0bbb8",
-    "https://github.com/ioi-foundation/dcrypt/releases/tag/v2.0.0",
+    "https://github.com/ioi-foundation/dcrypt/blob/master/docs/security/V2.0.0-WITHDRAWAL.md",
 ]
 categories = ["crypto-failure", "denial-of-service"]
 keywords = ["aead", "reordering", "replay", "streaming", "truncation"]
@@ -17,6 +17,12 @@ patched = [">= 2.0.0"]
 ```
 
 # Streaming AEAD does not authenticate stream structure
+
+**Release withdrawal (2026-08-09):** Version 2.0.0 remediates this specific
+issue, but is withdrawn and yanked for a separate implementation-policy
+violation. It is not a supported upgrade target. Version 1.2.3 is not a safe
+fallback, and no maintainer-supported patched release is currently available.
+The immutable `v2.0.0` tag is retained only as historical provenance.
 
 In all published versions of `dcrypt-symmetric` before 2.0.0, version-1 GCM and
 ChaCha20-Poly1305 streams used unauthenticated terminator, counter, and length
@@ -31,4 +37,5 @@ lengths, final flag, and caller AAD. It enforces authenticated finality and
 physical EOF, bounds frames to 16 KiB before allocation, retains partial-read
 plaintext, and rejects legacy version-1 input. Existing version-1 ciphertext
 cannot retrospectively prove completeness or ordering and must be migrated only
-through an application-specific, explicitly trusted process.
+through an application-specific, explicitly trusted process. Do not deploy
+2.0.0; await a supported replacement release.


### PR DESCRIPTION
## Summary

dcrypt 2.0.0 has been withdrawn and yanked because it violates the project's
zero-unsafe, zero-native-code, and zero-FFI implementation policy. Version
1.2.3 has also been yanked and is not a safe fallback. No maintainer-supported
patched release is currently available.

This follow-up:

- adds a prominent withdrawal warning to all four dcrypt advisories;
- replaces the deleted-release reference with the durable upstream withdrawal
  notice; and
- removes recommendations to deploy 2.0.0 while preserving the technically
  accurate vulnerability ranges and `patched >= 2.0.0` metadata for these four
  specific flaws.

The withdrawal is a separate implementation-policy correction. It does not
assert that these four named vulnerabilities persist in 2.0.0, and the
immutable v2.0.0 tag remains available as historical provenance.

Upstream notice:
https://github.com/ioi-foundation/dcrypt/blob/master/docs/security/V2.0.0-WITHDRAWAL.md

## Validation

- `rustsec-admin lint`
- `git diff --check`
