### PR TITLE
Add advisory for sp-sized-chunks: panic-safety UAF/double-free in clear/drop_left/drop_right

### DIFF
--- a/crates/sp-sized-chunks/RUSTSEC-0000-0000.md
+++ b/crates/sp-sized-chunks/RUSTSEC-0000-0000.md
@@ -2,26 +2,27 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "sp-sized-chunks"
-date = "2026-08-04"
+date = "2026-08-11"
 categories = ["memory-corruption"]
 keywords = ["panic-safety", "memory-safety", "use-after-free", "double-free"]
 informational = "unsound"
 
+[affected]
+[affected.functions]
+"sp_sized_chunks::Chunk::clear" = ["<= 0.1.0"]
+"sp_sized_chunks::Chunk::drop_left" = ["<= 0.1.0"]
+"sp_sized_chunks::Chunk::drop_right" = ["<= 0.1.0"]
+"sp_sized_chunks::InlineArray::clear" = ["<= 0.1.0"]
+
 [versions]
 patched = []
-unaffected = []
 ```
 
 # Panic-safety unsoundness in `Chunk` and `InlineArray` (use-after-free / double-free)
 
 Several methods in `sp-sized-chunks` drop elements before updating the container's length/boundary metadata. If an element's `Drop` panics during the drop, the metadata update is skipped, so the container still treats the already-dropped elements as live. When the container is later dropped, its own `Drop` re-visits those slots and drops the freed elements again — a use-after-free / double-free reachable from safe Rust.
 
-`sp-sized-chunks` is a fork of `sized-chunks` (companion advisory filed separately) and carries the same bug.
-
-## Affected methods
-
-- `Chunk::clear`, `Chunk::drop_left`, `Chunk::drop_right`
-- `InlineArray::clear`
+`sp-sized-chunks` is a fork of `sized-chunks` (companion advisory filed separately) and carries the same bug. The repository is archived and the crate is still on 0.1.0 with no fix available.
 
 ## Impact
 
@@ -29,7 +30,3 @@ Several methods in `sp-sized-chunks` drop elements before updating the container
 - **CWE-416 (Use-After-Free):** an element reads its own freed allocation during `Drop` (e.g. `String`) — confirmed under AddressSanitizer.
 
 All are reachable from safe Rust via `catch_unwind` with element types whose `Drop` can panic.
-
-## Status
-
-The repository is archived and the crate is still on 0.1.0 with no fix. Affected users should avoid these methods with element types whose `Drop` can panic, or migrate away from the crate.

--- a/crates/sp-sized-chunks/RUSTSEC-0000-0000.md
+++ b/crates/sp-sized-chunks/RUSTSEC-0000-0000.md
@@ -1,0 +1,35 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "sp-sized-chunks"
+date = "2026-08-04"
+categories = ["memory-corruption"]
+keywords = ["panic-safety", "memory-safety", "use-after-free", "double-free"]
+informational = "unsound"
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# Panic-safety unsoundness in `Chunk` and `InlineArray` (use-after-free / double-free)
+
+Several methods in `sp-sized-chunks` drop elements before updating the container's length/boundary metadata. If an element's `Drop` panics during the drop, the metadata update is skipped, so the container still treats the already-dropped elements as live. When the container is later dropped, its own `Drop` re-visits those slots and drops the freed elements again — a use-after-free / double-free reachable from safe Rust.
+
+`sp-sized-chunks` is a fork of `sized-chunks` (companion advisory filed separately) and carries the same bug.
+
+## Affected methods
+
+- `Chunk::clear`, `Chunk::drop_left`, `Chunk::drop_right`
+- `InlineArray::clear`
+
+## Impact
+
+- **CWE-415 (Double Free):** the same allocation is freed twice (e.g. an element holding `Box<T>`).
+- **CWE-416 (Use-After-Free):** an element reads its own freed allocation during `Drop` (e.g. `String`) — confirmed under AddressSanitizer.
+
+All are reachable from safe Rust via `catch_unwind` with element types whose `Drop` can panic.
+
+## Status
+
+The repository is archived and the crate is still on 0.1.0 with no fix. Affected users should avoid these methods with element types whose `Drop` can panic, or migrate away from the crate.


### PR DESCRIPTION
## Affected crate(s)

- `sp-sized-chunks` 0.1.0 (197 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

The repo is archived and the crate is still on 0.1.0 with no fix, so upstream reporting isn't possible. `sp-sized-chunks` is a fork of `sized-chunks` (companion advisory in #3111).

## Severity

Panic-safety unsoundness in `Chunk` and `InlineArray` (`clear`, `drop_left`, `drop_right`, `InlineArray::clear`). Elements are dropped before the length/boundary metadata is updated, so a panicking element `Drop` leaves stale metadata and the container's own `Drop` re-drops already-freed elements — use-after-free / double-free reachable from safe Rust, confirmed under AddressSanitizer.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate (repo archived, no fix on 0.1.0 — unreachable-author exception; fork of sized-chunks, discussed in #3111)