### PR TITLE
Add advisory for rtrb: panic-safety double-free in ReadChunk::commit

### DIFF
--- a/crates/rtrb/RUSTSEC-0000-0000.md
+++ b/crates/rtrb/RUSTSEC-0000-0000.md
@@ -25,35 +25,6 @@ as holding live elements. When the `RingBuffer` is later dropped (it walks
 touches the same slots, the already-dropped elements are dropped a second time —
 a double free (CWE-415) / use-after-free (CWE-416) reachable from safe Rust.
 
-## Details
-
-`ReadChunk::commit_unchecked`, used by both `commit` and `commit_all`:
-
-```rust
-unsafe fn commit_unchecked(self, n: usize) -> usize {
-    for i in 0..first_len {
-        self.first_ptr.add(i).drop_in_place();   // may panic
-    }
-    for i in 0..second_len {
-        self.second_ptr.add(i).drop_in_place();  // may panic
-    }
-    let head = c.buffer.increment(c.cached_head.get(), n);
-    c.buffer.head.store(head, Ordering::Release); // skipped on panic → stale head
-    c.cached_head.set(head);
-    n
-}
-```
-
-The head update comes after the destructors, so a panic inside `drop_in_place`
-skips it and leaves `head` pointing at slots that have already been dropped.
-
-## Prerequisites
-
-1. The ring buffer stores a type whose `Drop` implementation can panic.
-2. `commit` or `commit_all` is called on a `ReadChunk` covering such an element.
-3. The panic is caught (e.g. with `catch_unwind`), or the `RingBuffer` is
-   dropped during unwinding.
-
 ## Mitigation
 
 Update to 0.3.5 (0.3.x line) or 0.4.0. Note that 0.4.0 contains a behavior

--- a/crates/rtrb/RUSTSEC-0000-0000.md
+++ b/crates/rtrb/RUSTSEC-0000-0000.md
@@ -1,0 +1,60 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "rtrb"
+date = "2026-08-04"
+url = "https://github.com/mgeier/rtrb/issues/185"
+categories = ["memory-corruption"]
+keywords = ["memory-safety", "double-free", "use-after-free", "panic-safety"]
+
+[affected.functions]
+"rtrb::chunks::ReadChunk::commit" = ["< 0.3.5"]
+"rtrb::chunks::ReadChunk::commit_all" = ["< 0.3.5"]
+
+[versions]
+patched = ["^0.3.5", ">= 0.4.0"]
+```
+
+# Double free / use-after-free in `ReadChunk::commit` when an element's `Drop` panics
+
+`ReadChunk::commit` and `ReadChunk::commit_all` drop the committed elements
+before advancing the consumer head. If an element's `Drop` panics during the
+drop loop, `head` is never advanced, so the ring buffer still treats those slots
+as holding live elements. When the `RingBuffer` is later dropped (it walks
+`head..tail` and drops each slot), or a subsequent `read_chunk()` / `commit()`
+touches the same slots, the already-dropped elements are dropped a second time —
+a double free (CWE-415) / use-after-free (CWE-416) reachable from safe Rust.
+
+## Details
+
+`ReadChunk::commit_unchecked`, used by both `commit` and `commit_all`:
+
+```rust
+unsafe fn commit_unchecked(self, n: usize) -> usize {
+    for i in 0..first_len {
+        self.first_ptr.add(i).drop_in_place();   // may panic
+    }
+    for i in 0..second_len {
+        self.second_ptr.add(i).drop_in_place();  // may panic
+    }
+    let head = c.buffer.increment(c.cached_head.get(), n);
+    c.buffer.head.store(head, Ordering::Release); // skipped on panic → stale head
+    c.cached_head.set(head);
+    n
+}
+```
+
+The head update comes after the destructors, so a panic inside `drop_in_place`
+skips it and leaves `head` pointing at slots that have already been dropped.
+
+## Prerequisites
+
+1. The ring buffer stores a type whose `Drop` implementation can panic.
+2. `commit` or `commit_all` is called on a `ReadChunk` covering such an element.
+3. The panic is caught (e.g. with `catch_unwind`), or the `RingBuffer` is
+   dropped during unwinding.
+
+## Mitigation
+
+Update to 0.3.5 (0.3.x line) or 0.4.0. Note that 0.4.0 contains a behavior
+change in `is_abandoned()`, so users on 0.3.x should prefer 0.3.5.


### PR DESCRIPTION
## Affected crate(s)

* `rtrb` (3,205,892 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

Reported in [mgeier/rtrb#185](https://github.com/mgeier/rtrb/issues/185). Fixed in [mgeier/rtrb#186](https://github.com/mgeier/rtrb/pull/186), released in 0.3.5 and 0.4.0.

## Severity

Panic-safety unsoundness in `ReadChunk::commit` / `commit_all`: the committed elements are dropped before the consumer head is advanced, so a panicking element `Drop` leaves the head pointing at already-dropped slots. The `RingBuffer` destructor then drops them again — a double free (CWE-415) / use-after-free (CWE-416) reachable from safe Rust, confirmed under AddressSanitizer. Fixed in 0.3.5 and 0.4.0.

## Checklist

* Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
* `date` field is set to the public disclosure date
* Contains a concise and descriptive title after advisory metadata
* Asked maintainer(s) if publishing an advisory is appropriate (maintainer approved in the issue)