### PR TITLE
Add advisory for aligned_box: panic-safety double-free in realloc_with_default

### DIFF
--- a/crates/aligned_box/RUSTSEC-0000-0000.md
+++ b/crates/aligned_box/RUSTSEC-0000-0000.md
@@ -1,0 +1,38 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "aligned_box"
+date = "2026-09-09"
+url = "https://github.com/michaellass/aligned_box/pull/6"
+categories = ["memory-corruption"]
+keywords = ["memory-safety", "double-free", "use-after-free", "panic-safety"]
+
+[affected.functions]
+"aligned_box::AlignedBox::realloc_with_default" = ["< 0.3.1"]
+
+[versions]
+patched = [">= 0.3.1"]
+```
+
+# Double free in `AlignedBox<[T]>::realloc_with_default` when an element's `Drop` panics
+
+Shrinking an `AlignedBox<[T]>` takes ownership of the buffer out of
+`self.container` with `ManuallyDrop::take`, destroys the elements past the new
+length, and only then commits the new `Box` back into `self.container`.
+`ManuallyDrop::take` moves ownership but not the bits, so until that commit
+`self.container` still points at the original buffer.
+
+`T::drop` runs inside the destruction loop and is user code — `T` carries no
+bound that would exclude a panicking `Drop`. If it unwinds, the commit is
+skipped and `self.container` is left pointing at the buffer whose tail has
+already been destroyed. `AlignedBox`'s own destructor then reconstructs a `Box`
+from that pointer, drops every element again and deallocates — a double free
+(CWE-415) / use-after-free (CWE-416) reachable from safe Rust.
+
+Growing the slice destroys nothing and is unaffected, as is
+`realloc_with_value`, which requires `T: Copy` and therefore a `Drop` that
+cannot run.
+
+## Mitigation
+
+Update to 0.3.1.


### PR DESCRIPTION
## Affected crate(s)

- `aligned_box` (19,224 recent downloads per crates.io, 3 reverse dependencies)

## Links to upstream issue(s) or PR(s)

Reported and fixed in [michaellass/aligned_box#6](https://github.com/michaellass/aligned_box/pull/6), released in 0.3.1 on 2026-09-08.

## Severity

Panic-safety unsoundness when shrinking an `AlignedBox<[T]>` via `realloc_with_default`: ownership of the buffer is taken out of `self.container` before the tail elements are dropped, and only committed back afterwards. A panicking element `Drop` skips the commit and leaves `self.container` pointing at the partially destroyed buffer, which the destructor then drops again and deallocates — a double free (CWE-415) / use-after-free (CWE-416) reachable from safe Rust, confirmed with glibc's `double free detected in tcache 2`. Fixed in 0.3.1.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate (maintainer approved in the PR thread)