### PR TITLE
Mark RUSTSEC-2026-0273 as patched in manzana 0.3.0

### DIFF
--- a/crates/manzana/RUSTSEC-2026-0273.md
+++ b/crates/manzana/RUSTSEC-2026-0273.md
@@ -9,7 +9,6 @@ categories = ["crypto-failure"]
 keywords = ["apple", "secure-enclave", "ecdsa", "signature-verification"]
 
 [affected]
-arch = ["aarch64"]
 os = ["macos"]
 
 [affected.functions]
@@ -20,7 +19,7 @@ os = ["macos"]
 "manzana::secure_enclave::SecureEnclaveSigner::verify" = ["<= 0.2.0, >= 0.1.0"]
 
 [versions]
-patched = []
+patched = [">= 0.3.0"]
 ```
 
 # Stubbed cryptography without warnings


### PR DESCRIPTION
manzana 0.3.0 is published and fixes this advisory. I am the maintainer of manzana.

## patched = [">= 0.3.0"]

Fixed by **removing the cryptography rather than implementing it.** The `secure_enclave` module and the Security-framework FFI are deleted. 0.3.0 exports no key, signature or signer type, makes no Security framework call, and declares no cryptography dependency. Users wanting Secure Enclave or Keychain access are pointed at [`security-framework`](https://crates.io/crates/security-framework).

Implementing it properly needs an Apple Developer account and a code-signed binary with a Team ID; without one `SecKeyCreateRandomKey` returns `errSecInteractionNotAllowed`. Publishing cryptography that cannot be executed end-to-end is how this happened in the first place.

0.1.0 and 0.2.0 remain yanked.

## Also dropping `arch = ["aarch64"]`

The affected code was not aarch64-specific, and the narrower constraint under-reported who was exposed.

`SecureEnclaveSigner::is_available()` was `#[cfg(target_os = "macos")] true` — a compile-time constant with no runtime probe — so it returned `true` on x86_64 macOS hosts with no Secure Enclave at all, and `sign()`/`verify()` "succeeded" there exactly as they did on Apple Silicon. Intel Mac users were equally affected and, with `arch = ["aarch64"]` set, were not warned by `cargo audit`.

`os = ["macos"]` is kept.

## Note

Auditing for the reported defect turned up the same fabricate-a-plausible-value pattern outside the module this advisory names — `neural_engine::infer()` returning `Tensor::zeros(input.shape)`, `capabilities()` returning one chip's published figures on every chip, `metal::dispatch()` returning `Ok(())` having dispatched nothing. All removed in the same release; every operation that cannot reach hardware now returns `Err(Error::Unimplemented)`. Mentioned only for context — none of it changes the scope of this advisory, which is about the Secure Enclave signer.

Repository: https://github.com/paiml/manzana
Report: https://github.com/paiml/manzana/issues/3