### PR TITLE
Add advisory for pipedash-web: unauthenticated instance takeover via POST /api/v1/setup/config

### DIFF
--- a/crates/pipedash-web/RUSTSEC-0000-0000.md
+++ b/crates/pipedash-web/RUSTSEC-0000-0000.md
@@ -1,0 +1,114 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "pipedash-web"
+date = "2026-08-19"
+url = "https://github.com/hcavarsan/pipedash/issues/39"
+categories = ["privilege-escalation", "denial-of-service"]
+cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+keywords = ["authentication-bypass", "authorization", "web", "cors"]
+
+[versions]
+patched = []
+```
+
+# Unauthenticated attacker can set the API credential and take over a running `pipedash-web` instance
+
+Affected versions expose `POST /api/v1/setup/config` without authentication and without
+checking whether initial setup has already been completed. The handler accepts a
+`vault_password` field and writes it into the process environment:
+
+```rust
+// crates/pipedash-web/src/routes/setup.rs — create_initial_config
+if let Some(password) = &req.vault_password {
+    std::env::set_var("PIPEDASH_VAULT_PASSWORD", password);
+}
+```
+
+That same environment variable is what the authentication middleware reads, on every
+request, to determine which bearer token is valid:
+
+```rust
+// crates/pipedash-web/src/main.rs
+fn get_api_auth_token() -> Option<String> {
+    std::env::var("PIPEDASH_VAULT_PASSWORD").ok()
+}
+
+async fn auth_middleware(req: Request, next: Next) -> Result<Response, StatusCode> {
+    let path = req.uri().path();
+    if !path.starts_with("/api/v1/")
+        || path.starts_with("/api/v1/health")
+        || path.starts_with("/api/v1/setup")   // exempt
+        || path.starts_with("/api/v1/vault")
+        || path == "/api/v1/ws"
+        || path == "/api/v1/plugins"
+    {
+        return Ok(next.run(req).await);
+    }
+    // ... bearer token compared against get_api_auth_token()
+}
+```
+
+Because the middleware allowlists `/api/v1/setup` by path prefix, an unauthenticated
+caller who can reach the listener can choose the API credential and is then fully
+authorized for every protected route. This works against an instance that was started
+with a strong `PIPEDASH_VAULT_PASSWORD` correctly configured.
+
+## Impact
+
+`pipedash-web` is a CI/CD dashboard that stores long-lived provider credentials —
+GitHub personal access tokens with `repo` and `workflow` scope, GitLab and Bitbucket
+tokens, ArgoCD auth tokens, and optionally a Kubernetes kubeconfig. Successful
+exploitation grants full API access to the instance holding them, including the
+ability to enumerate and rewrite provider configuration, trigger and cancel pipeline
+runs, and invoke `POST /api/v1/factory-reset`.
+
+The same request also rewrites `config.toml` on disk and replaces the live storage
+manager. Because the vault key is re-derived from the attacker's chosen password, the
+existing encrypted tokens no longer decrypt and the legitimate operator is locked out,
+making this destructive and persistent even without further action.
+
+Once authenticated, the attacker additionally reaches an unrestricted SSRF: five
+provider endpoints accept a caller-supplied `base_url` that `HttpClientManager::client_for_url`
+uses without any allowlist, scheme restriction, or private-address filtering, and the
+configured credential is forwarded to whatever host is named. `client_for_url` also
+caches a `reqwest::Client` per distinct URL string in a `DashMap` that is never bounded
+or evicted, so repeated requests with distinct URLs exhaust memory.
+
+## Exposure
+
+The default configuration sets `cors_allow_all = true`, producing
+`Access-Control-Allow-Origin: *` together with `Access-Control-Allow-Methods: *` and
+`Access-Control-Allow-Headers: *`. A malicious web page can therefore drive the takeover
+from an operator's browser and read the responses, so an attacker does not need direct
+network access to the instance. The `PIPEDASH_CORS_ALLOW_ALL` variable that controls this
+is not documented in the project README.
+
+## Proof of concept
+
+Verified against the published image `ghcr.io/hcavarsan/pipedash-web:0.1.1`
+(digest `sha256:3d799913e92174f81a74cf839aa5bf07acc194aed320b63731e47fd96198355f`),
+started with `PIPEDASH_VAULT_PASSWORD` set to a strong value:
+
+```
+GET  /api/v1/providers                                  -> 401
+GET  /api/v1/providers   Authorization: Bearer pwned     -> 401
+
+POST /api/v1/setup/config
+     {"config":{},"vault_password":"pwned"}              -> 200
+     {"success":true,"message":"Configuration created and system initialized successfully"}
+
+GET  /api/v1/providers   Authorization: Bearer pwned     -> 200  []
+GET  /api/v1/providers   Authorization: Bearer <real>    -> 401  (operator locked out)
+```
+
+## Mitigation
+
+No patched release is available. Operators should not expose the listener to any
+untrusted network, should place an authenticating proxy in front of it, and should set
+`PIPEDASH_CORS_ALLOW_ALL=false`. Provider tokens held by an exposed instance should be
+rotated.
+
+A fix requires rejecting `POST /api/v1/setup/config` when setup has already completed,
+and holding the API credential in application state rather than in the process
+environment where a request handler can rewrite it.


### PR DESCRIPTION
Adds an advisory for `pipedash-web`: an unauthenticated caller who can reach the listener can set the API credential and take over a running instance.

`POST /api/v1/setup/config` is exempt from the auth middleware by path prefix and has no completed-setup guard. It writes a caller-supplied `vault_password` into `PIPEDASH_VAULT_PASSWORD`, which `get_api_auth_token()` reads per request to decide the valid bearer token. Setting it therefore grants full API access to a correctly-configured instance, and simultaneously locks the real operator out because the vault key is re-derived from the new password.

CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H — 9.8. `patched = []`, as there is no fixed release.

Reproduced against the published image `ghcr.io/hcavarsan/pipedash-web:0.1.1` (digest `sha256:3d799913e92174f81a74cf839aa5bf07acc194aed320b63731e47fd96198355f`), started with a strong `PIPEDASH_VAULT_PASSWORD` set:

```
GET  /api/v1/providers                                -> 401
GET  /api/v1/providers  Authorization: Bearer pwned    -> 401
POST /api/v1/setup/config
     {"config":{},"vault_password":"pwned"}            -> 200
GET  /api/v1/providers  Authorization: Bearer pwned    -> 200  []
GET  /api/v1/providers  Authorization: Bearer <real>   -> 401  (operator locked out)
```

### Disclosure status — please read before merging

I want to be upfront that this does not yet meet the prerequisites in `CONTRIBUTING.md`, and I would rather say so than have you discover it in review:

- **Reported upstream:** yes — hcavarsan/pipedash#39, filed today (2026-08-19).
- **Maintainer has confirmed the vulnerability:** **not yet.** The report is hours old.
- **Private disclosure first:** not possible. GitHub private vulnerability reporting is disabled on that repository and there is no `SECURITY.md`, so there was no private channel to use. I asked in the issue that private reporting be enabled.

So this sits under the "no response two weeks after public disclosure on the issue tracker" clause, and two weeks have not elapsed. **Please hold, label, or close this as you see fit** — I am filing now rather than in two weeks only so it is queued with the reproduction attached, not to bypass the waiting period. I will follow up on this PR either when the maintainer confirms or when the two weeks are up, whichever comes first, and I have offered upstream to coordinate timing if they would prefer to cut a patched release before this lands.

The crate is published on crates.io (`pipedash-web` 0.1.1, alongside nine sibling crates from the same workspace), which is why I am filing here rather than only on the issue tracker.

Full audit report with the other findings: https://claude.ai/code/artifact/cfeb8bbc-4413-48bf-9cbe-e678bf7f7de0
