### PR TITLE
Add advisory for owned-alloc: panic-safety double-free in OwnedAlloc::drop_in_place

### DIFF
--- a/crates/owned-alloc/RUSTSEC-0000-0000.md
+++ b/crates/owned-alloc/RUSTSEC-0000-0000.md
@@ -1,0 +1,39 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "owned-alloc"
+date = "2026-09-09"
+url = "https://gitlab.com/bzim/owned-alloc/-/issues/1"
+categories = ["memory-corruption"]
+keywords = ["panic-safety", "memory-safety", "use-after-free", "double-free"]
+
+[affected]
+[affected.functions]
+"owned_alloc::OwnedAlloc::drop_in_place" = ["<= 0.2.0"]
+"owned_alloc::MaybeUninitAlloc::drop_in_place" = ["<= 0.2.0"]
+
+[versions]
+patched = []
+```
+
+# Double free in `OwnedAlloc::drop_in_place` when the contained value's `Drop` panics
+
+`OwnedAlloc::drop_in_place` destroys the contained value by hand, then commits
+the ownership transfer with `mem::forget(self)` — which lives inside `into_raw`
+and so runs only after the destruction. `T::drop` is user code and may panic. If
+it does, the forget is skipped and the still-live `OwnedAlloc` unwinds, whose
+destructor drops the same `T` a second time and then deallocates. For a `T` that
+owns an allocation, the same block is freed twice — a double free (CWE-415).
+That destructor also reads the already-destroyed value through
+`Layout::for_value` before deallocating, a use-after-free (CWE-416).
+
+`MaybeUninitAlloc::drop_in_place` delegates to the same function, so both public
+entry points are affected. Storing a value whose `Drop` can panic and calling
+either is enough — no `unsafe` on the caller's side.
+
+## Fix
+
+No fixed release is available. The crate has had no release since 2018 and the
+maintainer has not responded to the report, nor to the one on `lockfree`, which
+is published from the same account. `forget_inner` leaks the value instead of
+destroying it, which is safe.


### PR DESCRIPTION
## Affected crate(s)

* `owned-alloc` (736,101 recent downloads per crates.io)

## Links to upstream issue(s) or PR(s)

Reported in [bzim/owned-alloc#1](https://gitlab.com/bzim/owned-alloc/-/issues/1) (2026-09-08). Same maintainer and account as `lockfree`, where a public issue and a private email have both gone unanswered; no release since 2018.

## Severity

Panic-safety unsoundness in `OwnedAlloc::drop_in_place`: the contained value is destroyed by hand, and the `mem::forget(self)` that commits the ownership transfer lives inside `into_raw` and so runs only afterwards. A panicking `T::drop` skips the commit, so the still-live `OwnedAlloc` unwinds and its destructor drops the same `T` a second time before deallocating — a double free (CWE-415). The destructor also reads the destroyed value through `Layout::for_value` on the way (CWE-416). Confirmed under AddressSanitizer (`attempting double-free`).

`MaybeUninitAlloc::drop_in_place` delegates to the same function, so both public entry points are affected. Storing a value whose `Drop` can panic and calling either is enough; no `unsafe` on the caller's side.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate (reported upstream)