### PR TITLE
Add advisory for simd-json uncontrolled recursion during Value materialization

### DIFF
--- a/crates/simd-json/RUSTSEC-0000-0000.md
+++ b/crates/simd-json/RUSTSEC-0000-0000.md
@@ -2,12 +2,12 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "simd-json"
-date = "2026-08-13"
+date = "2026-08-14"
 categories = ["denial-of-service"]
 keywords = ["json", "parser", "dos", "stack-overflow", "recursion"]
 
 [versions]
-patched = []
+patched = [">= 0.18.0"]
 ```
 
 # Unbounded recursion in `to_owned_value` / `to_borrowed_value` allows stack overflow from deeply nested JSON
@@ -62,8 +62,3 @@ representative harness.
 Bound recursion depth in the tape to `Value` materialization (return an error past a default limit;
 for reference serde_json's default recursion limit is 128), or make the materialization iterative
 with an explicit stack like stage2.
-
-## Duplicate check
-
-Not RUSTSEC-2019-0008 (that is an out-of-bounds read in string parsing, fixed in 0.1.15). No other
-RustSec/CVE advisory found, and no matching upstream issue or PR for this mechanism as of 2026-08-13.

--- a/crates/simd-json/RUSTSEC-0000-0000.md
+++ b/crates/simd-json/RUSTSEC-0000-0000.md
@@ -18,47 +18,7 @@ stack during materialization and aborts the process with SIGABRT (`fatal runtime
 overflow`). This is availability only. No CVSS is asserted, and no specific downstream product is
 claimed to be affected.
 
-Confirmed on simd-json 0.17.3 (latest release) at commit
-`7fa23d4526cd2f83d50fac39b496e9e212f2c8d3`. There is no fixed release yet, and the repository has no
-`SECURITY.md` / security contact, which is why this is reported here.
-
-## Where it is (and is not)
-
-The SIMD parse itself is fine. `to_tape` (stage2 uses an explicit heap stack) survives deep nesting.
-The overflow is in the tape to `Value` materialization:
-
-- `src/value/owned.rs:307` `parse()` dispatches to `parse_array` (`:317`) and `parse_map` (`:333`),
-  which call `self.parse()` per child (`:325`, `:340`, `:343`).
-- `src/value/borrowed.rs:456/466/482` has the same shape.
-- `to_owned_value` / `to_borrowed_value` (`src/value/owned.rs:48,67`) call these. There is no
-  `max_depth` or recursion guard in `src/` at 0.17.3 or on `origin/main`.
-
-It is not recursive `Drop`: a `mem::forget` variant aborts identically, before the value would be
-dropped.
-
-## Reproduction
-
-Default API, no opt-in feature, raw nested JSON, no custom recursive type needed.
-
-- Phase isolation: `to_tape` on depth 20k/50k/100k returns cleanly; `to_owned_value` aborts at about
-  50k depth (about 100 KB input) on an 8 MB stack, before the builder returns.
-- Representative HTTP harness: a thread-per-connection server calling the default `to_owned_value` on
-  the request body is fully taken down by a single ~100 KB request (health then refused, process
-  aborted), reproduced 3/3. A variant that pre-checks input nesting depth rejects the payload (400)
-  and stays up.
-
-A small source-only reproduction bundle (harness sources, pinned build, pre-generated payloads with
-SHA-256, raw transcripts, checksums) is available on request.
-
-## Impact
-
-Availability only (no confidentiality or integrity impact). An application that calls the default
-owned/borrowed value builders on untrusted JSON can be driven to a process abort by a small deeply
-nested input. Reachability inside any specific product is not established here; the server used is a
-representative harness.
-
-## Suggested fix
-
-Bound recursion depth in the tape to `Value` materialization (return an error past a default limit;
-for reference serde_json's default recursion limit is 128), or make the materialization iterative
-with an explicit stack like stage2.
+Confirmed on simd-json 0.17.3 at commit
+`7fa23d4526cd2f83d50fac39b496e9e212f2c8d3`. The issue was fixed in simd-json 0.18.0 by introducing
+maximum-depth checking. Applications that process untrusted JSON through these APIs should upgrade
+to version 0.18.0 or later.

--- a/crates/simd-json/RUSTSEC-0000-0000.md
+++ b/crates/simd-json/RUSTSEC-0000-0000.md
@@ -1,0 +1,69 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "simd-json"
+date = "2026-08-13"
+categories = ["denial-of-service"]
+keywords = ["json", "parser", "dos", "stack-overflow", "recursion"]
+
+[versions]
+patched = []
+```
+
+# Unbounded recursion in `to_owned_value` / `to_borrowed_value` allows stack overflow from deeply nested JSON
+
+`simd_json::to_owned_value` and `to_borrowed_value` materialize the parse tape into a recursive
+`Value` tree with no depth bound. Deeply nested JSON (for example `[[[ ... ]]]`) overflows the native
+stack during materialization and aborts the process with SIGABRT (`fatal runtime error: stack
+overflow`). This is availability only. No CVSS is asserted, and no specific downstream product is
+claimed to be affected.
+
+Confirmed on simd-json 0.17.3 (latest release) at commit
+`7fa23d4526cd2f83d50fac39b496e9e212f2c8d3`. There is no fixed release yet, and the repository has no
+`SECURITY.md` / security contact, which is why this is reported here.
+
+## Where it is (and is not)
+
+The SIMD parse itself is fine. `to_tape` (stage2 uses an explicit heap stack) survives deep nesting.
+The overflow is in the tape to `Value` materialization:
+
+- `src/value/owned.rs:307` `parse()` dispatches to `parse_array` (`:317`) and `parse_map` (`:333`),
+  which call `self.parse()` per child (`:325`, `:340`, `:343`).
+- `src/value/borrowed.rs:456/466/482` has the same shape.
+- `to_owned_value` / `to_borrowed_value` (`src/value/owned.rs:48,67`) call these. There is no
+  `max_depth` or recursion guard in `src/` at 0.17.3 or on `origin/main`.
+
+It is not recursive `Drop`: a `mem::forget` variant aborts identically, before the value would be
+dropped.
+
+## Reproduction
+
+Default API, no opt-in feature, raw nested JSON, no custom recursive type needed.
+
+- Phase isolation: `to_tape` on depth 20k/50k/100k returns cleanly; `to_owned_value` aborts at about
+  50k depth (about 100 KB input) on an 8 MB stack, before the builder returns.
+- Representative HTTP harness: a thread-per-connection server calling the default `to_owned_value` on
+  the request body is fully taken down by a single ~100 KB request (health then refused, process
+  aborted), reproduced 3/3. A variant that pre-checks input nesting depth rejects the payload (400)
+  and stays up.
+
+A small source-only reproduction bundle (harness sources, pinned build, pre-generated payloads with
+SHA-256, raw transcripts, checksums) is available on request.
+
+## Impact
+
+Availability only (no confidentiality or integrity impact). An application that calls the default
+owned/borrowed value builders on untrusted JSON can be driven to a process abort by a small deeply
+nested input. Reachability inside any specific product is not established here; the server used is a
+representative harness.
+
+## Suggested fix
+
+Bound recursion depth in the tape to `Value` materialization (return an error past a default limit;
+for reference serde_json's default recursion limit is 128), or make the materialization iterative
+with an explicit stack like stage2.
+
+## Duplicate check
+
+Not RUSTSEC-2019-0008 (that is an out-of-bounds read in string parsing, fixed in 0.1.15). No other
+RustSec/CVE advisory found, and no matching upstream issue or PR for this mechanism as of 2026-08-13.


### PR DESCRIPTION
## Affected crate(s)

- `simd-json` 0.17.3 (confirmed affected)

## Links to upstream issue(s) or PR(s)

- Upstream report and maintainer confirmation:
  https://github.com/simd-lite/simd-json/issues/473
- Fix commit:
  https://github.com/simd-lite/simd-json/commit/abb59c3bebf8cde1f0b974133a960ab3a968891d

The maintainer confirmed that the issue is fixed in version 0.18.

date = "2026-08-13"

[versions]
patched = [">= 0.18.0"]

## Severity

Deeply nested JSON passed through `to_owned_value` or
`to_borrowed_value` can cause uncontrolled recursion during tape-to-Value
materialization, resulting in native stack exhaustion and process abort.

The confirmed impact is availability only at the library level. No specific
downstream network service is claimed. The proposed severity is Low.

## Checklist

- [x] Advisory filename starts with `RUSTSEC-0000-0000`
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer whether publishing an advisory is appropriate