### PR TITLE
Add unsound advisory for hibit_tree

### DIFF
--- a/crates/hibit_tree/RUSTSEC-0000-0000.md
+++ b/crates/hibit_tree/RUSTSEC-0000-0000.md
@@ -1,0 +1,52 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "hibit_tree"
+date = "2026-08-27"
+url = "https://github.com/tower120/hibit_tree/pull/28"
+categories = ["memory-corruption"]
+keywords = ["panic-safety", "memory-safety", "use-after-free", "double-free"]
+informational = "unsound"
+
+[affected]
+[affected.functions]
+"hibit_tree::Tree::get_or_insert" = ["< 0.1.1-beta.1"]
+
+[versions]
+patched = [">= 0.1.1-beta.1"]
+```
+
+# Panic-safety unsoundness in `Tree::get_or_insert` (use-after-free / double-free)
+
+`BlockPtr::insert_impl` sets the occupancy bit in `mask` before running the child
+constructor, and writes the logical-to-physical index mapping only afterwards.
+The two are halves of the same metadata: `Drop for Tree` reads `mask` to decide
+whether a child exists at an index, and `child_indices` to decide which physical
+slot it lives in.
+
+If the constructor panics, the mapping is never written and stays at its
+zero-initialised default. Two logical indices then resolve to physical slot 0,
+and the destructor drops it twice. When no element occupies slot 0 at the time,
+the destructor instead runs `drop_in_place` over a slot that was never written.
+
+Reachable from safe Rust through `Tree::get_or_insert`, whose constructor is
+`|| Default::default()` — any `T: Default` whose `default()` can panic is
+enough.
+
+## Impact
+
+A heap-owning element such as `String` is freed twice, corrupting the allocator.
+Where slot 0 was never written, the destructor reads uninitialized bytes as a
+live value and frees whatever pointer they happen to contain.
+
+* CWE-415 (Double Free)
+* CWE-416 (Use-After-Free)
+* CWE-908 (Use of Uninitialized Resource)
+
+Confirmed under AddressSanitizer, which reports `attempting double-free` while
+the tree's destructor runs.
+
+## Fix
+
+Fixed in 0.1.1-beta.1, which tests the occupancy bit without setting it and
+commits both halves of the metadata together after the constructor has run.


### PR DESCRIPTION
## Affected crate(s)
- `hibit_tree` (123 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)
https://github.com/tower120/hibit_tree/pull/28

## Severity
`BlockPtr::insert_impl` set the occupancy bit in `mask` before running the child constructor and wrote the index mapping only afterwards, so a panicking `Default::default()` left the two halves of the metadata disagreeing — two logical indices resolved to the same physical slot and `Drop for Tree` destroyed it twice. Use-after-free / double-free reachable from safe Rust via `Tree::get_or_insert`, confirmed under AddressSanitizer. Fixed in 0.1.1-beta.1.

## Checklist
- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate (asked on the PR; the maintainer responded by releasing the fix as 0.1.1-beta.1)