### PR TITLE
Add unsound advisory for lockfree

### DIFF
--- a/crates/lockfree/RUSTSEC-0000-0000.md
+++ b/crates/lockfree/RUSTSEC-0000-0000.md
@@ -1,0 +1,52 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "lockfree"
+date = "2026-08-26"
+url = "https://gitlab.com/bzim/lockfree/-/issues/7"
+categories = ["memory-corruption"]
+keywords = ["panic-safety", "memory-safety", "use-after-free", "double-free", "uninitialized"]
+informational = "unsound"
+
+[affected]
+[affected.functions]
+"lockfree::map::Map::into_iter" = ["<= 0.5.1"]
+"lockfree::queue::SharedIncin::clear" = ["<= 0.5.1"]
+"lockfree::stack::SharedIncin::clear" = ["<= 0.5.1"]
+"lockfree::map::SharedIncin::clear" = ["<= 0.5.1"]
+"lockfree::channel::spmc::SharedIncin::clear" = ["<= 0.5.1"]
+"lockfree::channel::mpmc::SharedIncin::clear" = ["<= 0.5.1"]
+
+[versions]
+patched = []
+```
+
+# Double free in `Map::into_iter` and an uninitialized `Arc` in `SharedIncin::clear`
+
+Two independent soundness problems, both reachable from safe Rust.
+
+`Map::into_iter` drops `builder` (the caller-supplied hasher `H`) and `incin` by
+hand, then commits the ownership transfer with `mem::forget(self)`. `H::drop` is
+user code and may panic. If it does, `mem::forget(self)` is skipped and the
+still-live `Map` unwinds, whose field drop glue destroys `builder` a second
+time. An empty map is enough — no entries or concurrency required.
+
+`SharedIncin::clear` writes `mem::uninitialized::<Arc<_>>()` into `self.inner`
+before taking the real `Arc` out. `Arc` has a validity invariant, so this is
+undefined behaviour at the point of creation, with no panic or concurrency
+involved. Between that write and the repairing one, `self.inner` also holds
+garbage while `self` is still droppable, so an unwind from `incin.clear()` or
+`Arc::new` decrements a refcount through an uninitialized pointer. The
+`make_shared_incin!` macro is instantiated five times, so this covers `queue`,
+`stack`, `map`, `channel::spmc` and `channel::mpmc`.
+
+## Impact
+
+* CWE-415 (Double Free): the same allocation is freed twice.
+* CWE-416 (Use-After-Free): a freed allocation is accessed during a repeated `Drop`.
+* CWE-908 (Use of Uninitialized Resource): an `Arc` is constructed from uninitialized bytes.
+
+## Fix
+
+No fixed release is available. The crate has had no release since 2018-11-18 and
+the maintainer has not responded to the report.


### PR DESCRIPTION
## Affected crate(s)
- `lockfree` (601,950 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)
https://gitlab.com/bzim/lockfree/-/issues/7

## Severity
Two independent soundness problems, both reachable from safe Rust and confirmed with sanitizers. `Map::into_iter` drops the caller-supplied hasher before committing with `mem::forget(self)`, so a panicking `H::drop` leaves the unwinding `Map` to drop it again — use-after-free / double-free under AddressSanitizer, with an empty map. `SharedIncin::clear` writes `mem::uninitialized::<Arc<_>>()` into a live field, which Miri reports as undefined behavior with no panic or concurrency involved; the macro is instantiated five times. No fixed release.

## Checklist
- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate (reported two weeks ago, no response; the crate has had no release since 2018 and an August 2024 unmaintained inquiry also went unanswered)