### PR TITLE
Add advisory for imbl-sized-chunks

### DIFF
--- a/crates/imbl-sized-chunks/RUSTSEC-0000-0000.md
+++ b/crates/imbl-sized-chunks/RUSTSEC-0000-0000.md
@@ -1,0 +1,29 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "imbl-sized-chunks"
+date = "2026-09-04"
+url = "https://github.com/jneem/imbl-sized-chunks/pull/14"
+categories = ["memory-corruption"]
+keywords = ["memory-safety", "double-free", "use-after-free", "panic-safety"]
+
+[affected.functions]
+"imbl_sized_chunks::sized_chunk::Chunk::clear" = ["<= 0.1.3"]
+"imbl_sized_chunks::sized_chunk::Chunk::drop_left" = ["<= 0.1.3"]
+"imbl_sized_chunks::sized_chunk::Chunk::drop_right" = ["<= 0.1.3"]
+"imbl_sized_chunks::inline_array::InlineArray::clear" = ["<= 0.1.3"]
+"imbl_sized_chunks::inline_array::InlineArray::truncate" = ["<= 0.1.3"]
+
+[versions]
+patched = []
+```
+
+# Double free / use-after-free in `Chunk` and `InlineArray` removal methods when an element's `Drop` panics
+
+`Chunk::{clear, drop_left, drop_right}` and `InlineArray::{clear, truncate}` drop the removed elements before updating the metadata that records which slots hold live values — the `left`/`right` index pair for `Chunk`, the length field for `InlineArray`. If an element's `Drop` panics during the drop, that update is never reached, so the collection still treats the already-dropped elements as live. When the collection is later dropped (its destructor walks the range described by the stale metadata), or a subsequent operation touches the same slots, those elements are dropped a second time — a double free (CWE-415) / use-after-free (CWE-416) reachable from safe Rust.
+
+The stale field is `left` and `right` for `Chunk::clear`, `left` for `drop_left`, `right` for `drop_right`, and the length field for both `InlineArray` methods.
+
+## Mitigation
+
+No fixed release is available. A fix that commits the metadata before any element is dropped has been merged upstream but not published to crates.io. Until a release is made, avoid calling the affected methods with element types whose `Drop` can panic.


### PR DESCRIPTION
## Affected crate(s)

- `imbl-sized-chunks` (2,196,168 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

Reported and fixed in jneem/imbl-sized-chunks#14, merged 2026-08-17. Not yet released — the latest published version is 0.1.3 (December 2024), so `patched` is left empty.

## Severity

Panic-safety unsoundness in `Chunk::{clear, drop_left, drop_right}` and `InlineArray::{clear, truncate}`: the removed elements are dropped before the metadata recording which slots are live is updated (`left`/`right` for `Chunk`, the length field for `InlineArray`), so a panicking element `Drop` leaves that metadata covering already-dropped slots. The collection destructor then drops them again — a double free (CWE-415) / use-after-free (CWE-416) reachable from safe Rust, confirmed under AddressSanitizer.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate (maintainer approved in the PR thread)