### PR TITLE
Add unmaintained advisory for sevenz-rust

### DIFF
--- a/crates/sevenz-rust/RUSTSEC-0000-0000.md
+++ b/crates/sevenz-rust/RUSTSEC-0000-0000.md
@@ -10,4 +10,4 @@ patched = []
 ```
 # `sevenz-rust` is unmaintained   
 
-The `sevenz-rust` repository has been deleted and the crate is no longer actively maintained.
+The `sevenz-rust` repository has been deleted and the crate is no longer actively maintained. Users should migrate away from the library in favor of a modern up-to-date 7z library such as `sevenz-rust2`.

--- a/crates/sevenz-rust/RUSTSEC-0000-0000.md
+++ b/crates/sevenz-rust/RUSTSEC-0000-0000.md
@@ -1,0 +1,13 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "sevenz-rust"
+date = "2026-08-06"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+# `sevenz-rust` is unmaintained   
+
+The `sevenz-rust` repository has been deleted and the crate is no longer actively maintained.


### PR DESCRIPTION
## Affected crate(s)

- sevenz-rust (495,037 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

Repository for library has been deleted and project has been abandoned.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate (unable to find maintainer contact due to author's github being deleted)
