### PR TITLE
Add unmaintained advisory for color-thief

### DIFF
--- a/crates/color-thief/RUSTSEC-0000-0000.md
+++ b/crates/color-thief/RUSTSEC-0000-0000.md
@@ -1,0 +1,22 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "color-thief"
+date = "2026-08-21"
+url = "https://github.com/RazrFalcon/color-thief-rs"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `color-thief` is unmaintained
+
+The repository for `color-thief`, <https://github.com/RazrFalcon/color-thief-rs>, is archived on GitHub. The last commit on its default branch is dated 2023-05-15. The last release of the crate on crates.io is 0.2.2, published on 2022-06-04. The crate metadata still points at the archived repository and names no successor.
+
+## Alternatives
+
+- `kmeans_colors` (<https://github.com/okaneco/kmeans-colors>)
+- `auto-palette` (<https://github.com/t28hub/auto-palette>)
+
+Both crates extract a color palette from image pixel data.


### PR DESCRIPTION
## Affected crate(s)

- color-thief (about 66k recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

The source repository <https://github.com/RazrFalcon/color-thief-rs> is archived, so no issue can be opened there. The last default-branch commit is dated 2023-05-15 and the last crates.io release is 0.2.2 from 2022-06-04. The crate metadata still points at the archived repository and names no successor.

## Severity

Informational, unmaintained. No vulnerability is claimed.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [ ] Asked maintainer(s) if publishing an advisory is appropriate (the repository is archived and does not accept new issues)
