### PR TITLE
Add advisory for kawa Transfer-Encoding request smuggling (fixed in 0.7.0)

### DIFF
--- a/crates/kawa/RUSTSEC-0000-0000.md
+++ b/crates/kawa/RUSTSEC-0000-0000.md
@@ -1,0 +1,54 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "kawa"
+date = "2026-08-11"
+url = "https://github.com/CleverCloud/kawa/pull/19"
+keywords = ["http", "parsing", "request-smuggling"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"
+
+[versions]
+patched = [">= 0.7.0"]
+```
+
+# Lenient `Transfer-Encoding` parsing in `kawa` allows HTTP request smuggling
+
+`kawa`'s HTTP/1 header parser selected chunked framing using a suffix-only comparison on the
+raw `Transfer-Encoding` value, without trimming optional whitespace (OWS) and without
+requiring `chunked` to be the final transfer-coding:
+
+```rust
+const CHUNKED: &[u8] = b"chunked";
+if val.len() >= CHUNKED.len()
+    && compare_no_case(&val[val.len() - CHUNKED.len()..], CHUNKED)
+```
+
+Values such as `chunked\t`, `chunked ` (trailing space), and `chunked,identity` therefore did
+not select chunked framing. When such a request also carried a `Content-Length`, `kawa` framed
+the message by `Content-Length` and forwarded the `Transfer-Encoding` header unchanged, instead
+of rejecting the message as RFC 9112 §6.3 requires.
+
+A downstream server that resolves `Transfer-Encoding` correctly (trimming OWS per RFC 9110
+§5.6.3) then frames the same message as chunked. Front end and back end disagree on the message
+boundary, which is a CL.TE desynchronization: an attacker can prepend arbitrary bytes to the
+next request on a reused back end connection, bypassing any authentication, ACL, or rate
+limiting enforced only at the proxy.
+
+To be affected, `kawa` must be used to parse HTTP/1 requests that are forwarded to another HTTP
+implementation whose `Transfer-Encoding` handling is stricter. Backends observed to honor the
+obfuscated header include Go `net/http`, Puma, `uvicorn --http h11`, and Hypercorn.
+
+This is a regression of [sozu-proxy/sozu#726](https://github.com/sozu-proxy/sozu/issues/726),
+fixed in 2021 by sozu PR #739 and lost in the rewrite onto `kawa`.
+
+## Remediation
+
+Upgrade to `kawa` 0.7.0 or later, which trims OWS, requires `chunked` to be the final
+transfer-coding, and rejects a request whose `Transfer-Encoding` is present but does not end in
+`chunked` ([PR #19](https://github.com/CleverCloud/kawa/pull/19),
+[PR #21](https://github.com/CleverCloud/kawa/pull/21)).
+
+Users of `sozu` should upgrade to 2.2.0 or later, which depends on `kawa` 0.7.1. `sozu` 2.1.1
+and earlier bundle the affected `kawa` 0.6.8.
+
+Reported by Aymane Mazguiti (unclej4ck).

--- a/crates/kawa/RUSTSEC-0000-0000.md
+++ b/crates/kawa/RUSTSEC-0000-0000.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "kawa"
-date = "2026-08-11"
+date = "2026-07-15"
 url = "https://github.com/CleverCloud/kawa/pull/19"
 keywords = ["http", "parsing", "request-smuggling"]
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N"


### PR DESCRIPTION
## Affected crate(s)

- `kawa` (37,218 all-time downloads, 3,660 recent per crates.io). It is the HTTP/1
  parser used by the `sozu` reverse proxy (65,795 all-time downloads), so the affected
  position is a proxy front end.

## Links to upstream issue(s) or PR(s)

- Upstream fix: https://github.com/CleverCloud/kawa/pull/19 (merged 2026-07-15), plus
  follow-up https://github.com/CleverCloud/kawa/pull/21
- Released in kawa https://github.com/CleverCloud/kawa/releases/tag/v0.7.0 and v0.7.1
- `sozu` 2.2.0 depends on `kawa ^0.7.1`; its release notes describe the change as
  "HTTP/1 `Transfer-Encoding` smuggling hardening"
- Original issue this regressed from: https://github.com/sozu-proxy/sozu/issues/726
  (the fix commit's own code comment states it closes this issue)

Reported privately to `security@clever.cloud` on 2026-07-10, the contact published in
Clever Cloud's `.well-known/security.txt`, with a full write-up and a self-contained
reproduction. I received no reply, but the maintainers fixed and shipped it four days
later. There is currently no GHSA, no CVE, and no RustSec entry.

## Severity

HTTP request smuggling (CWE-444) at a proxy front end.
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N` (7.5).

`kawa` selected chunked framing with a suffix-only comparison on the raw
`Transfer-Encoding` value, with no OWS trim and no requirement that `chunked` be the
final transfer-coding:

```rust
const CHUNKED: &[u8] = b"chunked";
if val.len() >= CHUNKED.len()
    && compare_no_case(&val[val.len() - CHUNKED.len()..], CHUNKED)
```

So `chunked\t`, `chunked ` and `chunked,identity` did not select chunked framing. With a
`Content-Length` also present, `kawa` framed by `Content-Length` and forwarded the
`Transfer-Encoding` header unchanged instead of rejecting the message (RFC 9112 6.3). A
stricter downstream server frames the same message as chunked, which desynchronizes the
two and lets an attacker prepend bytes to the next request on a reused back end
connection, bypassing authentication or ACLs enforced only at the proxy.

Affected: all published versions before 0.7.0. Verified empirically on 0.6.8 via `sozu`
2.1.0 and 2.1.1. The unfixed handling is present by inspection in 0.6.5, 0.6.7 and 0.6.8;
0.6.3 and earlier use an exact-match compare that likewise neither normalizes nor rejects
an obfuscated value.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date (2026-07-15, the kawa 0.7.0
      release that shipped the fix publicly)
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate

On the last item: I reported privately to the documented security contact and got no
reply in 32 days, though the fix shipped. Following @djc's note, I am now asking the kawa
maintainers directly on their fix PR for approval, and will link their response here.

I could not run `rustsec-admin lint` locally (it requires rustc 1.96, this machine has
1.94), so I validated by hand against the README template and RUSTSEC-2021-0078. The
"Lint advisories" CI job passes. Happy to adjust anything.
