### PR TITLE
add advisory for zbus_polkit CVE-2026-78422

### DIFF
--- a/crates/zbus_polkit/RUSTSEC-0000-0000.md
+++ b/crates/zbus_polkit/RUSTSEC-0000-0000.md
@@ -1,0 +1,29 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "zbus_polkit"
+date = "2026-08-31"
+#withdrawn = "YYYY-MM-DD"
+url = "https://github.com/z-galaxy/zbus_polkit/pull/101"
+references = ["https://bugzilla.suse.com/show_bug.cgi?id=1277659"]
+#informational = "unmaintained"
+categories = ["privilege-escalation"]
+cvss = "CVSS:4.0/AV:L/AC:L/AT:P/PR:L/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"
+keywords = ["polkit"]
+aliases = ["CVE-2026-78422"]
+
+[affected]
+[affected.functions]
+"zbus_polkit::Subject::new_for_owner" = ["< 5.1.0"]
+
+[versions]
+patched = [">= 5.1.0"]
+```
+
+# `zbus_polkit`: authorization bypass via PID reuse
+
+`Subject::new_for_owner()` in the `zbus_polkit` crate encodes the uid entry of a unix-process polkit subject as an unsigned 32-bit integer (D-Bus type u), whereas the org.freedesktop.PolicyKit1.Authority interface specifies a signed 32-bit integer (D-Bus type i). Because of this type mismatch, polkit silently discards the caller-supplied UID and instead determines the subject's owner itself by looking up the PID in /proc, a lookup that is inherently subject to a time-of-check/time-of-use race.
+
+Consequently, an application that passes a UID obtained from a trustworthy source — for example `SO_PEERCRED` Unix socket peer credentials — in order to defend against PID reuse receives no protection, and the supplied UID has no effect on the authorization decision. A local unprivileged attacker who can cause an authorized process to terminate and then win the race to have their own process assigned the same PID can be authorized under the identity of the terminated process, bypassing the polkit authorization check and performing actions the attacker is not entitled to.
+
+This issue affects `zbus_polkit` before 5.1.0.


### PR DESCRIPTION
## Affected crate(s)

- `zbus_polkit` (recent downloads per crates.io: 598,053)

## Links to upstream issue(s) or PR(s)

* https://github.com/z-galaxy/zbus_polkit/pull/101
* https://bugzilla.suse.com/show_bug.cgi?id=CVE-2026-78422

## Severity

<!-- Briefly describe the risk and potential effect of the vulnerability.
     For example: allows remote denial-of-service via stack exhaustion,
     or: use-after-free that can lead to arbitrary code execution. -->
privilege escalation

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate
