### PR TITLE
Add note re hyphens in crate names

### DIFF
--- a/EXAMPLE_ADVISORY.md
+++ b/EXAMPLE_ADVISORY.md
@@ -20,6 +20,7 @@ keywords = ["example", "freeform", "keywords"]
 #os = ["windows"]
 
 #[affected.functions]
+# NB: change hyphens in the crate name to underscores, i.e. "crate-name" -> "crate_name"
 #"crate_name::MyStruct::vulnerable_fn" = [">= 1.3.0, < 1.3.4"]
 
 [versions]


### PR DESCRIPTION
In https://github.com/rustsec/advisory-db/pull/3128 I had to try a few different ways to mangle "gettext-rs". This commit ensures that future contributors don't have to re-discover that knowledge.

I realise that turning hyphens into underscores is Cargo convention, but I got confused anyway. Perhaps the fact that gettext-rs defines a library name of "gettextrs" contributed to that.

I'd open an issue first to discuss this, but it felt like too small a change to warrant that. Please don't feel pressured to merge this!