### PR TITLE
Add advisory for azure_core: authorization header written to logs

### DIFF
--- a/crates/azure_core/RUSTSEC-0000-0000.md
+++ b/crates/azure_core/RUSTSEC-0000-0000.md
@@ -34,60 +34,10 @@ Versions 0.22.0 and later, which are the rewritten and currently supported
 SDK, do not contain the affected code and do not log requests from
 `azure_core` at all.
 
-## Details
-
-`TransportPolicy::send` is the last policy in the legacy pipeline, and it
-`Debug`-formats every outgoing request, headers included, at debug level:
-
-```rust
-debug!("the following request will be passed to the transport policy: {request:#?}");
-```
-
-In 0.21.0 the `Debug` impl for `Headers` is intended to suppress the
-credential, but its condition is inverted — it emits the value for the
-`authorization` header and `[redacted]` for every other header:
-
-```rust
-impl Debug for Headers {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Headers(")?;
-        let redacted = HeaderValue::from_static("[redacted]");
-        f.debug_map()
-            .entries(self.0.iter().map(|(name, value)| {
-                if matching_ignore_ascii_case(name.as_str(), AUTHORIZATION.as_str()) {
-                    (name, value)      // <-- the credential, in the clear
-                } else {
-                    (name, &redacted)  // <-- everything harmless, redacted
-                }
-            }))
-            .finish()?;
-        write!(f, ")")
-    }
-}
-```
-
-Earlier versions redact nothing at all.
-
 ## Affected versions
 
 Every published legacy version except 0.2.0 writes the `authorization` header
 value to logs: 0.1.1 (2022-01-25), and 0.2.1 through 0.21.0 (2024-10-15).
-
-`azure_core` is a transitive dependency of the legacy client crates, so
-applications are commonly affected without depending on it directly —
-including through `azure_identity`, `azure_storage`, `azure_storage_blobs`,
-and the generated `azure_mgmt_*` crates, several of which have no release
-newer than 0.21.0.
-
-## Reproduction
-
-1. Depend on `azure_core = "0.21"` and any legacy client crate, for example
-   `azure_storage_blobs`.
-2. Enable debug logging (`RUST_LOG=debug` with a `log` or `tracing`
-   subscriber).
-3. Perform any authenticated request.
-4. The logged request shows `[redacted]` for every header except
-   `authorization`, which shows the live credential.
 
 ## Mitigation
 

--- a/crates/azure_core/RUSTSEC-0000-0000.md
+++ b/crates/azure_core/RUSTSEC-0000-0000.md
@@ -31,8 +31,7 @@ anyone with read access to the logs can replay them until they expire
 (CWE-532).
 
 Versions 0.22.0 and later, which are the rewritten and currently supported
-SDK, do not contain the affected code and do not log requests from
-`azure_core` at all.
+SDK, do not contain the affected code.
 
 ## Affected versions
 

--- a/crates/azure_core/RUSTSEC-0000-0000.md
+++ b/crates/azure_core/RUSTSEC-0000-0000.md
@@ -66,49 +66,12 @@ impl Debug for Headers {
 }
 ```
 
-That impl was added by [PR #1699][pr], titled "Redact the authorization header
-from Debug impl" and merged on 2024-07-18, which replaced `#[derive(Debug)]`
-on `Headers` with the hand-written impl above. The change was intended to fix
-exactly this exposure; the two arms of the condition are swapped. It is still
-present at the `legacy` branch HEAD.
-
-The inversion is in some respects worse than the behavior it replaced. The
-`[redacted]` markers printed for every harmless header give an operator
-auditing their logs positive evidence that sanitization is working, while the
-one header that matters is emitted verbatim.
-
-The inversion is not, however, the origin of the exposure. Earlier versions
-redact nothing at all, so the credential reaches the log across the whole
-published range; only the surrounding headers differ.
+Earlier versions redact nothing at all.
 
 ## Affected versions
 
 Every published legacy version except 0.2.0 writes the `authorization` header
-value to logs: 0.1.1 (2022-01-25), and 0.2.1 through 0.21.0 (2024-10-15). Two
-request-logging paths are involved, and from 0.4.0 on both are live at once:
-
-- **Retry policy, trace level** — 0.1.1, and 0.2.1 through 0.21.0. On every
-  successful response the retry policy `Debug`-formats the whole request:
-  `trace!("Successful response. Request={:?} response={:?}", request, response)`
-  (spelled `"Succesful response"` before 0.4.0).
-- **Transport policy, debug level** — 0.4.0 (2022-08-09) through 0.21.0. The
-  log quoted above, on every request, successful or not. This is the path most
-  deployments hit, debug being a far more commonly enabled level than trace.
-
-0.2.0 is the sole exception. Despite the higher version number it was
-published 2021-12-29, before 0.1.1, and predates the policy pipeline
-altogether — it has no transport or retry policy and logs no requests. It has
-since been yanked from crates.io.
-
-How the credential appears differs across the range, but it appears throughout:
-
-- 0.21.0: the inverted hand-written `Debug for Headers` shown above —
-  `authorization` in the clear, every other header `[redacted]`.
-- 0.2.1 through 0.20.0: no redaction at all. `Headers` carries
-  `#[derive(Debug)]` and prints every header value, `authorization` among
-  them.
-- 0.1.1: no `Headers` type yet; `Request` derives `Debug` over an
-  `http::HeaderMap`, with the same effect.
+value to logs: 0.1.1 (2022-01-25), and 0.2.1 through 0.21.0 (2024-10-15).
 
 `azure_core` is a transitive dependency of the legacy client crates, so
 applications are commonly affected without depending on it directly —
@@ -128,15 +91,10 @@ newer than 0.21.0.
 
 ## Mitigation
 
-- Upgrade to `azure_core` 0.22.0 or later where the client crates you use
-  have a release on the new SDK. 0.22.0 is the first version without the
-  affected code; the maintainers direct users to crates built on `azure_core`
-  1.0.0 or newer.
-- Where they do not, raise the log level for the legacy crates above debug —
-  for example `RUST_LOG=info,azure_core=warn`. Suppressing only the
-  `azure_core::policies::transport` target is not sufficient: the retry policy
-  logs the request too, at trace level. Note that a global debug level set for
-  diagnosing an unrelated problem is enough to start emitting credentials.
+- Upgrade to `azure_core` 0.22.0 or later. Azure recommends moving to crates
+  built upon `azure_core` 1.0.0 or newer.
+- If you are unable to upgrade, raise the log level above debug for the
+  impacted crates.
 - Treat logs produced by an affected build as credential-bearing: rotate any
   long-lived secret that authenticated a request while debug logging was on.
 

--- a/crates/azure_core/RUSTSEC-0000-0000.md
+++ b/crates/azure_core/RUSTSEC-0000-0000.md
@@ -2,7 +2,7 @@
 [advisory]
 id = "RUSTSEC-0000-0000"
 package = "azure_core"
-date = "2026-08-30"
+date = "2026-08-15"
 url = "https://github.com/Azure/azure-sdk-for-rust/issues/5074"
 references = [
     "https://github.com/Azure/azure-sdk-for-rust/pull/1699",

--- a/crates/azure_core/RUSTSEC-0000-0000.md
+++ b/crates/azure_core/RUSTSEC-0000-0000.md
@@ -7,9 +7,6 @@ url = "https://github.com/Azure/azure-sdk-for-rust/issues/5074"
 references = [
     "https://github.com/Azure/azure-sdk-for-rust/pull/1699",
     "https://github.com/Azure/azure-sdk-for-rust/commit/7a0e20c1e002ce06da0f3ec8795ef1529862ea97",
-    "https://github.com/Azure/azure-sdk-for-rust/blob/legacy/sdk/core/src/headers/mod.rs#L163-L178",
-    "https://github.com/Azure/azure-sdk-for-rust/blob/legacy/sdk/core/src/policies/transport.rs#L32",
-    "https://github.com/Azure/azure-sdk-for-rust/blob/legacy/sdk/core/src/policies/retry_policies/retry_policy.rs#L126",
 ]
 cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N"
 keywords = ["information-leak", "logs", "credentials", "authorization-header", "azure"]
@@ -40,8 +37,7 @@ value to logs: 0.1.1 (2022-01-25), and 0.2.1 through 0.21.0 (2024-10-15).
 
 ## Mitigation
 
-- Upgrade to `azure_core` 0.22.0 or later. Azure recommends moving to crates
-  built upon `azure_core` 1.0.0 or newer.
+- Upgrade to `azure_core` 1.0.0 or newer.
 - If you are unable to upgrade, raise the log level above debug for the
   impacted crates or submit a feature request for missing crates built on `azure_core` 1.0.0 or newer.
 - Treat logs produced by an affected build as credential-bearing: rotate any
@@ -51,20 +47,14 @@ value to logs: 0.1.1 (2022-01-25), and 0.2.1 through 0.21.0 (2024-10-15).
 
 The finding was reported to the Microsoft Security Response Center
 (VULN-211331), which determined that it does not meet the Microsoft Security
-Servicing Criteria definition of a security vulnerability, on the grounds that
-the affected implementation exists only on the unsupported legacy branch and
-is absent from the supported SDK. MSRC did not dispute the technical finding.
+Servicing Criteria definition of a security vulnerability.
 
 It was then disclosed publicly as [Azure/azure-sdk-for-rust#5074][issue] on
 2026-08-15, asking the maintainers to confirm the behavior so that an advisory
 could be filed for the legacy crates. A maintainer replied on 2026-08-26 and
 closed the issue as not planned: the `legacy` branch is unsupported, there are
 no plans to update it, and users should move to crates built on `azure_core`
-1.0.0 or newer. The technical finding was again not disputed.
-
-No fix will therefore ship for any affected version. This advisory exists so
-that users of the legacy crates, several of which have no successor release,
-receive an alert pointing at the supported SDK.
+1.0.0 or newer.
 
 [pr]: https://github.com/Azure/azure-sdk-for-rust/pull/1699
 [issue]: https://github.com/Azure/azure-sdk-for-rust/issues/5074

--- a/crates/azure_core/RUSTSEC-0000-0000.md
+++ b/crates/azure_core/RUSTSEC-0000-0000.md
@@ -43,7 +43,7 @@ value to logs: 0.1.1 (2022-01-25), and 0.2.1 through 0.21.0 (2024-10-15).
 - Upgrade to `azure_core` 0.22.0 or later. Azure recommends moving to crates
   built upon `azure_core` 1.0.0 or newer.
 - If you are unable to upgrade, raise the log level above debug for the
-  impacted crates.
+  impacted crates or submit a feature request for missing crates built on `azure_core` 1.0.0 or newer.
 - Treat logs produced by an affected build as credential-bearing: rotate any
   long-lived secret that authenticated a request while debug logging was on.
 

--- a/crates/azure_core/RUSTSEC-0000-0000.md
+++ b/crates/azure_core/RUSTSEC-0000-0000.md
@@ -1,0 +1,163 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "azure_core"
+date = "2026-08-30"
+url = "https://github.com/Azure/azure-sdk-for-rust/issues/5074"
+references = [
+    "https://github.com/Azure/azure-sdk-for-rust/pull/1699",
+    "https://github.com/Azure/azure-sdk-for-rust/commit/7a0e20c1e002ce06da0f3ec8795ef1529862ea97",
+    "https://github.com/Azure/azure-sdk-for-rust/blob/legacy/sdk/core/src/headers/mod.rs#L163-L178",
+    "https://github.com/Azure/azure-sdk-for-rust/blob/legacy/sdk/core/src/policies/transport.rs#L32",
+    "https://github.com/Azure/azure-sdk-for-rust/blob/legacy/sdk/core/src/policies/retry_policies/retry_policy.rs#L126",
+]
+cvss = "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N"
+keywords = ["information-leak", "logs", "credentials", "authorization-header", "azure"]
+license = "CC0-1.0"
+
+[versions]
+patched = [">= 0.22.0"]
+unaffected = ["= 0.2.0"]
+```
+
+# Legacy `azure_core` writes the `authorization` header value to logs
+
+Applications built on the legacy Azure SDK for Rust (`azure_core` 0.21.0 and
+earlier) write the value of the outgoing `authorization` header to their logs
+whenever debug-level logging is enabled, and in every affected version also at
+trace level. The leaked values are live credentials — Microsoft Entra
+ID bearer tokens, Azure Storage SharedKey signatures, and SAS tokens — and
+anyone with read access to the logs can replay them until they expire
+(CWE-532).
+
+Versions 0.22.0 and later, which are the rewritten and currently supported
+SDK, do not contain the affected code and do not log requests from
+`azure_core` at all.
+
+## Details
+
+`TransportPolicy::send` is the last policy in the legacy pipeline, and it
+`Debug`-formats every outgoing request, headers included, at debug level:
+
+```rust
+debug!("the following request will be passed to the transport policy: {request:#?}");
+```
+
+In 0.21.0 the `Debug` impl for `Headers` is intended to suppress the
+credential, but its condition is inverted — it emits the value for the
+`authorization` header and `[redacted]` for every other header:
+
+```rust
+impl Debug for Headers {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Headers(")?;
+        let redacted = HeaderValue::from_static("[redacted]");
+        f.debug_map()
+            .entries(self.0.iter().map(|(name, value)| {
+                if matching_ignore_ascii_case(name.as_str(), AUTHORIZATION.as_str()) {
+                    (name, value)      // <-- the credential, in the clear
+                } else {
+                    (name, &redacted)  // <-- everything harmless, redacted
+                }
+            }))
+            .finish()?;
+        write!(f, ")")
+    }
+}
+```
+
+That impl was added by [PR #1699][pr], titled "Redact the authorization header
+from Debug impl" and merged on 2024-07-18, which replaced `#[derive(Debug)]`
+on `Headers` with the hand-written impl above. The change was intended to fix
+exactly this exposure; the two arms of the condition are swapped. It is still
+present at the `legacy` branch HEAD.
+
+The inversion is in some respects worse than the behavior it replaced. The
+`[redacted]` markers printed for every harmless header give an operator
+auditing their logs positive evidence that sanitization is working, while the
+one header that matters is emitted verbatim.
+
+The inversion is not, however, the origin of the exposure. Earlier versions
+redact nothing at all, so the credential reaches the log across the whole
+published range; only the surrounding headers differ.
+
+## Affected versions
+
+Every published legacy version except 0.2.0 writes the `authorization` header
+value to logs: 0.1.1 (2022-01-25), and 0.2.1 through 0.21.0 (2024-10-15). Two
+request-logging paths are involved, and from 0.4.0 on both are live at once:
+
+- **Retry policy, trace level** — 0.1.1, and 0.2.1 through 0.21.0. On every
+  successful response the retry policy `Debug`-formats the whole request:
+  `trace!("Successful response. Request={:?} response={:?}", request, response)`
+  (spelled `"Succesful response"` before 0.4.0).
+- **Transport policy, debug level** — 0.4.0 (2022-08-09) through 0.21.0. The
+  log quoted above, on every request, successful or not. This is the path most
+  deployments hit, debug being a far more commonly enabled level than trace.
+
+0.2.0 is the sole exception. Despite the higher version number it was
+published 2021-12-29, before 0.1.1, and predates the policy pipeline
+altogether — it has no transport or retry policy and logs no requests. It has
+since been yanked from crates.io.
+
+How the credential appears differs across the range, but it appears throughout:
+
+- 0.21.0: the inverted hand-written `Debug for Headers` shown above —
+  `authorization` in the clear, every other header `[redacted]`.
+- 0.2.1 through 0.20.0: no redaction at all. `Headers` carries
+  `#[derive(Debug)]` and prints every header value, `authorization` among
+  them.
+- 0.1.1: no `Headers` type yet; `Request` derives `Debug` over an
+  `http::HeaderMap`, with the same effect.
+
+`azure_core` is a transitive dependency of the legacy client crates, so
+applications are commonly affected without depending on it directly —
+including through `azure_identity`, `azure_storage`, `azure_storage_blobs`,
+and the generated `azure_mgmt_*` crates, several of which have no release
+newer than 0.21.0.
+
+## Reproduction
+
+1. Depend on `azure_core = "0.21"` and any legacy client crate, for example
+   `azure_storage_blobs`.
+2. Enable debug logging (`RUST_LOG=debug` with a `log` or `tracing`
+   subscriber).
+3. Perform any authenticated request.
+4. The logged request shows `[redacted]` for every header except
+   `authorization`, which shows the live credential.
+
+## Mitigation
+
+- Upgrade to `azure_core` 0.22.0 or later where the client crates you use
+  have a release on the new SDK. 0.22.0 is the first version without the
+  affected code; the maintainers direct users to crates built on `azure_core`
+  1.0.0 or newer.
+- Where they do not, raise the log level for the legacy crates above debug —
+  for example `RUST_LOG=info,azure_core=warn`. Suppressing only the
+  `azure_core::policies::transport` target is not sufficient: the retry policy
+  logs the request too, at trace level. Note that a global debug level set for
+  diagnosing an unrelated problem is enough to start emitting credentials.
+- Treat logs produced by an affected build as credential-bearing: rotate any
+  long-lived secret that authenticated a request while debug logging was on.
+
+## Coordination
+
+The finding was reported to the Microsoft Security Response Center
+(VULN-211331), which determined that it does not meet the Microsoft Security
+Servicing Criteria definition of a security vulnerability, on the grounds that
+the affected implementation exists only on the unsupported legacy branch and
+is absent from the supported SDK. MSRC did not dispute the technical finding.
+
+It was then disclosed publicly as [Azure/azure-sdk-for-rust#5074][issue] on
+2026-08-15, asking the maintainers to confirm the behavior so that an advisory
+could be filed for the legacy crates. A maintainer replied on 2026-08-26 and
+closed the issue as not planned: the `legacy` branch is unsupported, there are
+no plans to update it, and users should move to crates built on `azure_core`
+1.0.0 or newer. The technical finding was again not disputed.
+
+No fix will therefore ship for any affected version. This advisory exists so
+that users of the legacy crates, several of which have no successor release,
+receive an alert pointing at the supported SDK.
+
+[pr]: https://github.com/Azure/azure-sdk-for-rust/pull/1699
+[issue]: https://github.com/Azure/azure-sdk-for-rust/issues/5074


### PR DESCRIPTION
## Affected crate(s)

- `azure_core` (6,582,265 recent downloads per crates.io) — and transitively
  the legacy client crates that depend on it (`azure_identity`,
  `azure_storage`, `azure_storage_blobs`, the generated `azure_mgmt_*` crates)

## Links to upstream issue(s) or PR(s)

- https://github.com/Azure/azure-sdk-for-rust/issues/5074 — public disclosure
  (2026-08-15); a maintainer replied 2026-08-26 and closed it as not planned:
  the `legacy` branch is unsupported, no fix will ship, users should move to
  `azure_core` >= 1.0.0. The technical finding was not disputed.
- https://github.com/Azure/azure-sdk-for-rust/pull/1699 — the upstream attempt
  to redact the header (0.21.0), whose condition is inverted.
- Also reported to MSRC (VULN-211331), which determined it does not meet the
  Microsoft Security Servicing Criteria definition of a vulnerability because
  the affected code exists only on the unsupported `legacy` branch. The
  technical finding was not disputed there either.

## Severity

Credential exposure via logs (CWE-532). With debug-level logging enabled (or
trace, for the retry-policy path present across the whole range), the legacy
SDK writes the outgoing `authorization` header value to application logs. The
leaked value is a live credential — an Entra ID bearer token, Storage
SharedKey signature, or SAS token — replayable by anyone with log read access
until it expires. In 0.21.0 the redaction added by upstream PR #1699 is
inverted: `authorization` is printed in the clear while every other header
shows `[redacted]`, giving log auditors false evidence that sanitization
works. Earlier versions redact nothing.

Affected: 0.1.1, and 0.2.1 through 0.21.0. Patched: >= 0.22.0 (the rewritten
SDK, which contains neither the affected code nor any request logging).
0.2.0 is unaffected — despite the version number it predates 0.1.1 and the
policy pipeline, logs no requests, and has been yanked. The range was
verified by inspecting every published legacy version.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate — issue
  #5074 asked them to confirm the behavior so an advisory could be filed;
  they confirmed no fix is planned and did not object

`rustsec-admin lint` passes. Several legacy client crates have no release on
the new SDK, so this advisory exists to alert their users and point at the
supported one.
