### PR TITLE
Add malware advisories for `greentic-{setup,setup-dev}`

### DIFF
--- a/crates/greentic-setup-dev/RUSTSEC-0000-0000.md
+++ b/crates/greentic-setup-dev/RUSTSEC-0000-0000.md
@@ -1,0 +1,24 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "greentic-setup-dev"
+date = "2026-09-07"
+categories = ["malicious"]
+
+[versions]
+patched = []
+unaffected = ["< 1.3.34027618345", "> 1.3.34027618345"]
+```
+
+# `greentic-setup-dev` 1.3.34027618345 was removed from crates.io due to containing malicious code
+
+A new version of the `greentic-setup-dev` crate was published with a variant of
+the PolinRider malware included that would fire when a project depending on
+`greentic-setup-dev` was opened in Visual Studio Code.
+
+One malicious version was published on 2026-09-06, approximately 27 hours
+before removal. This crate has no dependencies on crates.io. We have no
+evidence that this crate version was downloaded by any actual users, but
+Greentic users should check their systems nonetheless.
+
+Thanks to XX for the report.

--- a/crates/greentic-setup-dev/RUSTSEC-0000-0000.md
+++ b/crates/greentic-setup-dev/RUSTSEC-0000-0000.md
@@ -21,4 +21,4 @@ before removal. This crate has no dependencies on crates.io. We have no
 evidence that this crate version was downloaded by any actual users, but
 Greentic users should check their systems nonetheless.
 
-Thanks to XX for the report.
+Thanks to the Research Team at Nextron Systems GmbH for the report.

--- a/crates/greentic-setup/RUSTSEC-0000-0000.md
+++ b/crates/greentic-setup/RUSTSEC-0000-0000.md
@@ -1,0 +1,26 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "greentic-setup"
+date = "2026-09-07"
+categories = ["malicious"]
+
+[versions]
+patched = []
+unaffected = ["< 1.3.1-dev.34027618345", "> 1.3.1-dev.34027618345"]
+```
+
+# `greentic-setup` 1.3.1-dev.34027618345 was removed from crates.io due to containing malicious code
+
+A new version of the `greentic-setup` crate was published with a variant
+of the PolinRider malware included that would fire when a project
+depending on `greentic-setup` was opened in Visual Studio Code.
+
+One malicious version was published on 2026-09-06, approximately 27 hours
+before removal. This crate is depended on by four other crates in the
+Greentic ecosystem, namely `greentic-start`, `greentic-start-dev`,
+`greentic-operator`, and `greentic-operator-dev`. We have no evidence that this
+crate version was downloaded by any actual users, but Greentic users should
+check their systems nonetheless.
+
+Thanks to XX for the report.

--- a/crates/greentic-setup/RUSTSEC-0000-0000.md
+++ b/crates/greentic-setup/RUSTSEC-0000-0000.md
@@ -23,4 +23,4 @@ Greentic ecosystem, namely `greentic-start`, `greentic-start-dev`,
 crate version was downloaded by any actual users, but Greentic users should
 check their systems nonetheless.
 
-Thanks to XX for the report.
+Thanks to the Research Team at Nextron Systems GmbH for the report.


### PR DESCRIPTION
Draft for now, as we haven't yet confirmed whether the reporter wants to be credited. I'll update once we know, but I just don't want to forget about this.