### PR TITLE
add advisories for arone, aronenao and tinymember

### DIFF
--- a/crates/arone/RUSTSEC-0000-0000.md
+++ b/crates/arone/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "arone"
+date = "2026-08-20"
+expect-deleted = true
+url = "https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref"
+
+[versions]
+patched = []
+```
+
+# `arone` was removed from crates.io due to malicious code
+
+We identified `arone` contained malicious code executed through a build script.
+
+This crate had 7 versions, and the last was published at 2026-08-18 with no evidence
+of actual usage. The crate was removed from crates.io and the user account was
+locked.

--- a/crates/aronenao/RUSTSEC-0000-0000.md
+++ b/crates/aronenao/RUSTSEC-0000-0000.md
@@ -1,0 +1,19 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "aronenao"
+date = "2026-08-20"
+expect-deleted = true
+url = "https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref"
+
+[versions]
+patched = []
+```
+
+# `aronenao` was removed from crates.io due to malicious code
+
+We identified `aronenao` contained malicious code executed through a build script.
+
+This crate had 11 versions, and the last was published at 2026-08-18 with no evidence
+of actual usage. The crate was removed from crates.io and the user account was
+locked.

--- a/crates/tinymember/RUSTSEC-0000-0000.md
+++ b/crates/tinymember/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "tinymember"
+date = "2026-08-20"
+expect-deleted = true
+url = "https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref"
+
+[versions]
+patched = []
+```
+
+# `tinymember` was removed from crates.io due to affiliation with malicious code
+
+While `tinymember` did not directly contain malicious code, it was owned by the
+same user as `arone` and `aronenao`, which contained suspicious build scripts.
+
+This crate had 2 versions published on 2026-08-18 that had a total of 27 downloads.
+There were no crates depending on this crate on crates.io. The crate was removed
+from crates.io and the user account was locked.


### PR DESCRIPTION
## Affected crate(s)

- `arone`
- `aronenao`
- `tinymember`

## Links to upstream issue(s) or PR(s)

N/A

## Severity

During tha [arrayref attack](https://blog.rust-lang.org/2026/08/20/supply-chain-attack-on-arrayref) these three were flagged as suspicious. They were owned by the same user.

## Checklist

- [ ] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [ ] `date` field is set to the public disclosure date
- [ ] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate
