### PR TITLE
Add advisory for physis_pro: remote error body can permanently disable a shared LLM provider

### DIFF
--- a/crates/physis_pro/RUSTSEC-0000-0000.md
+++ b/crates/physis_pro/RUSTSEC-0000-0000.md
@@ -1,0 +1,90 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "physis_pro"
+date = "2026-08-26"
+url = "https://github.com/ilPez00/physis-pro/blob/main/security/advisories/physis_pro-provider-availability.md"
+categories = ["denial-of-service"]
+cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H"
+keywords = ["dos", "availability", "multi-tenant", "llm"]
+
+[versions]
+patched = [">= 0.1.9"]
+unaffected = ["< 0.1.6"]
+```
+
+# A remote error body can permanently disable a shared LLM provider
+
+`physis_pro` routes completions through a cascade of LLM providers and skips
+any provider marked unavailable. In `0.1.6` through `0.1.8`, a provider was
+marked unavailable by substring-matching the **text of a failed HTTP
+response**:
+
+```rust
+let lower = text.to_lowercase();
+if lower.contains("model_not_found")
+    || lower.contains("does not exist")
+    || lower.contains("valid api key")
+    || lower.contains("invalid api key")
+{
+    self.mark_unavailable();
+}
+```
+
+Two properties combine into a denial of service.
+
+**The matched text is partly attacker-controlled.** OpenAI-compatible
+endpoints quote the offending request back inside `error.message`, and the
+request carries the caller's prompt. A prompt containing a phrase such as
+`does not exist`, submitted so that it provokes any 4xx, is echoed into the
+body and matches.
+
+**The effect is permanent and shared.** `mark_unavailable()` stores `false`
+into an `AtomicBool` that is set to `true` only in `Provider::new()`. Nothing
+clears it, so the provider stays out of the cascade until the process
+restarts. The cascade is process-wide, and requests are separated only by an
+`X-Physis-User` header — an identity hint the crate does not authenticate — so
+the loss applies to every caller rather than the one who triggered it.
+
+Repeating this across the configured providers walks the cascade down to
+`No provider available`, disabling all LLM-backed functionality for the
+lifetime of the process.
+
+## Impact
+
+Any caller able to submit a prompt can disable LLM features for all users of
+the same process until it is restarted. Availability only — no disclosure or
+modification of data.
+
+The attack complexity is rated high because success depends on an upstream
+provider echoing request content in its error bodies. That is common among
+OpenAI-compatible gateways but is a property of the vendor, not of this crate,
+and can change without notice. A deployment configured with a single provider,
+or one whose provider never echoes, is correspondingly less exposed.
+
+## Patch
+
+Fixed in `0.1.9`.
+
+Detection now reads only the machine-written `error.code` / `error.type`
+fields and matches a fixed set of vendor codes that name a deployment fault
+(`model_not_found`, `model_decommissioned`, `invalid_api_key`, and similar).
+The human-readable message is never inspected. The generic
+`invalid_request_error` type is excluded, because it is the envelope for
+ordinary bad arguments and says nothing about provider health. A response body
+that is not JSON parks nothing.
+
+The park is also now a bounded 15-minute cooldown rather than a permanent
+latch, and the same treatment was applied to the `401`/`403` path. That caps
+any residual false positive at one window instead of a process lifetime, and
+lets a rotated key or a corrected model id take effect without a restart.
+
+## Workarounds
+
+Restarting the process restores every parked provider. There is no
+configuration that disables the matching in an affected version, so upgrading
+to `0.1.9` is the only fix.
+
+`0.1.6`, `0.1.7` and `0.1.8` have been yanked. A yank prevents new dependents
+from selecting those versions but does not affect a project whose `Cargo.lock`
+already pins one; such projects remain vulnerable until they upgrade.


### PR DESCRIPTION
Filed by the crate author, which per CONTRIBUTING waives the upstream-report and coordinated-disclosure prerequisites. The embargo is lifted: the fix, the affected range and the mechanism are already public in the crate's own repository and changelog.

**Summary.** `physis_pro` routes completions through a cascade of LLM providers. In `0.1.6`–`0.1.8` a provider was removed from the cascade by substring-matching the *text* of a failed HTTP response. OpenAI-compatible endpoints quote the offending request back inside `error.message`, and that request carries the caller's prompt — so a prompt containing a phrase like `does not exist` that provokes any 4xx would match. The removal was permanent (`mark_unavailable()` wrote a flag only `Provider::new()` ever cleared) and the cascade is process-wide, so the loss hit every caller rather than the one who caused it. Walking the cascade reaches `No provider available` for the life of the process.

Availability only — no disclosure or modification of data. Rated `AC:H` because success depends on the upstream provider echoing request content in its error bodies: common among OpenAI-compatible gateways, but a property of the vendor rather than of this crate.

**Fixed in `0.1.9`.** Detection now reads only the machine-written `error.code` / `error.type` fields against a fixed set of vendor codes, never the message prose, and skips bodies that are not JSON. The park became a bounded 15-minute cooldown rather than a permanent latch.

**Versions.** `patched = [">= 0.1.9"]`, `unaffected = ["< 0.1.6"]`. The lower bound was taken from the published tarballs rather than from git history — `0.1.5` carries only a pre-existing `401`/`403` latch, which keys on a status code rather than on caller-influenced text, so it is not vulnerable. `0.1.6`, `0.1.7` and `0.1.8` have been yanked.

`rustsec-admin lint` reports `Linted ok` for this file.

Full write-up: https://github.com/ilPez00/physis-pro/blob/main/security/advisories/physis_pro-provider-availability.md