### PR TITLE
Add advisory for tiberius: panics on hostile server input

### DIFF
--- a/crates/tiberius/RUSTSEC-0000-0000.md
+++ b/crates/tiberius/RUSTSEC-0000-0000.md
@@ -1,0 +1,94 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tiberius"
+date = "2026-07-29"
+url = "https://github.com/prisma/tiberius/issues/424"
+references = [
+    "https://github.com/prisma/tiberius/issues/424",
+    "https://github.com/prisma/tiberius/issues/425",
+]
+categories = ["denial-of-service"]
+keywords = ["tds", "mssql", "sql-server", "parser", "panic", "dos"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
+# aliases = []   # a GHSA was filed privately on 2026-07-29 but the maintainer has
+#                # not published it, so there is no resolvable alias or CVE yet
+
+[versions]
+patched = []            # no fixed release exists; latest is 0.12.3 (2024-07-19)
+```
+
+# tiberius panics on malformed or unexpected responses from a SQL Server (denial of service)
+
+`tiberius` decodes the TDS protocol from the server without treating server bytes as
+untrusted input. Eleven code paths respond to unexpected server-controlled values with
+`panic!`, `unimplemented!`, `todo!`, or `.unwrap()` on `None` rather than returning `Err`.
+
+The consequence is not simply that an attacker in the network path can disrupt a connection,
+which follows from being in the path. It is that a single server-controlled byte turns a
+recoverable connection error into a process-level panic. Under `panic = "abort"` that is a
+hard abort of the host process; otherwise it propagates out of whatever awaited the
+connection, so in pooled deployments it surfaces inside a pool worker rather than as an
+error the application can catch and retry.
+
+Three sites are in the PRELOGIN exchange, the first message of a TDS connection and the
+message that negotiates encryption, so they are reachable before authentication and before
+TLS is established:
+
+- an option token outside `0..=7` that is not the `0xFF` terminator, which is 247 of 256
+  possible byte values (`pre_login.rs`, "unsupported prelogin token")
+- a `PRELOGIN_THREADID` option whose server-supplied length is neither 0 nor 4
+  (`pre_login.rs`, "should never happen")
+- a well-formed response that simply declines the requested encryption level, which aborts
+  rather than returning an error (`pre_login.rs`, "Server does not allow the requested
+  encryption level"). This path requires a TLS feature, which is enabled by default.
+
+Eight more are in the server's login response and token stream. There the client has already
+transmitted credentials but has not authenticated the server. When the connection is
+configured `EncryptionLevel::Off` or `NotSupported` this traffic is plaintext and reachable
+by a network attacker with no credentials; when configured `On` it is inside TLS and requires
+a genuinely malicious server:
+
+- a FEATUREEXTACK feature id other than `0xFF` or `0x02`, which is 253 of 256 byte values
+  (`token_feature_ext_ack.rs`, "unsupported feature")
+- a FEDAUTH feature whose server-supplied `u32` data length is neither 0 nor 32
+  (`token_feature_ext_ack.rs`, "invalid Feature_Ext_Ack token")
+- a ROW token with no preceding COLMETADATA, which unwraps a `None` column metadata
+  (`token_row.rs`, `decode`)
+- the same via NBCROW (`token_row.rs`, `decode_nbc`)
+- token byte `0xA5` (`ColInfo`), which `TokenType::try_from` accepts as valid but the token
+  stream dispatcher has no arm for (`tds/stream/token.rs`)
+- a COLMETADATA column whose type token is `SSVariant` (`0x62`) or `Udt` (`0xF0`), both
+  accepted by `VarLenType::try_from` but absent from the length-prefix match
+  (`type_info.rs`)
+- an ENVCHANGE `BeginTransaction` or `EnlistDTCTransaction` whose length byte is not 8,
+  which reaches a bare `assert!` rather than a `debug_assert!` and so fires in release
+  builds, covering 255 of 256 byte values (`token_env_change.rs`)
+- a COLMETADATA `Intn` column followed by a ROW whose length byte is not 0, 1, 2, 4 or 8,
+  covering 251 of 256 byte values (`column_data/int.rs`); a 57-byte server response is
+  sufficient
+
+Three of these are reached by values the crate's own `try_from` conversions accept as valid
+TDS types. `ColInfo`, `Udt`, and `SSVariant` are real protocol types that are simply
+unimplemented, so a conforming server can trigger them without sending anything malformed.
+Genuinely unknown token and type bytes are already rejected correctly with `Error::Protocol`.
+The ENVCHANGE case is a bare `assert!` rather than a `debug_assert!`, so unlike a debug-only
+assertion it is live in release builds.
+
+Impact is denial of service only. There is no memory unsafety and no data disclosure. All
+eleven were confirmed against the published 0.12.3 crate in a release build, that is with
+`debug_assertions` disabled, driving only the public `Client::connect` API against a listener
+speaking TDS. The suggested CVSS above assumes an application connecting to a SQL Server it
+does not control, which is a real deployment shape; scoring the malicious-or-MITM-server
+precondition as `AC:H` instead gives 5.9 and is also defensible.
+
+No fixed version is available. The most recent release, 0.12.3, predates this report by two
+years, and every site is still present on the development branch (verified at `a6b4fcd`).
+
+On coordination: these were reported publicly on the issue tracker on 2026-07-29 as #424 and
+#425, and a private advisory was filed the same day through the repository's private
+vulnerability reporting. Neither issue has received a maintainer response in the fifteen days
+since, and the private advisory remains unpublished, which is why no resolvable GHSA or CVE
+alias is listed above.
+
+Reported by north-echo (North Echo Security Research).


### PR DESCRIPTION
## Affected crate(s)

- `tiberius` (622,315 recent downloads per crates.io, 97 reverse dependencies)

## Links to upstream issue(s) or PR(s)

- https://github.com/prisma/tiberius/issues/424
- https://github.com/prisma/tiberius/issues/425

Both filed 2026-07-29 and neither has received a maintainer response in the fifteen days since. A private advisory was filed the same day through the repository's private vulnerability reporting; it remains unpublished, which is why no resolvable GHSA or CVE alias is listed.

## Severity

Remote denial of service. Eleven decode paths respond to server-controlled values with `panic!`, `unimplemented!`, `todo!` or `.unwrap()` on `None` rather than returning `Err`. Three are in the PRELOGIN exchange, which is the first message of a TDS connection and the one that negotiates encryption, so they are reachable before authentication and before TLS. A single server-controlled byte turns a recoverable connection error into a process-level panic; under `panic = "abort"` that is a hard abort, and in pooled deployments it surfaces inside a pool worker rather than as an error the application can catch.

All eleven were confirmed against the published 0.12.3 crate in a **release** build, with `debug_assertions` off, driving only the public `Client::connect` API against a listener speaking TDS. Every site is still present on `main` at `a6b4fcd`, verified 2026-08-13.

No fixed version exists. The most recent release, 0.12.3, is from 2024-07-19, so `cargo audit` visibility is the only practical warning mechanism for the 97 dependents.

## On the qualifying criteria

Stated plainly rather than stretched: **tiberius makes no panic-free claim**, so the main clause of that bullet is not satisfied. The case rests on the parenthetical and on one other point.

The panics are useful for network denial of service. They are unauthenticated and remote, three are pre-auth and pre-TLS, and several fire on a single byte. One is a bare `assert!` rather than `debug_assert!`, so it is live in release builds and covers 255 of 256 byte values.

Separately, three sites are reached by values the crate's own `try_from` conversions **accept as valid TDS types**. `ColInfo`, `Udt` and `SSVariant` are real protocol types that are simply unimplemented, so a conforming server triggers them without sending anything malformed. Genuinely unknown bytes are already rejected correctly with `Error::Protocol`. The README lists "a perfect implementation of the TDS protocol" as a goal, so this is a deviation from stated intent rather than a hardening wish.

Happy to convert this to `informational` if you prefer that framing, and happy to adjust the CVSS. Scoring the malicious-or-MITM-server precondition as `AC:H` gives 5.9 and is equally defensible; I used `AC:L` on the basis of an application connecting to a SQL Server it does not control.

RUSTSEC-2020-0010 already exists for this crate but is an `unmaintained` informational scoped `unaffected = ["> 0.3.2"]`, covering the original 0.3 line rather than the current fork, so there is no overlap.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date (2026-07-29, when #424 and #425 were filed)
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate — reported upstream publicly and privately on 2026-07-29; no response in fifteen days, which follows the documented fallback

This advisory was researched and written with AI assistance; I verified every site against the published crate in a release build and reviewed the text before submitting.
