### PR TITLE
add advisory for proc-macro1, arrayref, append-only-vec, internment, proc-macro-en

### DIFF
--- a/crates/append-only-vec/RUSTSEC-0000-0000.md
+++ b/crates/append-only-vec/RUSTSEC-0000-0000.md
@@ -17,4 +17,4 @@ A new version of the `append-only-vec` crate was published with a direct depende
 on `proc-macro1`, which would execute a malicious build script.
 
 This compromised version was published on 2026-08-20 and removed approximately
-50 minutes later, with no evidence of actual usage.
+107 minutes later, with no evidence of actual usage.

--- a/crates/append-only-vec/RUSTSEC-0000-0000.md
+++ b/crates/append-only-vec/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "append-only-vec"
+date = "2026-08-20"
+url = "https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref"
+
+[versions]
+unaffected = ["<= 0.1.8"]
+patched = []
+```
+
+# `append-only-vec` 0.1.9 was removed from crates.io due to a malicious dependency
+
+A new version of the `append-only-vec` crate was published with a direct dependency
+on `proc-macro1`, which would execute a malicious build script.
+
+This compromised version was published on 2026-08-20 and removed approximately
+50 minutes later, with no evidence of actual usage.

--- a/crates/append-only-vec/RUSTSEC-0000-0000.md
+++ b/crates/append-only-vec/RUSTSEC-0000-0000.md
@@ -4,6 +4,7 @@ id = "RUSTSEC-0000-0000"
 package = "append-only-vec"
 date = "2026-08-20"
 url = "https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref"
+categories = ["malicious"]
 
 [versions]
 unaffected = ["<= 0.1.8"]

--- a/crates/arrayref/RUSTSEC-0000-0000.md
+++ b/crates/arrayref/RUSTSEC-0000-0000.md
@@ -4,6 +4,7 @@ id = "RUSTSEC-0000-0000"
 package = "arrayref"
 date = "2026-08-20"
 url = "https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref"
+categories = ["malicious"]
 
 [versions]
 unaffected = ["<= 0.3.9"]

--- a/crates/arrayref/RUSTSEC-0000-0000.md
+++ b/crates/arrayref/RUSTSEC-0000-0000.md
@@ -17,4 +17,4 @@ A new version of the `arrayref` crate was published with a direct dependency
 on `proc-macro1`, which would execute a malicious build script.
 
 This compromised version was published on 2026-08-20 and removed approximately
-50 minutes later, with no evidence of actual usage.
+86 minutes later, with no evidence of actual usage.

--- a/crates/arrayref/RUSTSEC-0000-0000.md
+++ b/crates/arrayref/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "arrayref"
+date = "2026-08-20"
+url = "https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref"
+
+[versions]
+unaffected = ["<= 0.3.9"]
+patched = []
+```
+
+# `arrayref` 0.3.10 was removed from crates.io due to a malicious dependency
+
+A new version of the `arrayref` crate was published with a direct dependency
+on `proc-macro1`, which would execute a malicious build script.
+
+This compromised version was published on 2026-08-20 and removed approximately
+50 minutes later, with no evidence of actual usage.

--- a/crates/internment/RUSTSEC-0000-0000.md
+++ b/crates/internment/RUSTSEC-0000-0000.md
@@ -4,6 +4,7 @@ id = "RUSTSEC-0000-0000"
 package = "internment"
 date = "2026-08-20"
 url = "https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref"
+categories = ["malicious"]
 
 [versions]
 unaffected = ["<= 0.8.6"]

--- a/crates/internment/RUSTSEC-0000-0000.md
+++ b/crates/internment/RUSTSEC-0000-0000.md
@@ -17,4 +17,4 @@ A new version of the `internment` crate was published with a direct dependency
 on `proc-macro1`, which would execute a malicious build script.
 
 This compromised version was published on 2026-08-20 and removed approximately
-50 minutes later, with no evidence of actual usage.
+90 minutes later, with no evidence of actual usage.

--- a/crates/internment/RUSTSEC-0000-0000.md
+++ b/crates/internment/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "internment"
+date = "2026-08-20"
+url = "https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref"
+
+[versions]
+unaffected = ["<= 0.8.6"]
+patched = []
+```
+
+# `internment` 0.8.7 was removed from crates.io due to a malicious dependency
+
+A new version of the `internment` crate was published with a direct dependency
+on `proc-macro1`, which would execute a malicious build script.
+
+This compromised version was published on 2026-08-20 and removed approximately
+50 minutes later, with no evidence of actual usage.

--- a/crates/proc-macro-en/RUSTSEC-0000-0000.md
+++ b/crates/proc-macro-en/RUSTSEC-0000-0000.md
@@ -5,6 +5,7 @@ package = "proc-macro-en"
 date = "2026-08-20"
 expect-deleted = true
 url = "https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref"
+categories = ["malicious"]
 
 [versions]
 patched = []

--- a/crates/proc-macro-en/RUSTSEC-0000-0000.md
+++ b/crates/proc-macro-en/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "proc-macro-en"
+date = "2026-08-20"
+expect-deleted = true
+url = "https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref"
+
+[versions]
+patched = []
+```
+
+# `proc-macro-en` was removed from crates.io due to malicious code
+
+We identified that `proc-macro-en` contained the same build script as
+`proc-macro1` and it was part of the same supply chain attack.
+
+This crate had one single version published at 2026-08-20. The crate was
+removed from crates.io and related user account was locked.

--- a/crates/proc-macro1/RUSTSEC-0000-0000.md
+++ b/crates/proc-macro1/RUSTSEC-0000-0000.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "proc-macro1"
+date = "2026-08-20"
+expect-deleted = true
+url = "https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref"
+
+[versions]
+patched = []
+```
+
+# `proc-macro1` was removed from crates.io due to malicious code
+
+It was reported `proc-macro1` contained a build script that would download a
+malicious payload.
+
+This crate had two versions, both published at 2026-08-20 and it was used
+in a supply chain attack targeting popular crates. The crate was removed from
+crates.io and related user accounts were locked.
+
+Thanks to the Research Team at Nextron Systems GmbH for reporting this to the 
+Rust security response working group, and thanks to Emily Albini for coordinating
+with the crates.io and infra-admin teams.

--- a/crates/proc-macro1/RUSTSEC-0000-0000.md
+++ b/crates/proc-macro1/RUSTSEC-0000-0000.md
@@ -5,6 +5,7 @@ package = "proc-macro1"
 date = "2026-08-20"
 expect-deleted = true
 url = "https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref"
+categories = ["malicious"]
 
 [versions]
 patched = []


### PR DESCRIPTION
Hope I took the correct approach to fill these advisories. Happy to iterate.

## Affected crate(s)

- `proc-macro1`
- `arrayref`
- `append-only-vec`
- `internment`
- `proc-macro-en`

## Links to upstream issue(s) or PR(s)

N/A

## Severity

https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
