### PR TITLE
Add advisory for unzip

### DIFF
--- a/crates/unzip/RUSTSEC-0000-0000.md
+++ b/crates/unzip/RUSTSEC-0000-0000.md
@@ -1,0 +1,88 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "unzip"
+date = "2026-09-09"
+url = "https://crates.io/crates/unzip"
+categories = ["code-execution"]
+keywords = ["zip-slip", "path-traversal", "directory-traversal", "arbitrary-file-write", "zip"]
+aliases = []
+references = []
+
+[affected.functions]
+"unzip::Unzipper::unzip" = ["^0.1.0"]
+
+[versions]
+patched = []
+unaffected = []
+```
+
+# `unzip`: archive extraction is vulnerable to path traversal (zip-slip)
+
+### Summary
+
+`Unzipper::unzip` extracts each archive entry to a path built from the entry's
+**raw, attacker-controlled name** without any traversal check. A ZIP archive whose
+entry names contain `../` components (or an absolute path) can therefore cause
+files to be written **outside** the destination directory chosen by the caller —
+a "zip-slip" / directory-traversal arbitrary file write (CWE-22 / CWE-23 /
+CWE-36).
+
+### Details
+
+When extracting, the crate reads the entry name with the `zip` crate's **raw**
+`ZipFile::name()` accessor and joins it directly onto the output directory
+(`src/lib.rs`):
+
+```rust
+filename: file.name().to_owned(),              // raw ZIP entry name (unsanitized)
+// ...
+let outpath: PathBuf = outdir.join(metadata.filename);
+// ...
+let mut outfile = fs::File::create(&outpath)?; // writes to the traversed path
+```
+
+`ZipFile::name()` returns the path exactly as stored in the archive; the
+traversal-safe accessor is `ZipFile::enclosed_name()`. No validation is performed
+on the joined path:
+
+* there is no rejection of `..` (`std::path::Component::ParentDir`) components,
+* there is no `canonicalize` + `starts_with(destination)` confinement check, and
+* the only transformation offered, `strip_components`, removes a fixed number of
+  *leading* path components and does **not** remove interior `..` components
+  (and defaults to `0`, i.e. no transformation at all).
+
+Because `Path::join` also resets to an absolute component, an entry named
+`/etc/cron.d/x` (or a Windows drive-qualified path) is written to that absolute
+location directly.
+
+### Impact
+
+A program that uses `unzip` to extract an untrusted archive can be coerced into
+writing arbitrary files anywhere the process has write access — for example
+overwriting `~/.bashrc`, dropping a unit into `/etc/cron.d/`, or planting a
+`.git/hooks/pre-commit` script — which is commonly escalatable to arbitrary code
+execution.
+
+### Affected versions
+
+All published versions are affected. `unzip` has only ever released `0.1.0`
+(published 2017-12-23) and appears unmaintained, so **no fixed version is
+available**.
+
+### Mitigation / workaround
+
+There is no patched release. Users should:
+
+* migrate to a maintained extraction crate, or extract using the `zip` crate
+  directly and derive each output path from `ZipFile::enclosed_name()` (which
+  rejects traversal and absolute paths); and/or
+* before writing any entry, canonicalize the joined output path and verify it is
+  still contained within the intended destination directory (reject the entry
+  otherwise), and reject entries whose names contain a `..` component or are
+  absolute.
+
+### Proof of concept
+
+A malicious archive with a single entry named `../ESCAPED.txt` extracted via
+`Unzipper::unzip` writes `ESCAPED.txt` one level above the destination directory.


### PR DESCRIPTION
## Affected crate(s)

- `unzip` (148,172 )

## Links to upstream issue(s) or PR(s)

None available. The crate lists no source repository or homepage on crates.io. There is only one published version (0.1.0, released 2017-12-23), and appears unmaintained — so there is no upstream issue tracker or PR to reference, and no fixed release exists. The crate owner is Ryan Leonard (crates.io/GitHub CodeLenny), but no repository is linked for this crate.

## Severity

Directory traversal ("zip-slip") during archive extraction 
→ arbitrary file write (CWE-22 / CWE-23 / CWE-36). 

Unzipper::unzip builds each output path from the raw, attacker-controlled ZIP entry name (ZipFile::name(), the traversal-unsafe accessor) and writes it via File::create with no validation. A malicious archive whose entry names contain ../ components (or an absolute path) therefore writes files outside the caller-chosen destination directory. This is commonly escalatable to code execution (e.g. overwriting ~/.bashrc, dropping a unit into /etc/cron.d/, or planting a .git/hooks/ script). The only precondition is that an application extracts an untrusted archive with this crate.

## Checklist

- [x] Advisory filename(s) starts with `RUSTSEC-0000-0000` as the ID
- [x] `date` field is set to the public disclosure date
- [x] Contains a concise and descriptive title after advisory metadata
- [x] Asked maintainer(s) if publishing an advisory is appropriate -- the crate has no linked repository or issue tracker and has not been updated since 2017 (single release, apparently abandoned).
