### PR TITLE
Add advisory for suppaftp CRLF command injection (GHSA-8mhj-xm4h-m5m6)

### DIFF
--- a/crates/suppaftp/RUSTSEC-0000-0000.md
+++ b/crates/suppaftp/RUSTSEC-0000-0000.md
@@ -1,0 +1,60 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "suppaftp"
+date = "2026-08-18"
+url = "https://github.com/veeso/suppaftp/security/advisories/GHSA-8mhj-xm4h-m5m6"
+categories = ["format-injection"]
+keywords = ["ftp", "ftps", "crlf", "command-injection"]
+aliases = ["GHSA-8mhj-xm4h-m5m6"]
+
+[versions]
+patched = [">= 10.0.2"]
+
+[affected.functions]
+# sync client
+"suppaftp::ImplFtpStream::login" = ["< 10.0.2"]
+"suppaftp::ImplFtpStream::cwd" = ["< 10.0.2"]
+"suppaftp::ImplFtpStream::mkdir" = ["< 10.0.2"]
+"suppaftp::ImplFtpStream::rmdir" = ["< 10.0.2"]
+"suppaftp::ImplFtpStream::rm" = ["< 10.0.2"]
+"suppaftp::ImplFtpStream::rename" = ["< 10.0.2"]
+"suppaftp::ImplFtpStream::retr" = ["< 10.0.2"]
+"suppaftp::ImplFtpStream::put_file" = ["< 10.0.2"]
+"suppaftp::ImplFtpStream::site" = ["< 10.0.2"]
+"suppaftp::ImplFtpStream::custom_command" = ["< 10.0.2"]
+# tokio client
+"suppaftp::tokio::ImplAsyncFtpStream::login" = ["< 10.0.2"]
+"suppaftp::tokio::ImplAsyncFtpStream::cwd" = ["< 10.0.2"]
+"suppaftp::tokio::ImplAsyncFtpStream::mkdir" = ["< 10.0.2"]
+"suppaftp::tokio::ImplAsyncFtpStream::rmdir" = ["< 10.0.2"]
+"suppaftp::tokio::ImplAsyncFtpStream::rm" = ["< 10.0.2"]
+"suppaftp::tokio::ImplAsyncFtpStream::rename" = ["< 10.0.2"]
+"suppaftp::tokio::ImplAsyncFtpStream::retr" = ["< 10.0.2"]
+"suppaftp::tokio::ImplAsyncFtpStream::put_file" = ["< 10.0.2"]
+"suppaftp::tokio::ImplAsyncFtpStream::site" = ["< 10.0.2"]
+"suppaftp::tokio::ImplAsyncFtpStream::custom_command" = ["< 10.0.2"]
+# smol client
+"suppaftp::smol::ImplAsyncFtpStream::login" = ["< 10.0.2"]
+"suppaftp::smol::ImplAsyncFtpStream::cwd" = ["< 10.0.2"]
+"suppaftp::smol::ImplAsyncFtpStream::mkdir" = ["< 10.0.2"]
+"suppaftp::smol::ImplAsyncFtpStream::rmdir" = ["< 10.0.2"]
+"suppaftp::smol::ImplAsyncFtpStream::rm" = ["< 10.0.2"]
+"suppaftp::smol::ImplAsyncFtpStream::rename" = ["< 10.0.2"]
+"suppaftp::smol::ImplAsyncFtpStream::retr" = ["< 10.0.2"]
+"suppaftp::smol::ImplAsyncFtpStream::put_file" = ["< 10.0.2"]
+"suppaftp::smol::ImplAsyncFtpStream::site" = ["< 10.0.2"]
+"suppaftp::smol::ImplAsyncFtpStream::custom_command" = ["< 10.0.2"]
+```
+
+# FTP command injection via CRLF in control channel arguments
+
+Affected versions of `suppaftp` wrote command arguments (user name, password, paths, `SITE` arguments and custom commands) to the FTP control channel without validation. An argument containing a carriage return (`\r`) or a line feed (`\n`) terminated the intended command line and let a second, attacker-chosen command be sent to the server within the same authenticated session.
+
+An application that passes untrusted input as credentials, paths or command strings to methods such as `login`, `cwd`, `mkdir`, `rmdir`, `rm`, `rename`, `retr`, `put_file`, `site` or `custom_command` can therefore be made to execute arbitrary FTP commands with the application's privileges, for example deleting files or redirecting a data connection with an injected `PORT`.
+
+All three clients are affected: sync, tokio and smol, with or without TLS.
+
+The flaw was corrected in version 10.0.2 (commit [194bdd1](https://github.com/veeso/suppaftp/commit/194bdd1979b16c4848d1fad6897dfa524b688d88)): every command line is validated before it is written to the wire and rejected with `FtpError::ConnectionError` (`std::io::ErrorKind::InvalidInput`) if it contains CR or LF anywhere but in the trailing terminator. As a consequence, `custom_command` no longer accepts several commands joined by CRLF in a single call.
+
+Users who cannot upgrade should reject or strip `\r` and `\n` from any untrusted string before passing it to the client.

--- a/crates/suppaftp/RUSTSEC-0000-0000.md
+++ b/crates/suppaftp/RUSTSEC-0000-0000.md
@@ -3,7 +3,7 @@
 id = "RUSTSEC-0000-0000"
 package = "suppaftp"
 date = "2026-08-18"
-url = "https://github.com/veeso/suppaftp/security/advisories/GHSA-8mhj-xm4h-m5m6"
+url = "https://github.com/veeso/suppaftp/pull/172"
 categories = ["format-injection"]
 keywords = ["ftp", "ftps", "crlf", "command-injection"]
 aliases = ["GHSA-8mhj-xm4h-m5m6"]


### PR DESCRIPTION
## Affected crate(s)

- suppaftp (863,658 recent downloads)

## Links to upstream issue(s) or PR(s)

- veeso/suppaftp#171 (report, by @suidpit / Shielder, found by Team Atlanta, verified by OSTIF)
- veeso/suppaftp#172 (fix, released as 10.0.2)
- GHSA-8mhj-xm4h-m5m6

## Severity

Command arguments (user name, password, paths, `SITE` arguments, custom commands) were written to the FTP control channel without validation. An argument containing a carriage return or line feed terminated the intended command and let a second, attacker-chosen command be smuggled to the server within the same authenticated session. Affects the sync, tokio and smol clients, with or without TLS.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate (I am the crate maintainer)
