### PR TITLE
Add unsound advisory for stack_dst

### DIFF
--- a/crates/stack_dst/RUSTSEC-0000-0000.md
+++ b/crates/stack_dst/RUSTSEC-0000-0000.md
@@ -1,0 +1,56 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "stack_dst"
+date = "2026-08-27"
+url = "https://github.com/thepowersgang/stack_dst-rs/issues/16"
+categories = ["memory-corruption"]
+keywords = ["panic-safety", "memory-safety", "use-after-free", "double-free"]
+informational = "unsound"
+
+[affected]
+[affected.functions]
+"stack_dst::Stack::pop" = ["< 0.8.2"]
+"stack_dst::Fifo::pop_front" = ["< 0.8.2"]
+"stack_dst::Value::replace_stable" = ["< 0.8.2"]
+
+[versions]
+patched = [">= 0.8.2"]
+```
+
+# Panic-safety unsoundness in `Stack::pop`, `Fifo::pop_front` and `Value::replace_stable` (use-after-free / double-free)
+
+Three removal and replacement paths destroy an initialized value before
+committing the metadata change that removes it. Destruction runs `T::drop()`,
+which is user code and may panic. If it does, the commit is skipped and the
+container still claims ownership of the already-destroyed value, so its own
+destructor drops that value a second time.
+
+`Stack::pop` drops the top value before reducing `next_ofs`. `Stack`'s
+destructor pops in a loop, so an unchanged `next_ofs` re-drops the same value.
+
+`Fifo::pop_front` (via `pop_front_inner`) drops the front value before advancing
+`read_pos`. An unchanged `read_pos` still points at the destroyed value.
+
+`Value::replace_stable` drops the existing value before writing the replacement.
+If the destructor panics the replacement is never written, but the backing
+storage still holds the old value's metadata.
+
+This is separate from RUSTSEC-2021-0033, which covered a clone panic on
+insertion in `push_cloned` and was fixed in 0.6.1.
+
+## Impact
+
+A heap-owning value is freed twice, corrupting the allocator. Reachable from
+safe Rust with any element type whose `Drop` can panic — no `unsafe` on the
+caller's side.
+
+* CWE-415 (Double Free)
+* CWE-416 (Use-After-Free)
+
+Confirmed under AddressSanitizer, which reports `attempting double-free` on all
+three paths.
+
+## Fix
+
+Fixed in 0.8.2.


### PR DESCRIPTION
## Affected crate(s)
- `stack_dst` (5,257 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)
https://github.com/thepowersgang/stack_dst-rs/issues/16

## Severity
Three removal/replacement paths destroy an initialized value before committing the metadata change that removes it. A panicking `T::drop()` skips the commit, so the container still treats the destroyed value as live and drops it again — use-after-free / double-free reachable from safe Rust, confirmed under AddressSanitizer on all three paths. Separate from RUSTSEC-2021-0033, which covered `push_cloned`. Fixed in 0.8.2.

## Checklist
- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate (asked on the issue; the maintainer approved with a 👍 reaction)