### PR TITLE
Create advisory for h2 unbounded empty DATA frames

### DIFF
--- a/crates/h2/RUSTSEC-0000-0000.md
+++ b/crates/h2/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "h2"
+date = "2026-08-17"
+url = "https://github.com/hyperium/hyper/security/advisories/GHSA-q83h-524g-xf6h"
+categories = ["denial-of-service"]
+keywords = ["http", "http2", "h2"]
+aliases = ["GHSA-q83h-524g-xf6h"]
+
+[versions]
+patched = [">= 0.4.16"]
+```
+
+# h2 unbounded empty DATA frames
+
+The h2 crate, used internally by hyper, had a flaw that would accept and queue empty DATA frames without limit.
+If streams were not actively drained, this could lead to unbounded memory usage, or a panic if the length overflows.
+
+Low severity.
+
+Patched in v0.4.16.


### PR DESCRIPTION
GHSA-q83h-524g-xf6h

## Affected crate(s)

- h2 (53,934,365 per month)

## Links to upstream issue(s) or PR(s)

- https://github.com/hyperium/hyper/security/advisories/GHSA-q83h-524g-xf6h

## Severity

- Low. Potential CPU churn or DOS.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
