### PR TITLE
add advisory for procspawn: unmaintained

### DIFF
--- a/crates/procspawn/RUSTSEC-0000-0000.md
+++ b/crates/procspawn/RUSTSEC-0000-0000.md
@@ -1,0 +1,30 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "procspawn"
+date = "2026-08-27"
+#withdrawn = "YYYY-MM-DD"
+url = "https://github.com/mitsuhiko/procspawn/issues/58"
+#references = ["https://github.com/mitsuhiko/procspawn/issues/58"]
+informational = "unmaintained"
+#categories = ["crypto-failure"]
+#cvss = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+#keywords = ["unmaintained"]
+#aliases = ["CVE-2018-XXXX"]
+#related = ["CVE-2018-YYYY", "CVE-2018-ZZZZ"]
+#license = "CC-BY-4.0"
+
+[affected]
+#arch = ["x86", "x86_64"]
+os = ["linux", "macos"]
+#[affected.functions]
+#"mycrate::MyType::vulnerable_function" = ["< 1.2.0, >= 1.1.0"]
+
+[versions]
+patched = []
+#unaffected = ["< 1.1.0"]
+```
+
+# `procspawn` is unmaintained
+
+The crate `procspawn` is no longer maintained. Also `procspawn` uses stale dependencies, one of which is also unmaintained according to [RUSTSEC-2025-0141](https://rustsec.org/advisories/RUSTSEC-2025-0141).


### PR DESCRIPTION
## Affected crate(s)

- `procspawn` (39,334 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

- https://github.com/mitsuhiko/procspawn/issues/58
- https://github.com/mitsuhiko/procspawn/issues/57

## Severity

- crate is unmaintained
- one dependency has been advised as "unmaintained" ([RUSTSEC-2025-0141](https://rustsec.org/advisories/RUSTSEC-2025-0141))

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate --> did not respond (v.s.)
