### PR TITLE
Add advisory for orx-split-vec (panic-safety uninitialized read)

### DIFF
--- a/crates/orx-split-vec/RUSTSEC-0000-0000.md
+++ b/crates/orx-split-vec/RUSTSEC-0000-0000.md
@@ -1,0 +1,29 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "orx-split-vec"
+date = "2026-08-11"
+url = "https://github.com/orxfun/orx-split-vec/issues/95"
+categories = ["memory-corruption"]
+keywords = ["panic-safety", "memory-safety", "uninitialized-read"]
+informational = "unsound"
+
+[versions]
+patched = [">= 4.0.0"]
+```
+
+# Panic-safety unsoundness in `SplitVec::extend_from_slice` (uninitialized read)
+
+`SplitVec::extend_from_slice` increments the logical length `self.len` before cloning the incoming elements into the reserved slots. If an element's `Clone` panics mid-fill, unwinding leaves `self.len` counting slots that were never initialized. A later safe read (`get`, indexing, `iter`) then reads one of those uninitialized slots.
+
+This is reachable from safe Rust — a read of uninitialized memory (CWE-908). It is not a double-free: `SplitVec` has no manual `Drop` and its elements live in a standard `Vec`, so the defect is a read, not a free.
+
+## Impact
+
+A safe read after the panic returns a value built from uninitialized bytes. For a heap-owning element type such as `String`, the resulting value has garbage length/pointer fields.
+
+Confirmed under Miri. AddressSanitizer stays silent for this class, since the uninitialized bytes are consumed as a non-dereferenced field rather than an invalid load or free.
+
+## Fix
+
+Fixed in `orx-split-vec` 4.0.0, which no longer commits the length before the elements are cloned.


### PR DESCRIPTION
## Affected crate(s)

- `orx-split-vec` (1,996,435 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

Reported in https://github.com/orxfun/orx-split-vec/issues/95. Fixed in 4.0.0.

## Severity

Panic-safety unsoundness in `SplitVec::extend_from_slice`: the logical length is committed before the elements are cloned, so a panicking `Clone` leaves uninitialized slots inside the length. A subsequent safe read returns uninitialized memory — CWE-908, confirmed under Miri. Fixed in 4.0.0.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate (maintainer approved in the issue: "Yes, please")