### PR TITLE
Add advisory for zkboo-ecc: incorrect fixed-base scalar multiplication when the comb window width divides the scalar width

### DIFF
--- a/crates/zkboo-ecc/RUSTSEC-0000-0000.md
+++ b/crates/zkboo-ecc/RUSTSEC-0000-0000.md
@@ -1,0 +1,64 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "zkboo-ecc"
+date = "2026-08-24"
+url = "https://github.com/zkboo/zkboo-ecc/commit/7b9f17ec0003d65d254d58d73b31440f72de9ad6"
+categories = ["crypto-failure"]
+keywords = ["elliptic-curve", "secp256k1", "zero-knowledge"]
+
+[versions]
+patched = [">= 1.0.1"]
+unaffected = ["< 1.0.0"]
+
+[affected.functions]
+"zkboo_ecc::montgomery::Curve::mul_secret_scalar" = [">= 1.0.0, < 1.0.1"]
+```
+
+# Fixed-base scalar multiplication returns an incorrect point when the comb window width divides the scalar width
+
+`Curve::mul_secret_scalar` recodes the secret scalar into one signed digit per window,
+carrying a residual that the final window consumes whole. The final window extracts its
+digit magnitude from the residual's `w - 1` index bits, which is sound only when the
+windows span at least one bit more than the scalar.
+
+The window count was `width.div_ceil(w)`, which leaves no such headroom when the window
+width `w` divides the scalar width. The residual can then reach `2^(w+1) - 1`, its top
+bit is dropped, and the routine silently returns the wrong curve point.
+
+For the 256-bit secp256k1 scalar this affects `w` in {2, 4, 8, 16}. Measured against a
+native reference, 5 of 14 boundary scalars were wrong at both `w = 4` and `w = 8`,
+including `2^256 - 2`, `n - 1`, `n + 1` and `2^255`.
+
+## Affected configurations
+
+The window width is only reachable by callers that build their own `WindowTables`:
+
+- `zkboo_ecc::montgomery::Curve::mul_secret_scalar`, with a `WindowTables` whose
+  `window_bits()` divides the scalar width;
+- the `*_with_tables` entry points of the downstream `zkboo-bip32` crate, which forward a
+  caller-supplied `WindowTables`.
+
+**The default configuration is not affected.** `DEFAULT_COMB_WINDOW_BITS` is 5, which does
+not divide 256, and every convenience API in `zkboo-ecc` and `zkboo-bip32` uses it. The
+default path is bit-identical before and after the fix, so no proof generated with it is
+invalidated.
+
+## Impact
+
+Silently incorrect results from a cryptographic primitive. An affected circuit computes a
+point other than the intended `d·G`. Because prover and verifier execute the same circuit,
+the resulting proof still verifies — it simply attests to a different statement than the
+one intended, so downstream artefacts such as derived public keys and addresses are wrong.
+
+This is a correctness failure, **not** a soundness break of the underlying proof system:
+it does not let a prover convince a verifier of a statement the circuit did not compute.
+
+## Remediation
+
+Upgrade to `zkboo-ecc` 1.0.1, which allocates one window more than the scalar strictly
+requires so the invariant holds at every width, and rejects the degenerate one-bit window.
+Version 0.1.0 predates fixed-base comb multiplication and is not affected.
+
+Users who cannot upgrade should use a window width that does not divide the scalar width —
+for secp256k1, any `w` in {3, 5, 6, 7, 9, 10, 11, 12, 13, 14, 15}, or the crate default.


### PR DESCRIPTION
Filed by the crate author.

`zkboo-ecc`'s `Curve::mul_secret_scalar` recodes a secret scalar into one signed digit per comb window, carrying a residual that the final window consumes whole. The window count was `width.div_ceil(w)`, which leaves the final window no headroom when the window width `w` divides the scalar width — the residual can then exceed what the final window's `w - 1` index bits can hold, its top bit is dropped, and the routine silently returns the wrong curve point.

For the 256-bit secp256k1 scalar this affects `w` in {2, 4, 8, 16}. Measured against a native reference, 5 of 14 boundary scalars were wrong at both `w = 4` and `w = 8`.

The default window width is 5, which does not divide 256, so every convenience entry point in `zkboo-ecc` and in the downstream `zkboo-bip32` is unaffected and bit-identical across the fix. The width is only reachable by callers supplying their own `WindowTables`.

Scope note: this is a correctness failure in a cryptographic primitive, not a soundness break of the underlying zero-knowledge proof system — prover and verifier run the same circuit, so an affected proof still verifies, it simply attests to a different statement than intended (e.g. a wrong derived public key or address).

Fixed in 1.0.1 (`zkboo/zkboo-ecc@7b9f17e`); 0.1.0 predates comb multiplication and is unaffected.