### PR TITLE
Incorporate updated information on `arrayref` usage

### DIFF
--- a/crates/append-only-vec/RUSTSEC-2026-0262.md
+++ b/crates/append-only-vec/RUSTSEC-2026-0262.md
@@ -16,5 +16,11 @@ patched = []
 A new version of the `append-only-vec` crate was published with a direct dependency
 on `proc-macro1`, which would execute a malicious build script.
 
-This compromised version was published on 2026-08-20 and removed approximately
-107 minutes later, with no evidence of actual usage.
+The compromised version of this crate was published on 2026-08-20, and was
+removed approximately 107 minutes later.
+
+The compromised crate version was used as part of a malware campaign targeted
+at users of `arrayvec`, which was downloaded 2,285 times before being removed;
+see [the `arrayvec` advisory][arrayvec-advisory] for more detail.
+
+[arrayvec-advisory]: https://rustsec.org/advisories/RUSTSEC-2026-0260.html

--- a/crates/append-only-vec/RUSTSEC-2026-0262.md
+++ b/crates/append-only-vec/RUSTSEC-2026-0262.md
@@ -20,7 +20,7 @@ The compromised version of this crate was published on 2026-08-20, and was
 removed approximately 107 minutes later.
 
 The compromised crate version was used as part of a malware campaign targeted
-at users of `arrayvec`, which was downloaded 2,285 times before being removed;
-see [the `arrayvec` advisory][arrayvec-advisory] for more detail.
+at users of `arrayref`, which was downloaded 2,285 times before being removed;
+see [the `arrayref` advisory][arrayref-advisory] for more detail.
 
-[arrayvec-advisory]: https://rustsec.org/advisories/RUSTSEC-2026-0260.html
+[arrayref-advisory]: https://rustsec.org/advisories/RUSTSEC-2026-0260.html

--- a/crates/arone/RUSTSEC-2026-0259.md
+++ b/crates/arone/RUSTSEC-2026-0259.md
@@ -12,8 +12,15 @@ patched = []
 
 # `arone` was removed from crates.io due to malicious code
 
-We identified `arone` contained malicious code executed through a build script.
+We identified that `arone` contained malicious code executed through a build
+script.
 
-This crate had 7 versions, and the last was published at 2026-08-18 with no evidence
-of actual usage. The crate was removed from crates.io and the user account was
-locked.
+This crate had 7 versions, with the most recent one being published at
+2026-08-18. The crate was removed from crates.io on 2026-08-20 and the user
+account was locked.
+
+This crate was used as part of a malware campaign targeted at users of
+`arrayvec`, which was downloaded 2,285 times before being removed; see
+[the `arrayvec` advisory][arrayvec-advisory] for more detail.
+
+[arrayvec-advisory]: https://rustsec.org/advisories/RUSTSEC-2026-0260.html

--- a/crates/arone/RUSTSEC-2026-0259.md
+++ b/crates/arone/RUSTSEC-2026-0259.md
@@ -20,7 +20,7 @@ This crate had 7 versions, with the most recent one being published at
 account was locked.
 
 This crate was used as part of a malware campaign targeted at users of
-`arrayvec`, which was downloaded 2,285 times before being removed; see
-[the `arrayvec` advisory][arrayvec-advisory] for more detail.
+`arrayref`, which was downloaded 2,285 times before being removed; see
+[the `arrayref` advisory][arrayref-advisory] for more detail.
 
-[arrayvec-advisory]: https://rustsec.org/advisories/RUSTSEC-2026-0260.html
+[arrayref-advisory]: https://rustsec.org/advisories/RUSTSEC-2026-0260.html

--- a/crates/aronenao/RUSTSEC-2026-0261.md
+++ b/crates/aronenao/RUSTSEC-2026-0261.md
@@ -12,8 +12,15 @@ patched = []
 
 # `aronenao` was removed from crates.io due to malicious code
 
-We identified `aronenao` contained malicious code executed through a build script.
+We identified that `aronenao` contained malicious code executed through a build
+script.
 
-This crate had 11 versions, and the last was published at 2026-08-18 with no evidence
-of actual usage. The crate was removed from crates.io and the user account was
+This crate had 11 versions, with the most recent one being published at
+2026-08-18. The crate was removed from crates.io and the user account was
 locked.
+
+This crate was used as part of a malware campaign targeted at users of
+`arrayvec`, which was downloaded 2,285 times before being removed; see
+[the `arrayvec` advisory][arrayvec-advisory] for more detail.
+
+[arrayvec-advisory]: https://rustsec.org/advisories/RUSTSEC-2026-0260.html

--- a/crates/aronenao/RUSTSEC-2026-0261.md
+++ b/crates/aronenao/RUSTSEC-2026-0261.md
@@ -20,7 +20,7 @@ This crate had 11 versions, with the most recent one being published at
 locked.
 
 This crate was used as part of a malware campaign targeted at users of
-`arrayvec`, which was downloaded 2,285 times before being removed; see
-[the `arrayvec` advisory][arrayvec-advisory] for more detail.
+`arrayref`, which was downloaded 2,285 times before being removed; see
+[the `arrayref` advisory][arrayref-advisory] for more detail.
 
-[arrayvec-advisory]: https://rustsec.org/advisories/RUSTSEC-2026-0260.html
+[arrayref-advisory]: https://rustsec.org/advisories/RUSTSEC-2026-0260.html

--- a/crates/arrayref/RUSTSEC-2026-0260.md
+++ b/crates/arrayref/RUSTSEC-2026-0260.md
@@ -17,4 +17,6 @@ A new version of the `arrayref` crate was published with a direct dependency
 on `proc-macro1`, which would execute a malicious build script.
 
 This compromised version was published on 2026-08-20 and removed approximately
-86 minutes later. It was downloaded 2,285 times.
+86 minutes later. It was downloaded 2,285 times, which constituted less than
+10% of arrayvec download traffic across all versions, as most users had older
+versions of arrayvec in their lockfiles.

--- a/crates/arrayref/RUSTSEC-2026-0260.md
+++ b/crates/arrayref/RUSTSEC-2026-0260.md
@@ -18,5 +18,5 @@ on `proc-macro1`, which would execute a malicious build script.
 
 This compromised version was published on 2026-08-20 and removed approximately
 86 minutes later. It was downloaded 2,285 times, which constituted less than
-10% of arrayvec download traffic across all versions, as most users had older
-versions of arrayvec in their lockfiles.
+10% of `arrayref` download traffic across all versions, as most users had older
+versions of `arrayref` in their lockfiles.

--- a/crates/arrayref/RUSTSEC-2026-0260.md
+++ b/crates/arrayref/RUSTSEC-2026-0260.md
@@ -17,4 +17,4 @@ A new version of the `arrayref` crate was published with a direct dependency
 on `proc-macro1`, which would execute a malicious build script.
 
 This compromised version was published on 2026-08-20 and removed approximately
-86 minutes later, with no evidence of actual usage.
+86 minutes later. It was downloaded 2,285 times.

--- a/crates/internment/RUSTSEC-2026-0266.md
+++ b/crates/internment/RUSTSEC-2026-0266.md
@@ -20,7 +20,7 @@ The compromised version of this crate was published on 2026-08-20, and was
 removed approximately 90 minutes later.
 
 The compromised version was used as part of a malware campaign targeted at
-users of `arrayvec`, which was downloaded 2,285 times before being removed; see
-[the `arrayvec` advisory][arrayvec-advisory] for more detail.
+users of `arrayref`, which was downloaded 2,285 times before being removed; see
+[the `arrayref` advisory][arrayref-advisory] for more detail.
 
-[arrayvec-advisory]: https://rustsec.org/advisories/RUSTSEC-2026-0260.html
+[arrayref-advisory]: https://rustsec.org/advisories/RUSTSEC-2026-0260.html

--- a/crates/internment/RUSTSEC-2026-0266.md
+++ b/crates/internment/RUSTSEC-2026-0266.md
@@ -16,5 +16,11 @@ patched = []
 A new version of the `internment` crate was published with a direct dependency
 on `proc-macro1`, which would execute a malicious build script.
 
-This compromised version was published on 2026-08-20 and removed approximately
-90 minutes later, with no evidence of actual usage.
+The compromised version of this crate was published on 2026-08-20, and was
+removed approximately 90 minutes later.
+
+The compromised version was used as part of a malware campaign targeted at
+users of `arrayvec`, which was downloaded 2,285 times before being removed; see
+[the `arrayvec` advisory][arrayvec-advisory] for more detail.
+
+[arrayvec-advisory]: https://rustsec.org/advisories/RUSTSEC-2026-0260.html

--- a/crates/proc-macro-en/RUSTSEC-2026-0264.md
+++ b/crates/proc-macro-en/RUSTSEC-2026-0264.md
@@ -20,7 +20,7 @@ This crate had one single version published at 2026-08-20. The crate was
 removed from crates.io and related user account was locked.
 
 This crate was used as part of a malware campaign targeted at users of
-`arrayvec`, which was downloaded 2,285 times before being removed; see
-[the `arrayvec` advisory][arrayvec-advisory] for more detail.
+`arrayref`, which was downloaded 2,285 times before being removed; see
+[the `arrayref` advisory][arrayref-advisory] for more detail.
 
-[arrayvec-advisory]: https://rustsec.org/advisories/RUSTSEC-2026-0260.html
+[arrayref-advisory]: https://rustsec.org/advisories/RUSTSEC-2026-0260.html

--- a/crates/proc-macro-en/RUSTSEC-2026-0264.md
+++ b/crates/proc-macro-en/RUSTSEC-2026-0264.md
@@ -18,3 +18,9 @@ We identified that `proc-macro-en` contained the same build script as
 
 This crate had one single version published at 2026-08-20. The crate was
 removed from crates.io and related user account was locked.
+
+This crate was used as part of a malware campaign targeted at users of
+`arrayvec`, which was downloaded 2,285 times before being removed; see
+[the `arrayvec` advisory][arrayvec-advisory] for more detail.
+
+[arrayvec-advisory]: https://rustsec.org/advisories/RUSTSEC-2026-0260.html

--- a/crates/proc-macro1/RUSTSEC-2026-0265.md
+++ b/crates/proc-macro1/RUSTSEC-2026-0265.md
@@ -16,10 +16,15 @@ patched = []
 It was reported `proc-macro1` contained a build script that would download a
 malicious payload.
 
-This crate had two versions, both published at 2026-08-20 and it was used
-in a supply chain attack targeting popular crates. The crate was removed from
-crates.io and related user accounts were locked.
+This crate had two versions, both published on 2026-08-20. The crate was
+removed from crates.io and related user accounts were locked.
 
-Thanks to the Research Team at Nextron Systems GmbH for reporting this to the 
+This crate was used as part of a malware campaign targeted at users of
+`arrayvec`, which was downloaded 2,285 times before being removed; see
+[the `arrayvec` advisory][arrayvec-advisory] for more detail.
+
+Thanks to the Research Team at Nextron Systems GmbH for reporting this to the
 Rust security response working group, and thanks to Emily Albini for coordinating
 with the crates.io and infra-admin teams.
+
+[arrayvec-advisory]: https://rustsec.org/advisories/RUSTSEC-2026-0260.html

--- a/crates/proc-macro1/RUSTSEC-2026-0265.md
+++ b/crates/proc-macro1/RUSTSEC-2026-0265.md
@@ -20,11 +20,11 @@ This crate had two versions, both published on 2026-08-20. The crate was
 removed from crates.io and related user accounts were locked.
 
 This crate was used as part of a malware campaign targeted at users of
-`arrayvec`, which was downloaded 2,285 times before being removed; see
-[the `arrayvec` advisory][arrayvec-advisory] for more detail.
+`arrayref`, which was downloaded 2,285 times before being removed; see
+[the `arrayref` advisory][arrayref-advisory] for more detail.
 
 Thanks to the Research Team at Nextron Systems GmbH for reporting this to the
 Rust security response working group, and thanks to Emily Albini for coordinating
 with the crates.io and infra-admin teams.
 
-[arrayvec-advisory]: https://rustsec.org/advisories/RUSTSEC-2026-0260.html
+[arrayref-advisory]: https://rustsec.org/advisories/RUSTSEC-2026-0260.html


### PR DESCRIPTION
Our initial analysis was based on readily available aggregates, but a check of the actual logs has given us a more accurate number.