### PR TITLE
Add information about GHSA-f42v-x7gq-phc8

### DIFF
--- a/crates/sudo-rs/RUSTSEC-0000-0000.md
+++ b/crates/sudo-rs/RUSTSEC-0000-0000.md
@@ -1,0 +1,54 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "sudo-rs"
+date = "2026-08-31"
+url = "https://github.com/trifectatechfoundation/sudo-rs/security/advisories/GHSA-f42v-x7gq-phc8"
+categories = ["privilege-escalation"]
+cvss = "CVSS:3.1/AV:L/AC:H/PR:H/UI:N/S:U/C:H/I:H/A:H"
+keywords = ["TOCTOU"]
+aliases = ["GHSA-f42v-x7gq-phc8"]
+
+[affected]
+
+[versions]
+patched = [">= 0.2.15"]
+unaffected = ["<= 0.2.7"]
+```
+
+# Time-of-check vs time-of-use issue in sudoedit allows local privilege escalation
+
+## Summary
+
+Users that are explicitly permitted to edit only specific files using sudoedit, are still able to place files in arbitrary directories.
+Impact
+
+This only affects systems where sudoedit is used to give very fine-grained edit permissions, which is not the default configuration. For users that have full sudoedit permission or no sudoedit permission at all, no escalation is enabled by this bug.
+
+A user that is allowed to place files in an arbitrary directory can (by placing a file in /etc/sudoers.d) obviously fully escalate their privileges.
+Versions affected
+
+sudoedit was added in version 0.2.8. sudo-rs versions 0.2.7 and earlier are not affected. This bug is fixed in sudo-rs 0.2.15.
+
+## Example
+
+Suppose /etc/sudoers contains the following:
+
+```
+user ALL=sudoedit /etc/hosts
+```
+
+Then, if user runs a process that creates a symbolic link that rapidly alternates between pointing to /etc and the target directory of interest, eventually a sudoedit link/hosts command will succeed in allowing an edit to a file named hosts in that directory instead of /etc.
+
+## Background
+
+Dealing with symbolic links and components of a path under the control of the invoking user is a known challenge for privilege escalation tools such as sudo. For sudoedit, sudo-rs performs thorough checks such as canonicalizing paths, checking that all path-components cannot be altered by the user, and prohibiting the editing of symbolic links. After a path is sanitized, it is checked against the /etc/sudoers policy, and if the policy allows editing it, it is then opened.
+
+The intent of the business logic in sudo-rs is that the sanitization only occurs once, and the results then subsequently used for both the policy check and the path to open. But due to a coding mistake (a missing call to Iterator::collect), the sanitization step accidentally occurred twice: once to produce a path to check against the policy, and then again to determine the file path to open. This of course is a classic time-of-check vs. time-of-use (TOCTOU) situation, which can be exploited by causing a race condition.
+
+By itself the TOCTOU bug does not give the attacker full control over the path name (in the example above, only a file called hosts can be created), however, in the majority of systems the /etc/sudoers file will contain a declaration such as @includedir which will read any files in a directory as part of the sudoers policy, and so an attacker can simply place a file there to give them full sudo rights. Since @includedir typically sits at the end of /etc/sudoers and the contents of that directory are read in alphanumerical order, it is exceedingly likely those permissions will override the earlier limited ones the attacker had.
+
+## Credits
+
+This issue was reported by @eikendev, who used Claude Opus 5 to perform a security analysis of sudo-rs.
+This advisory text was written by the sudo-rs team.


### PR DESCRIPTION
## Affected crate(s)

- sudo-rs (recent downloads per crates.io)

@squell is it ok if this is published in rustsec?

## Links to upstream issue(s) or PR(s)

information copied from:

https://github.com/trifectatechfoundation/sudo-rs/security/advisories/GHSA-f42v-x7gq-phc8

## Severity

local privilege escalation

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
