### PR TITLE
Add advisory for stable-vec (double-free in BitVecCore::clear)

### DIFF
--- a/crates/stable-vec/RUSTSEC-0000-0000.md
+++ b/crates/stable-vec/RUSTSEC-0000-0000.md
@@ -1,0 +1,47 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "stable-vec"
+date = "2026-08-24"
+url = "https://github.com/LukasKalbertodt/stable-vec/pull/51"
+categories = ["memory-corruption"]
+keywords = ["panic-safety", "memory-safety", "use-after-free", "double-free"]
+aliases = ["GHSA-mr2v-63pc-gmr4"]
+informational = "unsound"
+
+[affected]
+[affected.functions]
+"stable_vec::BitVecCore::clear" = ["< 0.4.3"]
+
+[versions]
+patched = [">= 0.4.3"]
+```
+
+# Panic-safety unsoundness in `BitVecCore::clear` (double-free / use-after-free)
+
+`BitVecCore::clear` drops every occupied element with `drop_in_place` and only
+afterwards clears the occupancy bits and resets `len`. If an element's `Drop`
+panics, those metadata updates are skipped, so the slot of the already-dropped
+element stays marked as occupied. `BitVecCore::drop` calls `clear()` again,
+visits the same slot, and drops the element a second time — a double-free /
+use-after-free reachable from safe Rust.
+
+Reachable via the public `StableVec::clear` and `ExternStableVec::clear`, which
+delegate to `BitVecCore::clear`.
+
+## Impact
+
+* CWE-415 (Double Free): the same allocation is freed twice.
+* CWE-416 (Use-After-Free): a freed allocation is accessed during a repeated `Drop`.
+
+Reachable entirely from safe Rust via `catch_unwind` with element types whose
+`Drop` can panic. Confirmed under AddressSanitizer on 0.4.2.
+
+## Fix
+
+Fixed in `stable-vec` 0.4.3 by removing each element via `remove_at`, which
+clears the occupancy bit before taking the value out.
+
+Release 0.4.3 also fixes several other panic-safety issues found by the
+maintainer; see [GHSA-mr2v-63pc-gmr4](https://github.com/LukasKalbertodt/stable-vec/security/advisories/GHSA-mr2v-63pc-gmr4)
+and the 0.4.3 changelog for the full list.


### PR DESCRIPTION
## Affected crate(s)

- `stable-vec` (440,370 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

Reported and fixed via https://github.com/LukasKalbertodt/stable-vec/pull/51 (merged). Released in 0.4.3.

The maintainer also published https://github.com/LukasKalbertodt/stable-vec/security/advisories/GHSA-mr2v-63pc-gmr4, which covers this issue together with several other panic-safety fixes the maintainer made in the same release.

This advisory is scoped to `BitVecCore::clear`, the issue reported in the PR linked above.

## Severity

Panic-safety unsoundness in `BitVecCore::clear`, reachable from safe Rust via `StableVec::clear` and `ExternStableVec::clear`. Every occupied element is dropped with `drop_in_place` before the occupancy bits and `len` are updated, so a panicking element `Drop` leaves the slot marked occupied. `BitVecCore::drop` calls `clear()` again and drops the same element a second time — use-after-free / double-free, confirmed under AddressSanitizer on 0.4.2. Fixed in 0.4.3.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate (maintainer approved in the upstream PR — "no, I don't mind, feel free to do so")