### PR TITLE
Add NRDAX-T0185 reference to RUSTSEC-2026-0185 (quinn-proto)

### DIFF
--- a/crates/quinn-proto/RUSTSEC-2026-0185.md
+++ b/crates/quinn-proto/RUSTSEC-2026-0185.md
@@ -8,6 +8,7 @@ categories = ["denial-of-service"]
 cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"
 keywords = ["oom"]
 aliases = ["CVE-2026-25800", "GHSA-4w2j-m93h-cj5j"]
+references = ["https://nrdax.com/techniques/NRDAX-T0185-out-of-order-stream-reassembly-oom"]
 
 [versions]
 patched = [">= 0.11.15"]


### PR DESCRIPTION
Adds a `references` entry for NRDAX-T0185 to the existing quinn-proto advisory. No other field is touched.

NRDAX-T0185 catalogues the mechanism this advisory describes, unbounded retention of non-contiguous stream fragments that never become deliverable, and classifies it under memory amplification within a public registry of node-infrastructure failure techniques. The entry records the qualifying conditions the advisory sets out and gives the record a stable identifier in that taxonomy alongside its existing CVE and GHSA aliases.

To be explicit about scope: this is a single-implementation entry, so the reference adds classification rather than a sibling case, and it makes no claim beyond what this advisory and its linked sources already state.

No change to `package`, `date`, `url`, `categories`, `cvss`, `keywords`, `aliases` or the patched version range.
