### PR TITLE
Add unmaintained advisory for `lasso`

### DIFF
--- a/crates/lasso/RUSTSEC-0000-0000.md
+++ b/crates/lasso/RUSTSEC-0000-0000.md
@@ -1,0 +1,20 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "lasso"
+date = "2026-08-28"
+url = "https://github.com/Kixiron/lasso/issues/53"
+informational = "unmaintained"
+
+[versions]
+patched = []
+```
+
+# `lasso` is unmaintained
+
+The author of `lasso` is unresponsive, with no GitHub activity since 2024 and outstanding issues such as [one from Jun 2024](https://github.com/Kixiron/lasso/issues/48).
+
+Maintained alternatives:
+
+- [`string-interner`](https://crates.io/crates/string-interner)
+- [`string_cache`](https://crates.io/crates/string_cache)


### PR DESCRIPTION
Author unresponsive since 2024.

## Affected crate(s)

- `lasso` (871k recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

https://github.com/Kixiron/lasso/issues/53

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate

Regarding claiming implicit unmaintenance, the maintenance status issue has only been open since May, which AFAIU would generally not be long enough to be considered unmaintained. However
- a [non-trivial issue](https://github.com/Kixiron/lasso/issues/48) (with proposed solution) has been opened since Jun 3rd, 2024, with no maintainer response
- author has not had any GitHub activity at all since Aug 19th, 2024 

It is mostly the fact that there is no signs of the maintainer for two years that makes me think it's ok to mark the crate as unmaintained. Their website linked on GitHub is also defunct, so it's hard to contact them.

Of course, I would be happy to give it a few months more for a response before adding it to the advisory. This is my first time reporting something, so feel free to let me know what/whether it is appropriate :)