### PR TITLE
Move gettext advisory to correct crate directory

### DIFF
--- a/crates/gettext-sys/RUSTSEC-0000-0000.md
+++ b/crates/gettext-sys/RUSTSEC-0000-0000.md
@@ -7,10 +7,9 @@ url = "https://github.com/gettext-rs/gettext-rs/issues/64"
 informational = "unsound"
 categories = ["memory-corruption", "thread-safety"]
 
-[affected]
 [affected.functions]
-"gettextrs::setlocale" = ["< 0.8.0"]
-"gettextrs::TextDomain::init" = ["< 0.8.0"]
+"gettext_sys::setlocale" = ["< 0.8.0"]
+"gettext_sys::TextDomain::init" = ["< 0.8.0"]
 
 [versions]
 patched = [">= 0.8.0"]


### PR DESCRIPTION
From 

- #3119 

this was in the wrong dir but GitHub Actions did not report that in a way that I noticed...

Fixes #3126.