### PR TITLE
Add advisory for webbrowser argument injection

### DIFF
--- a/crates/webbrowser/RUSTSEC-0000-0000.md
+++ b/crates/webbrowser/RUSTSEC-0000-0000.md
@@ -1,0 +1,45 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "webbrowser"
+date = "2026-07-29"
+url = "https://github.com/amodm/webbrowser-rs/security/advisories/GHSA-2ph8-5cr8-hr33"
+references = [
+    "https://github.com/amodm/webbrowser-rs/commit/31d1b924885551c0e553909d27c738ca6958a0f3",
+    "https://github.com/amodm/webbrowser-rs/releases/tag/v1.2.2",
+]
+categories = ["format-injection"]
+keywords = ["argument-injection", "browser", "unix"]
+aliases = ["GHSA-2ph8-5cr8-hr33"]
+
+[affected.functions]
+"webbrowser::open" = ["<= 1.2.1"]
+"webbrowser::open_browser" = ["<= 1.2.1"]
+"webbrowser::open_browser_with_options" = ["<= 1.2.1"]
+
+[versions]
+patched = [">= 1.2.2"]
+```
+
+# Unix `BROWSER` handling allows browser argument injection
+
+On Unix platforms handled by `src/unix.rs`, affected versions substitute the
+caller-supplied URL into the `BROWSER` environment-variable template before
+tokenizing the resulting string with `split_ascii_whitespace()`. If an
+application passes an attacker-controlled non-HTTP(S) URL whose parsed form
+retains spaces and the effective `BROWSER` template contains `%s`, text that
+should remain within one URL argument becomes additional browser arguments.
+
+The issue was reproduced with Chromium by injecting
+`--remote-debugging-port`, which exposed a local DevTools endpoint, and
+`--proxy-server`, which redirected browser traffic through an
+attacker-controlled proxy. The available arguments and resulting impact depend
+on the browser launched by the affected application.
+
+Version 1.2.2 fixes the issue by tokenizing the `BROWSER` template before
+substituting the URL, preserving the URL as part of a single argument. Users
+should upgrade to version 1.2.2 or later. Applications that only need HTTP(S)
+URLs can also enable the crate's `hardened` feature as defense in depth.
+
+This issue was reported by
+[@dywzju09-blip](https://github.com/dywzju09-blip).


### PR DESCRIPTION
## Affected crate(s)

- `webbrowser` (`<= 1.2.1`; fixed in `1.2.2`)

## Links to upstream issue(s) or PR(s)

- Published upstream advisory: https://github.com/amodm/webbrowser-rs/security/advisories/GHSA-2ph8-5cr8-hr33
- Fix commit: https://github.com/amodm/webbrowser-rs/commit/31d1b924885551c0e553909d27c738ca6958a0f3
- Fix PR: https://github.com/amodm/webbrowser-rs/pull/119
- Patched release: https://github.com/amodm/webbrowser-rs/releases/tag/v1.2.2

## Severity

On affected Unix paths, an attacker-controlled non-HTTP(S) URL containing spaces can be split into additional browser arguments when the effective `BROWSER` template contains `%s`.

This was reproduced with Chromium by injecting flags that exposed a local DevTools endpoint and redirected browser traffic through an attacker-controlled proxy.

Exploitation requires an application to pass attacker-controlled URL text, use the generic Unix backend, and launch a browser that recognizes the injected flags.

## Checklist

- [x] Advisory filename starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] The vulnerability was confirmed and publicly disclosed by the upstream maintainer as `GHSA-2ph8-5cr8-hr33`
- [x] Asked the maintainer(s) whether publishing a RustSec advisory is appropriate