### PR TITLE
apimock: Path traversal in apimock-server's file-serving fallback

### DIFF
--- a/crates/apimock-server/RUSTSEC-0000-0000.md
+++ b/crates/apimock-server/RUSTSEC-0000-0000.md
@@ -3,7 +3,7 @@
 id = "RUSTSEC-0000-0000"
 package = "apimock-server"
 date = "2026-08-26"
-url = "https://github.com/apimokka/apimock-rs/security/advisories/GHSA-72g6-wgrg-vhm7"
+url = "https://github.com/apimokka/apimock-rs/commit/ff0dd152ecfccb3bf00e15cc92bd4d57e485c854"
 aliases = ["GHSA-72g6-wgrg-vhm7"]
 categories = ["file-disclosure"]
 keywords = ["path-traversal", "http", "file-serving"]
@@ -15,53 +15,19 @@ patched = [">= 5.19.1"]
 
 # Path traversal in apimock-server's file-serving fallback
 
-`apimock-server` is the crate that implements apimock's HTTP serving,
-and it carries the vulnerable code: the dyn-route fallback resolved a
-request path against the configured response directory without confining
-the result to it. A request containing a raw `..` segment could read
-files outside that directory, returned with HTTP 200.
+The file-serving fallback joined a request-derived path onto the
+configured response directory and checked only that the result existed,
+never that it stayed inside that directory. A request containing a raw
+`..` segment could read any file readable by the process, returned with
+HTTP 200.
 
-This is the same issue as the advisory for the `apimock` crate. It is
-recorded separately because `apimock-server` is published independently,
-so a dependent embedding the server directly is affected without
-depending on `apimock` at all.
-
-The resolved path was checked only for existence, never for whether it
-stayed inside the directory it was resolved against, and no traversal
-check existed elsewhere in the serving path. The same missing check
-applied to a rule's `respond.file_path` and to a path returned by a Rhai
-middleware script; both are operator-authored rather than
-request-derived.
-
-## Impact
-
-An unauthenticated client that can reach the listener, and that sends a
-non-normalised path, can read any file readable by the process.
+Read-only: no write, no code execution.
 
 Exposure depends on the bind address. The default is `127.0.0.1`;
-deployments binding `0.0.0.0` or a LAN address — containers most
-commonly, since binding loopback makes the port unreachable from the
-host — are reachable from the network. Browsers and most HTTP clients
-normalise `..` away before sending.
+deployments binding `0.0.0.0` or a LAN address are reachable from the
+network. Most HTTP clients normalise `..` away before sending, so
+reaching it requires a client that does not.
 
-Impact is read-only: no write, no code execution.
-
-## Patches
-
-Fixed in **5.19.1**.
-
-`apimock-server` exists only on the 5.x line — its first published
-version is 5.0.0, so every published version before 5.19.1 is affected.
-The 4.x line predates the workspace split and ships as the single
-`apimock` crate; see that crate's advisory for 4.x.
-
-Every resolved path is now canonicalised and checked against the
-canonicalised base directory for its site; anything outside is refused
-with a bare 404. As a second, independent control, `..` segments are
-stripped from the request path before file resolution.
-
-## Workarounds
-
-- Bind the listener to `127.0.0.1` (the default).
-- Do not expose the server to an untrusted network.
-- Run it from a directory containing nothing sensitive above it.
+All published versions before 5.19.1 are affected. Fixed in 5.19.1 by
+canonicalising each resolved path and rejecting anything outside its
+base directory.

--- a/crates/apimock-server/RUSTSEC-0000-0000.md
+++ b/crates/apimock-server/RUSTSEC-0000-0000.md
@@ -1,0 +1,67 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "apimock-server"
+date = "2026-08-26"
+url = "https://github.com/apimokka/apimock-rs/security/advisories/GHSA-72g6-wgrg-vhm7"
+aliases = ["GHSA-72g6-wgrg-vhm7"]
+categories = ["file-disclosure"]
+keywords = ["path-traversal", "http", "file-serving"]
+cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N"
+
+[versions]
+patched = [">= 5.19.1"]
+```
+
+# Path traversal in apimock-server's file-serving fallback
+
+`apimock-server` is the crate that implements apimock's HTTP serving,
+and it carries the vulnerable code: the dyn-route fallback resolved a
+request path against the configured response directory without confining
+the result to it. A request containing a raw `..` segment could read
+files outside that directory, returned with HTTP 200.
+
+This is the same issue as the advisory for the `apimock` crate. It is
+recorded separately because `apimock-server` is published independently,
+so a dependent embedding the server directly is affected without
+depending on `apimock` at all.
+
+The resolved path was checked only for existence, never for whether it
+stayed inside the directory it was resolved against, and no traversal
+check existed elsewhere in the serving path. The same missing check
+applied to a rule's `respond.file_path` and to a path returned by a Rhai
+middleware script; both are operator-authored rather than
+request-derived.
+
+## Impact
+
+An unauthenticated client that can reach the listener, and that sends a
+non-normalised path, can read any file readable by the process.
+
+Exposure depends on the bind address. The default is `127.0.0.1`;
+deployments binding `0.0.0.0` or a LAN address — containers most
+commonly, since binding loopback makes the port unreachable from the
+host — are reachable from the network. Browsers and most HTTP clients
+normalise `..` away before sending.
+
+Impact is read-only: no write, no code execution.
+
+## Patches
+
+Fixed in **5.19.1**.
+
+`apimock-server` exists only on the 5.x line — its first published
+version is 5.0.0, so every published version before 5.19.1 is affected.
+The 4.x line predates the workspace split and ships as the single
+`apimock` crate; see that crate's advisory for 4.x.
+
+Every resolved path is now canonicalised and checked against the
+canonicalised base directory for its site; anything outside is refused
+with a bare 404. As a second, independent control, `..` segments are
+stripped from the request path before file resolution.
+
+## Workarounds
+
+- Bind the listener to `127.0.0.1` (the default).
+- Do not expose the server to an untrusted network.
+- Run it from a directory containing nothing sensitive above it.

--- a/crates/apimock-server/RUSTSEC-0000-0000.md
+++ b/crates/apimock-server/RUSTSEC-0000-0000.md
@@ -31,3 +31,7 @@ reaching it requires a client that does not.
 All published versions before 5.19.1 are affected. Fixed in 5.19.1 by
 canonicalising each resolved path and rejecting anything outside its
 base directory.
+
+**This advisory also covers `apimock` 5.x**, which depends on
+`apimock-server`. `apimock` 4.x predates the crate split and carries its
+own advisory for the same issue, fixed in 4.8.1.

--- a/crates/apimock/RUSTSEC-0000-0000.md
+++ b/crates/apimock/RUSTSEC-0000-0000.md
@@ -1,0 +1,76 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "apimock"
+date = "2026-08-26"
+url = "https://github.com/apimokka/apimock-rs/security/advisories/GHSA-72g6-wgrg-vhm7"
+aliases = ["GHSA-72g6-wgrg-vhm7"]
+categories = ["file-disclosure"]
+keywords = ["path-traversal", "http", "file-serving"]
+cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N"
+
+[versions]
+patched = [">= 4.8.1, < 5.0.0", ">= 5.19.1"]
+```
+
+# Path traversal in apimock's file-serving fallback
+
+apimock's file-serving fallback resolved a request path against the
+configured response directory without confining the result to it. A
+request containing a raw `..` segment could read files outside that
+directory, returned with HTTP 200.
+
+When no rule matches a request, apimock falls back to serving a file
+whose path is derived from the request URL, joined onto the configured
+response directory. The resolved path was checked only for existence,
+never for whether it stayed inside the directory it was resolved
+against. URL normalisation trimmed leading and trailing slashes but did
+not remove `..` segments, and no traversal check existed elsewhere in
+the serving path.
+
+The same missing check applied to a rule's configured
+`respond.file_path` and to a file path returned by a Rhai middleware
+script. Both are operator-authored rather than request-derived, so
+neither could be triggered by a client.
+
+## Impact
+
+An unauthenticated client that can reach the listener, and that sends a
+non-normalised path, can read any file readable by the apimock process.
+
+In the default configuration apimock binds `127.0.0.1`, where an
+attacker must already be able to run a process on the machine. Browsers
+and most HTTP clients and proxies normalise `..` away before sending, so
+a malicious web page cannot reach it either.
+
+The deployments genuinely exposed are those binding `0.0.0.0` or a LAN
+address — most commonly running apimock in a container, where binding
+`127.0.0.1` would make the port unreachable from the host. Shared
+development servers and CI runners on a shared network are the same
+shape. A multi-user machine is also affected on the loopback default,
+since any local user can reach a loopback listener.
+
+Impact is read-only: no write, no code execution.
+
+## Patches
+
+Fixed in **4.8.1** and **5.19.1**. Both the 4.x and 5.x lines are
+supported and each has its own fix — there is no requirement to change
+major version.
+
+Every resolved path is now canonicalised and checked against the
+canonicalised base directory for its site; anything outside is refused
+with a bare 404. As a second, independent control, `..` segments are
+stripped from the request path before file resolution.
+
+## Versions before 4.0.0
+
+Versions earlier than 4.0.0 were **not assessed**. They are not claimed
+unaffected, and the `patched` requirement above treats them as
+vulnerable, which is the conservative reading rather than a finding.
+
+## Workarounds
+
+- Bind the listener to `127.0.0.1` (the default).
+- Do not run apimock on a shared or untrusted network.
+- Run it from a directory containing nothing sensitive above it.

--- a/crates/apimock/RUSTSEC-0000-0000.md
+++ b/crates/apimock/RUSTSEC-0000-0000.md
@@ -3,7 +3,7 @@
 id = "RUSTSEC-0000-0000"
 package = "apimock"
 date = "2026-08-26"
-url = "https://github.com/apimokka/apimock-rs/security/advisories/GHSA-72g6-wgrg-vhm7"
+url = "https://github.com/apimokka/apimock-rs/commit/a9c05fec2d36a750c30e797291a0557f230c8faf"
 aliases = ["GHSA-72g6-wgrg-vhm7"]
 categories = ["file-disclosure"]
 keywords = ["path-traversal", "http", "file-serving"]
@@ -15,62 +15,17 @@ patched = [">= 4.8.1, < 5.0.0", ">= 5.19.1"]
 
 # Path traversal in apimock's file-serving fallback
 
-apimock's file-serving fallback resolved a request path against the
-configured response directory without confining the result to it. A
-request containing a raw `..` segment could read files outside that
-directory, returned with HTTP 200.
+The file-serving fallback joined a request-derived path onto the
+configured response directory and checked only that the result existed,
+never that it stayed inside that directory. A request containing a raw
+`..` segment could read any file readable by the process, returned with
+HTTP 200.
 
-When no rule matches a request, apimock falls back to serving a file
-whose path is derived from the request URL, joined onto the configured
-response directory. The resolved path was checked only for existence,
-never for whether it stayed inside the directory it was resolved
-against. URL normalisation trimmed leading and trailing slashes but did
-not remove `..` segments, and no traversal check existed elsewhere in
-the serving path.
+Read-only: no write, no code execution.
 
-The same missing check applied to a rule's configured
-`respond.file_path` and to a file path returned by a Rhai middleware
-script. Both are operator-authored rather than request-derived, so
-neither could be triggered by a client.
+On the 4.x line `apimock` is a single crate containing the serving code.
+From 5.0.0 the serving code lives in `apimock-server`, so 5.x is
+affected through that dependency.
 
-## Impact
-
-An unauthenticated client that can reach the listener, and that sends a
-non-normalised path, can read any file readable by the apimock process.
-
-In the default configuration apimock binds `127.0.0.1`, where an
-attacker must already be able to run a process on the machine. Browsers
-and most HTTP clients and proxies normalise `..` away before sending, so
-a malicious web page cannot reach it either.
-
-The deployments genuinely exposed are those binding `0.0.0.0` or a LAN
-address — most commonly running apimock in a container, where binding
-`127.0.0.1` would make the port unreachable from the host. Shared
-development servers and CI runners on a shared network are the same
-shape. A multi-user machine is also affected on the loopback default,
-since any local user can reach a loopback listener.
-
-Impact is read-only: no write, no code execution.
-
-## Patches
-
-Fixed in **4.8.1** and **5.19.1**. Both the 4.x and 5.x lines are
-supported and each has its own fix — there is no requirement to change
-major version.
-
-Every resolved path is now canonicalised and checked against the
-canonicalised base directory for its site; anything outside is refused
-with a bare 404. As a second, independent control, `..` segments are
-stripped from the request path before file resolution.
-
-## Versions before 4.0.0
-
-Versions earlier than 4.0.0 were **not assessed**. They are not claimed
-unaffected, and the `patched` requirement above treats them as
-vulnerable, which is the conservative reading rather than a finding.
-
-## Workarounds
-
-- Bind the listener to `127.0.0.1` (the default).
-- Do not run apimock on a shared or untrusted network.
-- Run it from a directory containing nothing sensitive above it.
+Fixed in 4.8.1 and 5.19.1 by canonicalising each resolved path and
+rejecting anything outside its base directory.

--- a/crates/apimock/RUSTSEC-0000-0000.md
+++ b/crates/apimock/RUSTSEC-0000-0000.md
@@ -10,7 +10,8 @@ keywords = ["path-traversal", "http", "file-serving"]
 cvss = "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N"
 
 [versions]
-patched = [">= 4.8.1, < 5.0.0", ">= 5.19.1"]
+patched = [">= 4.8.1, < 5.0.0"]
+unaffected = [">= 5.0.0"]
 ```
 
 # Path traversal in apimock's file-serving fallback
@@ -24,8 +25,10 @@ HTTP 200.
 Read-only: no write, no code execution.
 
 On the 4.x line `apimock` is a single crate containing the serving code.
-From 5.0.0 the serving code lives in `apimock-server`, so 5.x is
-affected through that dependency.
+Fixed in 4.8.1 by canonicalising each resolved path and rejecting
+anything outside its base directory.
 
-Fixed in 4.8.1 and 5.19.1 by canonicalising each resolved path and
-rejecting anything outside its base directory.
+**apimock 5.0.0 and later are not affected by this advisory.** From
+5.0.0 the serving code moved to the `apimock-server` crate, which
+`apimock` depends on; that crate carries its own advisory for the same
+issue, fixed in 5.19.1.


### PR DESCRIPTION
## Affected crate(s)

- `apimock` (62,580 downloads all-time; 947 recent per crates.io)
- `apimock-server` (653 downloads all-time; 408 recent per crates.io)

## Links to upstream issue(s) or PR(s)

Filed by the crate maintainers — reported, fixed and disclosed by us, so
there is no third-party upstream report to link.

- Advisory: https://github.com/apimokka/apimock-rs/security/advisories/GHSA-72g6-wgrg-vhm7
- Fixed releases:
  - https://github.com/apimokka/apimock-rs/releases/tag/4.8.1
  - https://github.com/apimokka/apimock-rs/releases/tag/5.19.1

## Severity

Path traversal allowing **unauthenticated remote file disclosure**: a
request carrying a raw `..` segment escaped the configured response
directory, and the file was returned with HTTP 200. Read-only — no
write, no code execution.

Exposure is conditional on deployment, which is why we rate it modestly:

- The default bind is `127.0.0.1`, where an attacker must already be able
  to run a process on the machine.
- Browsers and most HTTP clients and proxies normalise `..` away before
  sending, so a malicious web page cannot reach it.
- The genuinely exposed deployments bind `0.0.0.0` or a LAN address —
  most commonly a container, where binding loopback would make the port
  unreachable from the host. Multi-user machines are also affected on the
  loopback default.

CVSS v4.0: `AV:N/AC:L/AT:P/PR:N/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N` —
`AT:P` records the non-default-bind requirement.

apimock is a development and testing mock server, not intended for
production or as a public listener; that context bounds the impact but
does not remove it, which is why it was fixed rather than documented.

## Two crates, two version ranges

`apimock` spans both supported lines — 4.x ships as that single crate,
5.x as a workspace — so it carries two ranges with separate fixes:
`< 4.8.1` (patched 4.8.1) and `>= 5.0.0, < 5.19.1` (patched 5.19.1).
**Both lines are supported; neither requires a major-version change.**

`apimock-server` only exists post-split (first published 5.0.0), so its
range is `>= 5.0.0, < 5.19.1`, patched 5.19.1. It is filed separately
because it is published independently and carries the vulnerable serving
code — a dependent embedding it directly is affected without depending
on `apimock`.

Versions before 4.0.0 were not assessed and are therefore treated as
affected rather than claimed unaffected.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
