### PR TITLE
Add informational unsoundness advisory for burn-ndarray (UnsafeSharedRef aliasing UB)

### DIFF
--- a/crates/burn-ndarray/RUSTSEC-0000-0000.md
+++ b/crates/burn-ndarray/RUSTSEC-0000-0000.md
@@ -1,0 +1,44 @@
+```toml
+[advisory]
+id = "RUSTSEC-0000-0000"
+package = "burn-ndarray"
+date = "2026-08-29"
+url = "https://github.com/tracel-ai/burn/issues/5345"
+references = ["https://github.com/tracel-ai/burn/pull/5346"]
+informational = "unsound"
+keywords = ["undefined-behavior", "aliasing", "data-race", "miri", "rayon"]
+
+[versions]
+patched = [">= 0.22.0-pre.3"]
+unaffected = ["< 0.6.0"]
+```
+
+# UnsafeSharedRef::get() hands out aliased (dangling) `&mut` references, undefined behavior in parallel operators
+
+`UnsafeSharedRef` (`src/sharing.rs`, present since burn-ndarray 0.6.0) stores
+a `&mut T` inside an `UnsafeCell` and implements `Sync` unconditionally.
+`get()` copies the reference out with `core::ptr::read`. Under the Rust
+aliasing model, the newly created `&mut` is retagged as unique, which
+invalidates every reference previously handed out; each subsequent call to
+`get()` therefore returns a dangling `&mut T`.
+
+`run_par!` passes an `UnsafeSharedRef` to rayon workers in the ndarray
+implementations of conv2d (forward and backward), average/max pooling
+including the SIMD variants, adaptive average pooling, interpolation,
+grid_sample and matmul. Parallel execution of these operators — reachable
+from the crate's safe public API with ordinary, valid inputs — writes through
+references whose tag has already been invalidated, which is a data race and
+undefined behavior. Miri (Stacked Borrows) reports the violation both for the
+minimal pattern and for the real `conv.forward` code path; running natively
+is silent, i.e. the defect is latent undefined behavior that the optimizer is
+permitted to turn into miscompilation under its `noalias` assumptions.
+
+No observable misbehavior or security impact has been demonstrated, so this
+is filed as an informational soundness advisory.
+
+The issue was fixed in
+[tracel-ai/burn#5346](https://github.com/tracel-ai/burn/pull/5346) by storing
+a `RawArrayViewMut` and returning an independent `ArrayViewMut` per call,
+first released in burn-ndarray 0.22.0-pre.3. 
+
+Reported by dywzju09-blip.


### PR DESCRIPTION
Adds `crates/burn-ndarray/RUSTSEC-0000-0000.md`, an `informational = "unsound"` advisory
for `burn-ndarray`.

## Upstream status (CONTRIBUTING prerequisites)

- Reported upstream: https://github.com/tracel-ai/burn/issues/5345 (public, 2026-08-11)
- Confirmed by a burn maintainer, and the advisory was agreed in-thread:
  https://github.com/tracel-ai/burn/issues/5345#issuecomment-5425075277 —
  *"That said, I don't object if you want to submit an informational unsoundness advisory
  for `burn-ndarray`, which is being deprecated."*
- Fixed by https://github.com/tracel-ai/burn/pull/5346 (merged 2026-08-12), first
  released in `burn-ndarray` 0.22.0-pre.3 (2026-08-25).

## Version ranges (verified against release tags)

- Vulnerable code (`src/sharing.rs`: `unsafe impl Sync` + `core::ptr::read` of a stored
  `&mut`) first shipped in burn-ndarray 0.6.0 (2023-03-21) → `unaffected = ["< 0.6.0"]`.
- Present in every release through 0.22.0-pre.2 → `patched = [">= 0.22.0-pre.3"]`
  (verified: the fix commit is an ancestor of the `v0.22.0-pre.3` tag and is absent from
  `v0.22.0-pre.2`).

## Classification rationale

Per the advisory-db criteria, soundness issues (UB reachable from safe code) are tracked
as informational advisories. Miri reports aliasing UB for both the minimal pattern and the
real `conv.forward` path, but no observable misbehavior or security impact has been
demonstrated, hence `informational = "unsound"`, no `categories`, no CVSS.

The placeholder ID `RUSTSEC-0000-0000` is used per CONTRIBUTING; please assign the real
identifier on merge.