### PR TITLE
Move RUSTSEC-2026-0244 to correct crate

### DIFF
--- a/crates/gettext-rs/RUSTSEC-2026-0244.md
+++ b/crates/gettext-rs/RUSTSEC-2026-0244.md
@@ -8,8 +8,8 @@ informational = "unsound"
 categories = ["memory-corruption", "thread-safety"]
 
 [affected.functions]
-"gettext-rs::setlocale" = ["< 0.8.0"]
-"gettext-rs::TextDomain::init" = ["< 0.8.0"]
+"gettext_rs::setlocale" = ["< 0.8.0"]
+"gettext_rs::TextDomain::init" = ["< 0.8.0"]
 
 [versions]
 patched = [">= 0.8.0"]

--- a/crates/gettext-rs/RUSTSEC-2026-0244.md
+++ b/crates/gettext-rs/RUSTSEC-2026-0244.md
@@ -1,15 +1,15 @@
 ```toml
 [advisory]
 id = "RUSTSEC-2026-0244"
-package = "gettext-sys"
+package = "gettext-rs"
 date = "2026-08-06"
 url = "https://github.com/gettext-rs/gettext-rs/issues/64"
 informational = "unsound"
 categories = ["memory-corruption", "thread-safety"]
 
 [affected.functions]
-"gettext_sys::setlocale" = ["< 0.8.0"]
-"gettext_sys::TextDomain::init" = ["< 0.8.0"]
+"gettextrs::setlocale" = ["< 0.8.0"]
+"gettextrs::TextDomain::init" = ["< 0.8.0"]
 
 [versions]
 patched = [">= 0.8.0"]

--- a/crates/gettext-rs/RUSTSEC-2026-0244.md
+++ b/crates/gettext-rs/RUSTSEC-2026-0244.md
@@ -8,8 +8,8 @@ informational = "unsound"
 categories = ["memory-corruption", "thread-safety"]
 
 [affected.functions]
-"gettextrs::setlocale" = ["< 0.8.0"]
-"gettextrs::TextDomain::init" = ["< 0.8.0"]
+"gettext-rs::setlocale" = ["< 0.8.0"]
+"gettext-rs::TextDomain::init" = ["< 0.8.0"]
 
 [versions]
 patched = [">= 0.8.0"]


### PR DESCRIPTION
In https://github.com/rustsec/advisory-db/pull/3119 I specified the wrong `package` ("gettext-sys" instead of "gettext-rs"). This caused problems for downstream users (https://github.com/rustsec/advisory-db/issues/3126). https://github.com/rustsec/advisory-db/pull/3125 attempted a fix but got it wrong (updated everything to align with the wrong `package`). This PR is my attempt to fix it properly.

/cc @djc 