### PR TITLE
Add advisory for circular-buffer (panic-safety UAF/double-free)

### DIFF
--- a/crates/circular-buffer/RUSTSEC-0000-0000.md
+++ b/crates/circular-buffer/RUSTSEC-0000-0000.md
@@ -1,0 +1,34 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "circular-buffer"
+date = "2026-08-11"
+url = "https://github.com/andreacorbellini/rust-circular-buffer/blob/master/CHANGELOG.md"
+categories = ["memory-corruption"]
+keywords = ["panic-safety", "memory-safety", "use-after-free", "double-free"]
+informational = "unsound"
+
+[versions]
+patched = [">= 2.0.1"]
+```
+
+# Panic-safety unsoundness in `truncate_back`, `truncate_front`, `clear`, and `extend_from_slice` (use-after-free / double-free)
+
+Several methods in `circular-buffer` drop elements before updating the buffer's start/end metadata. If an element's `Drop` panics during the drop, the metadata update is skipped, so the buffer still treats the already-dropped elements as live. When the buffer is later dropped (or used after the panic is caught), those elements are visited again — a use-after-free / double-free reachable from safe Rust.
+
+## Affected methods
+
+- `truncate_back`, `truncate_front` — confirmed under AddressSanitizer.
+- `extend_from_slice` — reaches the bug through `truncate_front` / `clear`; confirmed under AddressSanitizer.
+- `clear` — delegates to `truncate_back(0)` and carries the same bug.
+
+## Impact
+
+- **CWE-415 (Double Free):** the same allocation is freed twice.
+- **CWE-416 (Use-After-Free):** a freed allocation is accessed during a repeated `Drop`.
+
+Reachable entirely from safe Rust via `catch_unwind` with element types whose `Drop` can panic.
+
+## Fix
+
+Fixed in `circular-buffer` 2.0.1 by adjusting the buffer's start/end metadata before the elements are dropped.

--- a/crates/circular-buffer/RUSTSEC-0000-0000.md
+++ b/crates/circular-buffer/RUSTSEC-0000-0000.md
@@ -23,12 +23,6 @@ patched = [">= 2.0.1"]
 
 Several methods in `circular-buffer` drop elements before updating the buffer's start/end metadata. If an element's `Drop` panics during the drop, the metadata update is skipped, so the buffer still treats the already-dropped elements as live. When the buffer is later dropped (or used after the panic is caught), those elements are visited again — a use-after-free / double-free reachable from safe Rust.
 
-## Affected methods
-
-- `truncate_back`, `truncate_front` — confirmed under AddressSanitizer.
-- `extend_from_slice` — reaches the bug through `truncate_front` / `clear`; confirmed under AddressSanitizer.
-- `clear` — delegates to `truncate_back(0)` and carries the same bug.
-
 ## Impact
 
 - **CWE-415 (Double Free):** the same allocation is freed twice.

--- a/crates/circular-buffer/RUSTSEC-0000-0000.md
+++ b/crates/circular-buffer/RUSTSEC-0000-0000.md
@@ -8,6 +8,13 @@ categories = ["memory-corruption"]
 keywords = ["panic-safety", "memory-safety", "use-after-free", "double-free"]
 informational = "unsound"
 
+[affected]
+[affected.functions]
+"circular_buffer::CircularBuffer::truncate_back" = ["< 2.0.1"]
+"circular_buffer::CircularBuffer::truncate_front" = ["< 2.0.1"]
+"circular_buffer::CircularBuffer::clear" = ["< 2.0.1"]
+"circular_buffer::CircularBuffer::extend_from_slice" = ["< 2.0.1"]
+
 [versions]
 patched = [">= 2.0.1"]
 ```


### PR DESCRIPTION
## Affected crate(s)

- `circular-buffer` (920,280 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

Reported privately by email (no public issue). Fixed in 2.0.1; the maintainer documented it as undefined behavior and credited the report in the changelog: https://github.com/andreacorbellini/rust-circular-buffer/blob/master/CHANGELOG.md

## Severity

Panic-safety unsoundness in `truncate_back`, `truncate_front`, `clear`, and `extend_from_slice`. Elements are dropped before the buffer's start/end metadata is updated, so a panicking element `Drop` leaves stale metadata and the buffer later re-drops already-freed elements — use-after-free / double-free reachable from safe Rust, confirmed under AddressSanitizer. Fixed in 2.0.1.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate (maintainer confirmed by email and explicitly approved filing an advisory — "please feel free to do so")