### PR TITLE
RUSTSEC-2023-0071: record 0.9.10 / 0.10-rc still unpatched

### DIFF
--- a/crates/rsa/RUSTSEC-2023-0071.md
+++ b/crates/rsa/RUSTSEC-2023-0071.md
@@ -27,8 +27,6 @@ Still affected as of 2026-09-12: rsa 0.9.10 (latest stable) and rsa 0.10.0-rc.18
 ### Workarounds
 Avoid using the `rsa` crate in settings where attackers can observe timing, for example over the network. Local use on a non-compromised computer is fine.
 
-jsonwebtoken users who need RSA should enable the `aws_lc_rs` backend. The `rust_crypto` backend of jsonwebtoken 11 still depends on rsa 0.9.6.
-
 ### References
 This vulnerability was discovered as part of the "[Marvin Attack]", which revealed several implementations of RSA including OpenSSL had not properly mitigated timing sidechannel attacks.
 

--- a/crates/rsa/RUSTSEC-2023-0071.md
+++ b/crates/rsa/RUSTSEC-2023-0071.md
@@ -6,7 +6,7 @@ date = "2023-11-22"
 keywords = ["cryptography"]
 categories = ["crypto-failure"]
 url = "https://github.com/RustCrypto/RSA/issues/626"
-references = ["https://github.com/RustCrypto/RSA/issues/19#issuecomment-1822995643", "https://people.redhat.com/~hkario/marvin/"]
+references = ["https://github.com/RustCrypto/RSA/issues/19#issuecomment-1822995643", "https://people.redhat.com/~hkario/marvin/", "https://github.com/RustCrypto/RSA/pull/394", "https://github.com/RustCrypto/RSA/pull/680", "https://github.com/RustCrypto/RSA/pull/702"]
 cvss = "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N"
 aliases = ["CVE-2023-49092", "GHSA-c38w-74pg-36hr", "GHSA-4grx-2x9w-596c"]
 
@@ -20,10 +20,14 @@ patched = []
 Due to a non-constant-time implementation, information about the private key is leaked through timing information which is observable over the network. An attacker may be able to use that information to recover the key.
 
 ### Patches
-No patch is yet available, however work is underway to migrate to a fully constant-time implementation.
+No patch is yet available. The crypto-bigint migration ([RustCrypto/RSA#394](https://github.com/RustCrypto/RSA/pull/394)) did not close this. Tracking is [RustCrypto/RSA#626](https://github.com/RustCrypto/RSA/issues/626) (padding still not constant-time). Implicit rejection work is in [RustCrypto/RSA#680](https://github.com/RustCrypto/RSA/pull/680); default-path blinding is in [RustCrypto/RSA#702](https://github.com/RustCrypto/RSA/pull/702).
+
+Still affected as of 2026-09-12: rsa 0.9.10 (latest stable) and rsa 0.10.0-rc.18 (latest). `patched = []` is intentional.
 
 ### Workarounds
-The only currently available workaround is to avoid using the `rsa` crate in settings where attackers are able to observe timing information, e.g. local use on a non-compromised computer is fine.
+Avoid using the `rsa` crate in settings where attackers can observe timing, for example over the network. Local use on a non-compromised computer is fine.
+
+jsonwebtoken users who need RSA should enable the `aws_lc_rs` backend. The `rust_crypto` backend of jsonwebtoken 11 still depends on rsa 0.9.6.
 
 ### References
 This vulnerability was discovered as part of the "[Marvin Attack]", which revealed several implementations of RSA including OpenSSL had not properly mitigated timing sidechannel attacks.


### PR DESCRIPTION
`patched = []` stays empty. There is still no fixed rsa release.

This updates the human text and references so cargo-audit readers are not left on the old "work is underway to migrate to crypto-bigint" story:

- 0.9.10 (latest stable) and 0.10.0-rc.18 (latest) are still affected
- RustCrypto/RSA#394 did not close Marvin
- Tracking remains RustCrypto/RSA#626
- In-progress: RustCrypto/RSA#680 (implicit rejection), RustCrypto/RSA#702 (default-path blinding)
