### PR TITLE
Add unmaintained advisory for sp-sized-chunks

### DIFF
--- a/crates/sp-sized-chunks/RUSTSEC-0000-0000.md
+++ b/crates/sp-sized-chunks/RUSTSEC-0000-0000.md
@@ -11,4 +11,4 @@ patched = []
 
 # `sp-sized-chunks` is unmaintained
 
-The `sp-sized-chunks` crate is a fork of `sized-chunks`. Its repository is archived and the crate is no longer maintained. Users should migrate to a maintained alternative.
+The `sp-sized-chunks` crate is a fork of `sized-chunks`. Its repository is archived and the crate is no longer maintained. Users should migrate to [`imbl-sized-chunks`](https://crates.io/crates/imbl-sized-chunks), a maintained fork.

--- a/crates/sp-sized-chunks/RUSTSEC-0000-0000.md
+++ b/crates/sp-sized-chunks/RUSTSEC-0000-0000.md
@@ -1,0 +1,14 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "sp-sized-chunks"
+date = "2026-08-11"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `sp-sized-chunks` is unmaintained
+
+The `sp-sized-chunks` crate is a fork of `sized-chunks`. Its repository is archived and the crate is no longer maintained. Users should migrate to a maintained alternative.


### PR DESCRIPTION
## Affected crate(s)

- `sp-sized-chunks` (195 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

The repository is archived and the crate is no longer maintained.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate (repository archived)